### PR TITLE
chore: tidy release-please config and document major-bump policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,12 +285,21 @@ The convention is `type(scope)?: short subject`. Common types:
 |------|-------------------|----------|
 | `feat:` | Minor bump (1.2.0 -> 1.3.0) | New user-facing feature |
 | `fix:` | Patch bump (1.2.0 -> 1.2.1) | Bug fix |
-| `feat!:` or footer `BREAKING CHANGE:` | Major bump (1.2.0 -> 2.0.0) | Backwards-incompatible change |
+| `feat!:` or footer `BREAKING CHANGE:` | Major bump (1.2.0 -> 2.0.0) | Backwards-incompatible change. **Ask the maintainer first.** |
 | `docs:` | No bump | Documentation only |
 | `refactor:` | No bump | Code restructuring with no behavior change |
 | `test:` | No bump | Test-only changes |
 | `chore:` | No bump | Build, deps, repo housekeeping |
 | `ci:` | No bump | CI/release workflow changes |
+
+**Major bumps are a maintainer decision, not an automatic one.** Even if a
+change is technically backwards-incompatible, the agent / contributor
+opening a PR should not unilaterally tag it `feat!:` or attach a
+`BREAKING CHANGE:` footer. Ask first. The maintainer accumulates
+breaking changes and decides when there's enough to warrant a major
+release. To force an explicit version when one is wanted, the
+maintainer can add a `Release-As: 2.0.0` footer to a commit; release-please
+honours it on the next run.
 
 The simplest discipline for keeping `main`'s commit log clean:
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,8 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "go",
   "include-component-in-tag": false,
-  "bump-minor-pre-major": true,
-  "bump-patch-for-minor-pre-major": true,
   "draft": false,
   "prerelease": false,
   "packages": {


### PR DESCRIPTION
Two cleanups, both essentially documentation:

## \`release-please-config.json\`

Drop \`bump-minor-pre-major\` and \`bump-patch-for-minor-pre-major\`. They only modify pre-1.0 behavior and are inert now that we're shipping 1.0.0+. Inert config is just noise that confuses the next reader.

## AGENTS.md — major-bump policy

The conventional-commits machinery technically lets any contributor trigger a major version bump by tagging a commit with \`feat!:\` or a \`BREAKING CHANGE:\` footer. That's too sharp a knife for a project at this stage.

- Added "**Ask the maintainer first.**" to the breaking-change row in the conventional-commits table.
- Added a paragraph below the table spelling out the policy: contributors don't unilaterally mark breaking changes; the maintainer accumulates them and decides when to cut a major release.
- Documented the \`Release-As: x.y.z\` commit footer for forcing an explicit version when one is wanted.

## Side effect

release-please will re-run on this push. \`chore:\` doesn't bump, so PR #8 (the open \`v1.0.0\` release PR) should stay as-is — also useful as a smoke test that release-please idempotency is working as expected.