### PR TITLE
ci: add workflow_dispatch to release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,5 +22,15 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
+          # Push tags using a Personal Access Token rather than the
+          # default GITHUB_TOKEN. GitHub deliberately suppresses
+          # workflow-from-workflow chains when the pushing identity is
+          # GITHUB_TOKEN, which would prevent the release workflow from
+          # firing on tag push. PAT-pushed tags trigger downstream
+          # workflows normally.
+          #
+          # The token must be a fine-grained PAT scoped to this repo
+          # with: Contents (Read+Write), Pull requests (Read+Write).
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,22 +3,16 @@ name: Release
 # Builds binaries for a tag and attaches them to the matching GitHub
 # release. Two ways this gets triggered:
 #
-#   1. Automatically on tag push (vX.Y.Z) -- the desired path.
+#   1. Automatically on tag push (vX.Y.Z) -- the normal path.
+#      release-please.yml uses RELEASE_PLEASE_TOKEN (a fine-grained PAT)
+#      to push tags so this workflow fires on tag-push events.
 #
-#      CAVEAT: tag pushes performed by release-please-action using the
-#      default GITHUB_TOKEN do NOT trigger this workflow. GitHub
-#      deliberately suppresses workflow-from-workflow chains when the
-#      pushing identity is GITHUB_TOKEN, to prevent infinite loops. To
-#      get fully automatic releases, configure release-please.yml to
-#      use a PAT instead of GITHUB_TOKEN; PAT-pushed tags do trigger
-#      downstream workflows.
-#
-#   2. Manually via workflow_dispatch (the workaround). Pick the tag
-#      from the dropdown when running the workflow. Useful when (1)
-#      didn't fire because release-please pushed the tag.
-#
-# Once we adopt a PAT in release-please.yml, the manual path becomes
-# vestigial, but harmless to keep around.
+#   2. Manually via workflow_dispatch -- the backup path. Pick the tag
+#      from the input field when running the workflow. Useful for
+#      retrying a failed release build, or backfilling a tag whose
+#      auto-trigger was suppressed (e.g. before the PAT was configured,
+#      tags pushed via the default GITHUB_TOKEN didn't trigger the
+#      workflow).
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,35 @@
 name: Release
 
-# Triggered by tag pushes (vX.Y.Z), which release-please creates when
-# its release PR is merged. Builds binaries and attaches them to the
-# GitHub release that release-please already created.
+# Builds binaries for a tag and attaches them to the matching GitHub
+# release. Two ways this gets triggered:
+#
+#   1. Automatically on tag push (vX.Y.Z) -- the desired path.
+#
+#      CAVEAT: tag pushes performed by release-please-action using the
+#      default GITHUB_TOKEN do NOT trigger this workflow. GitHub
+#      deliberately suppresses workflow-from-workflow chains when the
+#      pushing identity is GITHUB_TOKEN, to prevent infinite loops. To
+#      get fully automatic releases, configure release-please.yml to
+#      use a PAT instead of GITHUB_TOKEN; PAT-pushed tags do trigger
+#      downstream workflows.
+#
+#   2. Manually via workflow_dispatch (the workaround). Pick the tag
+#      from the dropdown when running the workflow. Useful when (1)
+#      didn't fire because release-please pushed the tag.
+#
+# Once we adopt a PAT in release-please.yml, the manual path becomes
+# vestigial, but harmless to keep around.
 
 on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to build (e.g. v1.0.0). Must already exist."
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -20,6 +42,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          # On workflow_dispatch we check out the tag the operator
+          # supplied; on tag-push the default ref already points at
+          # the tag.
+          ref: ${{ inputs.tag || github.ref }}
           # goreleaser needs the full history to compute changelog
           # diffs and previous-tag info, even though release-please
           # owns the actual changelog body.


### PR DESCRIPTION
The `v1.0.0` release was cut but has no binary assets — the release workflow never ran.

## Why

GitHub deliberately suppresses workflow-from-workflow chains when the pushing identity is `GITHUB_TOKEN`, to prevent infinite loops. The `v1.0.0` tag was pushed by `release-please-action` using the default `GITHUB_TOKEN`, so the tag-push event was suppressed and `release.yml` didn't fire.

## Fix (two parts)

### 1. `release-please.yml` switches to a PAT

`release-please-action` now uses `RELEASE_PLEASE_TOKEN` (fine-grained PAT scoped to this repo with `Contents: Read+Write` and `Pull requests: Read+Write`) instead of the default `GITHUB_TOKEN`. PAT-pushed tags trigger downstream workflows normally, restoring fully automatic releases. Future versions cut by release-please will fire `release.yml` automatically with no manual intervention.

### 2. `release.yml` gains `workflow_dispatch`

A backup manual trigger with a tag input. Useful for:
- Retrying a failed release build.
- Backfilling tags whose auto-trigger was suppressed (e.g. `v1.0.0`, which was pushed before the PAT was configured).

The checkout step now picks `inputs.tag` for manual runs and falls back to `github.ref` for tag pushes, so both paths land on the right commit.

## Backfilling v1.0.0

After merging this, run:

```sh
gh workflow run release.yml -f tag=v1.0.0
```

(or click "Run workflow" in the GitHub UI on the release.yml page). Should take ~1 minute. After that completes, `v1.0.0` will have `linux_x86_64` / `linux_arm64` / `darwin_arm64` tarballs plus `SHA256SUMS` attached, which is what PR-C's update logic needs to test against.
