### PR TITLE
feat: add self-update support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,6 +228,17 @@ Shared LLM-shaped value types. The OpenAI chat-completions wire shape is treated
 - `Persister`: small wrapper that binds path + logger at construction so the agent can call `Save`/`Load` through the `StateStore` port without re-passing them.
 - `sanitizeMessages`: strips trailing partial turns (assistant messages with unsatisfied `tool_call_id`s) so the resumed log is always a valid replay.
 
+### internal/update/
+
+Self-update orchestration. Polls the configured GitHub repo's `releases/latest`, compares versions, downloads the matching tarball, verifies it against `SHA256SUMS`, swaps the binary in place, and triggers graceful shutdown so the new binary takes over.
+
+- **`Updater`**: main type. Constructed once in `cmd/faultline/main.go`, shared with the tools package via `Check` / `Apply` methods so the `update_check` / `update_apply` tools can drive the same pipeline.
+- **`Run(ctx)`**: background polling loop. First check delayed 30s to avoid hammering GitHub on tight restart loops; subsequent checks on `cfg.CheckInterval`. No-op when `cfg.Enabled` is false.
+- **`Apply(ctx)`**: downloads, verifies SHA256, extracts the binary from the tarball, atomically swaps (rotating old to `<binary>.previous` as a one-deep rollback slot), records to `meta/version-history.md`, and calls the `TriggerShutdown` callback. Serialized by an internal mutex; an `applied` atomic flag prevents repeat applies after one has succeeded.
+- **`Result`**: the value `TriggerShutdown` receives — used by `cmd/faultline/main.go` to decide whether to `os.Exit(0)`, `syscall.Exec` the new binary, or run a configured restart command after `Agent.Run` returns.
+- Asset selection follows goreleaser's name template: `faultline_<version>_<os>_<arch>.tar.gz`, with `amd64` rewritten to `x86_64` to match the Linux convention.
+- `IsNewer` / `IsPrerelease` use `golang.org/x/mod/semver` for tag comparison; non-semver "current" (e.g. `dev` from a local build) is treated as the oldest possible version, so dev builds upgrade to real releases when self-update is enabled.
+
 ## Key Design Patterns
 
 1. **Hexagonal architecture (ports & adapters)**: see `Standards/Hexagonal-Architecture.md` in the user's vault. The agent depends only on interfaces it owns; adapters implement those interfaces structurally.

--- a/README.md
+++ b/README.md
@@ -136,13 +136,27 @@ An optional Docker-based execution environment for Python scripts. Uses [`uv`](h
 
 When `[email]` is configured, the agent gets an `email_fetch` tool that opens a short-lived IMAP connection per call. Useful for letting the agent pick up things its operator emails to a dedicated inbox.
 
+### Self-update (optional)
+
+When `[update]` is enabled, a background goroutine polls GitHub releases on a configured interval. If a newer version is available, the updater downloads the matching release tarball, verifies it against the published `SHA256SUMS`, atomically swaps the binary in place (keeping the old binary as `<binary>.previous` for one-deep rollback), and triggers graceful shutdown so the new binary takes over.
+
+The LLM does not decide whether to update. The agent has `update_check` and `update_apply` tools that kick off the same code path, so the operator can say "update yourself" via Telegram, but the actual decision logic is in code.
+
+Three restart modes:
+- **`exit`** (default) — save state and exit. Suitable for any process supervisor that respawns the unit (systemd, Docker, Kubernetes, runit, supervisord).
+- **`self-exec`** — save state and `syscall.Exec` the new binary, replacing the process image. Same PID. Suitable for bare-process runs without a supervisor.
+- **`command`** — save state, run a configured restart command, exit. For custom orchestrators.
+
+Disabled by default. See `[update]` in `config.example.toml` for the full surface.
+
 ## Tools
 
 | Category | Tools |
 |----------|-------|
 | **Internet** | `web_fetch`, `wiki_fetch` |
 | **Memory** | `memory_read`, `memory_write`, `memory_edit`, `memory_append`, `memory_insert`, `memory_delete`, `memory_move`, `memory_restore`, `memory_list`, `memory_list_trash`, `memory_empty_trash`, `memory_search`, `memory_grep` |
-| **System** | `context_status`, `get_time`, `sleep`, `send_message` |
+| **System** | `context_status`, `get_time`, `sleep`, `send_message`, `get_version` |
+| **Self-update** (when enabled) | `update_check`, `update_apply` |
 | **Sandbox** (when enabled) | `sandbox_write`, `sandbox_read`, `sandbox_edit`, `sandbox_append`, `sandbox_insert`, `sandbox_delete`, `sandbox_rename`, `sandbox_list`, `sandbox_execute`, `sandbox_shell`, `sandbox_install_package`, `sandbox_upgrade_package`, `sandbox_remove_package`, `sandbox_list_packages` |
 | **Email** (when configured) | `email_fetch` |
 

--- a/cmd/faultline/main.go
+++ b/cmd/faultline/main.go
@@ -10,7 +10,11 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
 	"os/signal"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -26,6 +30,7 @@ import (
 	"github.com/matjam/faultline/internal/prompts"
 	"github.com/matjam/faultline/internal/search/bm25"
 	"github.com/matjam/faultline/internal/tools"
+	"github.com/matjam/faultline/internal/update"
 	"github.com/matjam/faultline/internal/version"
 )
 
@@ -53,14 +58,34 @@ func main() {
 	ctx, forceCancel := context.WithCancel(context.Background())
 	defer forceCancel()
 
+	// shutdownCh is closed exactly once -- by either the signal
+	// handler or the updater. Whichever fires first wins; the other
+	// is a no-op via shutdownOnce.
 	shutdownCh := make(chan struct{})
+	var shutdownOnce sync.Once
+
+	// updateResult is set by the updater BEFORE it closes shutdownCh,
+	// so when Agent.Run returns we can read it and dispatch the
+	// configured restart action. nil = signal-driven shutdown, no
+	// restart needed.
+	var updateResult atomic.Pointer[update.Result]
+
+	closeShutdown := func(r *update.Result) {
+		shutdownOnce.Do(func() {
+			if r != nil {
+				updateResult.Store(r)
+			}
+			close(shutdownCh)
+		})
+	}
+
 	sigCh := make(chan os.Signal, 2)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 
 	go func() {
 		<-sigCh
 		logger.Info("shutdown requested, saving state... (send again to force quit)")
-		close(shutdownCh)
+		closeShutdown(nil)
 
 		<-sigCh
 		logger.Info("forced shutdown")
@@ -168,9 +193,27 @@ func main() {
 		email = &cfg.Email
 	}
 
-	exec := tools.New(memory, index, tg, sb, email, kb, logger,
+	// Updater. Always constructed so the get_version tool works even
+	// when self-update is disabled; the polling goroutine starts only
+	// when cfg.Update.Enabled.
+	binaryPath := cfg.Update.BinaryPath
+	if binaryPath == "" {
+		if exe, err := os.Executable(); err == nil {
+			binaryPath = exe
+		}
+	}
+	updater := update.New(update.Config{
+		Enabled:         cfg.Update.Enabled,
+		CheckInterval:   cfg.Update.CheckInterval.Duration(),
+		GitHubRepo:      cfg.Update.GitHubRepo,
+		AllowPrerelease: cfg.Update.AllowPrerelease,
+		BinaryPath:      binaryPath,
+	}, memory, closeShutdown, logger)
+	go updater.Run(ctx)
+
+	toolExec := tools.New(memory, index, tg, sb, email, kb, updater, logger,
 		cfg.Agent.MaxTokens, cfg.Limits, cfg.Agent.MaxSleep.Duration())
-	defer exec.Close()
+	defer toolExec.Close()
 
 	state := jsonfile.NewPersister(cfg.Agent.StateFile, logger)
 
@@ -182,7 +225,7 @@ func main() {
 		Search:    index,
 		Operator:  operator,
 		Tokenizer: tokenizer,
-		Tools:     exec,
+		Tools:     toolExec,
 		State:     state,
 	}, logger)
 	defer a.Close()
@@ -201,6 +244,62 @@ func main() {
 	}
 
 	logger.Info("agent shut down gracefully")
+
+	// If shutdown was triggered by an applied update, dispatch the
+	// configured restart action. Adapters that own their own resources
+	// were closed via defer above, so it is safe to exec a new binary
+	// or run a restart command at this point.
+	if r := updateResult.Load(); r != nil {
+		dispatchRestart(*r, cfg.Update.RestartMode, cfg.Update.RestartCommand, binaryPath, logger)
+	}
+}
+
+// dispatchRestart runs the configured action after a successful update
+// has been applied and the agent loop has shut down cleanly. Returns
+// only on "exit" or "command" (the supervisor / new process takes over
+// from here); does not return for "self-exec".
+func dispatchRestart(r update.Result, mode, command, binaryPath string, logger *slog.Logger) {
+	switch mode {
+	case "", "exit":
+		logger.Info("update applied; exiting for supervisor restart",
+			"from", r.FromVersion, "to", r.ToVersion)
+	case "self-exec":
+		logger.Info("update applied; replacing process image with new binary",
+			"from", r.FromVersion, "to", r.ToVersion, "binary", binaryPath)
+		// syscall.Exec replaces the current process image. Same PID.
+		// On success this call never returns. On failure we fall
+		// through to os.Exit so the supervisor (if any) can pick up
+		// the new binary on the next start.
+		if err := syscall.Exec(binaryPath, os.Args, os.Environ()); err != nil {
+			logger.Error("self-exec failed; falling back to exit", "error", err)
+			os.Exit(1)
+		}
+	case "command":
+		logger.Info("update applied; running configured restart command",
+			"from", r.FromVersion, "to", r.ToVersion, "command", command)
+		runRestartCommand(command, logger)
+	default:
+		logger.Warn("unknown restart_mode; treating as exit",
+			"mode", mode, "from", r.FromVersion, "to", r.ToVersion)
+	}
+}
+
+// runRestartCommand splits command on whitespace and starts it
+// detached so it survives this process exiting. Errors are logged but
+// not fatal; the new binary is already in place, so even a failed
+// restart command leaves the deploy in a recoverable state.
+func runRestartCommand(command string, logger *slog.Logger) {
+	parts := strings.Fields(command)
+	if len(parts) == 0 {
+		logger.Warn("restart_command is empty; nothing to run")
+		return
+	}
+	cmd := exec.Command(parts[0], parts[1:]...)
+	// Detach: new session group so the child outlives our exit.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		logger.Error("restart command failed to start", "error", err)
+	}
 }
 
 // buildLogger wires a console handler at the configured level alongside a

--- a/config.example.toml
+++ b/config.example.toml
@@ -140,6 +140,59 @@ user     = ""
 password = ""
 
 # ---------------------------------------------------------------------------
+# [update] — automatic self-update.
+#
+# When enabled, a background goroutine polls the configured GitHub repo's
+# releases on the given interval. If a newer version is available, the
+# updater downloads the matching release tarball, verifies it against the
+# published SHA256SUMS, atomically swaps the binary, and triggers graceful
+# shutdown so the new binary takes over. The agent's get_version tool is
+# always available; update_check / update_apply are advertised only when
+# self-update is enabled.
+#
+# The LLM does not decide whether to update -- it can only kick off the
+# same code path the polling goroutine runs. Disable here if you don't
+# want auto-updates at all.
+# ---------------------------------------------------------------------------
+[update]
+enabled = false
+
+# How often to poll GitHub releases. Operator-triggered checks via the
+# update_check tool run on demand regardless of this interval. Use shorter
+# values (e.g. "5m") for fast iteration; the default is conservative
+# enough not to risk GitHub rate-limit issues even if you run many agents.
+check_interval = "1h"
+
+# "owner/name" of the GitHub repository whose releases we poll.
+github_repo = "matjam/faultline"
+
+# What to do after a successful update applies. Options:
+#   "exit"      - save state and os.Exit(0). Suitable for any process
+#                 supervisor that respawns the unit (systemd, Docker,
+#                 Kubernetes, runit, supervisord, etc.). This is the
+#                 simplest and most common choice.
+#   "self-exec" - save state and syscall.Exec the new binary, replacing
+#                 the current process image. Same PID. Use this when
+#                 running bare without a supervisor (tmux, screen,
+#                 manual ./faultline run).
+#   "command"   - save state, run restart_command (split on whitespace,
+#                 detached), then exit. For custom orchestrators.
+restart_mode = "exit"
+
+# Only used when restart_mode = "command".
+restart_command = ""
+
+# Whether to consider releases marked as prerelease (alpha / beta / rc).
+# Default false: stable releases only.
+allow_prerelease = false
+
+# Absolute path of the running binary. The updater swaps this file in
+# place. Leave empty to auto-detect via os.Executable() at startup; you
+# really only need to set this if running under unusual launchers that
+# break os.Executable().
+binary_path = ""
+
+# ---------------------------------------------------------------------------
 # [limits] — content-size caps for LLM-facing surfaces.
 #
 # Each limit applies to a different surface; when content is clipped, a

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/sqs/go-xoauth2 v0.0.0-20120917012134-0911dad68e56 // indirect
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
 	github.com/yuin/goldmark v1.6.0 // indirect
+	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/yuin/goldmark v1.6.0 h1:boZcn2GTjpsynOsC0iJHnBWa4Bi0qzfJjthwauItG68=
 github.com/yuin/goldmark v1.6.0/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
+golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
 golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
 golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	Sandbox  SandboxConfig  `toml:"sandbox"`
 	Email    EmailConfig    `toml:"email"`
 	Limits   LimitsConfig   `toml:"limits"`
+	Update   UpdateConfig   `toml:"update"`
 }
 
 // APIConfig holds LLM API connection settings.
@@ -128,6 +129,49 @@ func (t TelegramConfig) Enabled() bool {
 	return t.Token != "" && t.ChatID != 0
 }
 
+// UpdateConfig holds settings for the automatic self-update goroutine.
+// Disabled by default; opt in by setting Enabled = true.
+type UpdateConfig struct {
+	// Enabled toggles the entire self-update mechanism. When false, the
+	// updater goroutine doesn't run and the update_check / update_apply
+	// tools are not advertised to the LLM.
+	Enabled bool `toml:"enabled"`
+
+	// CheckInterval controls how often the updater polls GitHub for new
+	// releases. Operator-triggered checks (via the update_check tool)
+	// run on demand regardless. Zero falls back to a 1-hour default.
+	CheckInterval duration `toml:"check_interval"`
+
+	// GitHubRepo is the "owner/name" path of the repository whose
+	// releases we poll. Defaults to "matjam/faultline".
+	GitHubRepo string `toml:"github_repo"`
+
+	// RestartMode controls what the agent does after a successful
+	// update applies. One of:
+	//   "exit"      - save state and os.Exit(0); supervisor (systemd,
+	//                 docker, k8s) is expected to respawn the agent.
+	//   "self-exec" - save state and syscall.Exec the new binary,
+	//                 replacing this process image. Same PID. Suitable
+	//                 for bare-process runs without a supervisor.
+	//   "command"   - save state, run RestartCommand, exit. For custom
+	//                 orchestrators.
+	// Default "exit".
+	RestartMode string `toml:"restart_mode"`
+
+	// RestartCommand is run when RestartMode = "command". Split on
+	// whitespace and exec'd. Empty for the other modes.
+	RestartCommand string `toml:"restart_command"`
+
+	// AllowPrerelease, when true, considers GitHub releases marked as
+	// prerelease (alpha/beta/rc tags) as candidates. Default false.
+	AllowPrerelease bool `toml:"allow_prerelease"`
+
+	// BinaryPath is the absolute path of the running binary. The
+	// updater swaps this file in place. Empty falls back to
+	// os.Executable() at startup.
+	BinaryPath string `toml:"binary_path"`
+}
+
 // EmailConfig holds optional IMAP email connection settings.
 type EmailConfig struct {
 	Host     string `toml:"host"`
@@ -193,6 +237,12 @@ func Default() *Config {
 			MemorySearchResultChars: 6000,
 			SandboxOutputChars:      64000,
 		},
+		Update: UpdateConfig{
+			Enabled:       false,
+			CheckInterval: duration(1 * time.Hour),
+			GitHubRepo:    "matjam/faultline",
+			RestartMode:   "exit",
+		},
 	}
 }
 
@@ -214,6 +264,13 @@ func Load(path string) (*Config, error) {
 	// genuinely wants no sleep cap can set a very large value explicitly.
 	if cfg.Agent.MaxSleep.Duration() <= 0 {
 		cfg.Agent.MaxSleep = duration(15 * time.Minute)
+	}
+
+	// Same logic for update poll interval -- 0 in the file shouldn't
+	// silently disable polling. A user who wants polling off should
+	// set update.enabled = false.
+	if cfg.Update.CheckInterval.Duration() <= 0 {
+		cfg.Update.CheckInterval = duration(1 * time.Hour)
 	}
 
 	return cfg, nil

--- a/internal/prompts/templates/system.md
+++ b/internal/prompts/templates/system.md
@@ -27,6 +27,9 @@ Your goal is to learn about the world and become a positive force in it. How you
 - **get_time()** — Get current date and time.
 - **sleep(seconds)** — Pause your loop for N seconds without burning context. Operator messages interrupt immediately. Bounded by a configured maximum.
 - **send_message(text)** — Send a message to your collaborator via Telegram (if configured).
+- **get_version()** — Print the running binary's version, commit SHA, and build time. Useful right after an update to confirm what version is now running.
+- **update_check()** — (when self-update is enabled) Poll GitHub for newer releases. Read-only; does not apply anything.
+- **update_apply()** — (when self-update is enabled) Download and install the latest release, then trigger graceful shutdown so the new binary takes over. The agent restarts under whatever process supervisor or restart strategy the operator configured.
 
 ## Memory
 

--- a/internal/tools/executor.go
+++ b/internal/tools/executor.go
@@ -29,6 +29,8 @@ import (
 	"github.com/matjam/faultline/internal/config"
 	"github.com/matjam/faultline/internal/llm"
 	"github.com/matjam/faultline/internal/search/bm25"
+	"github.com/matjam/faultline/internal/update"
+	"github.com/matjam/faultline/internal/version"
 )
 
 // memoryPathSegment defines the allowed shape of a single path segment
@@ -506,6 +508,47 @@ func (te *Executor) ToolDefs() []llm.Tool {
 				},
 			},
 		},
+		{
+			Type: llm.ToolTypeFunction,
+			Function: &llm.FunctionDef{
+				Name:        "get_version",
+				Description: "Get the running binary's version, commit SHA, and build time. Use this to confirm what version is running, especially after an update.",
+				Parameters: map[string]interface{}{
+					"type":       "object",
+					"properties": map[string]interface{}{},
+				},
+			},
+		},
+	}
+
+	// update_check / update_apply only when self-update is enabled in
+	// config. Operators on deployments without self-update can still
+	// query the running version via get_version above.
+	if te.updater != nil && te.updater.Enabled() {
+		tools = append(tools,
+			llm.Tool{
+				Type: llm.ToolTypeFunction,
+				Function: &llm.FunctionDef{
+					Name:        "update_check",
+					Description: "Check GitHub releases for a newer version of faultline. Does NOT apply anything; just polls. Returns the current version, the latest released version, whether an update is available, and the time of the check.",
+					Parameters: map[string]interface{}{
+						"type":       "object",
+						"properties": map[string]interface{}{},
+					},
+				},
+			},
+			llm.Tool{
+				Type: llm.ToolTypeFunction,
+				Function: &llm.FunctionDef{
+					Name:        "update_apply",
+					Description: "Download and apply the latest released version, then trigger graceful shutdown so the new binary takes over. The actual restart strategy (process supervisor exit, self-exec, or a configured restart command) is set in operator config; you don't pick it. Returns an error message if no update is available or if the apply fails.",
+					Parameters: map[string]interface{}{
+						"type":       "object",
+						"properties": map[string]interface{}{},
+					},
+				},
+			},
+		)
 	}
 
 	if te.telegram != nil {
@@ -895,7 +938,8 @@ type Executor struct {
 	telegram      *telegram.Bot
 	sandbox       *docker.Sandbox
 	email         *config.EmailConfig
-	kobold        *kobold.Client // optional; nil means no perf info in context_status
+	kobold        *kobold.Client  // optional; nil means no perf info in context_status
+	updater       *update.Updater // optional; always non-nil but Enabled() may be false
 	logger        *slog.Logger
 	http          *http.Client
 	cache         *webCache
@@ -906,7 +950,7 @@ type Executor struct {
 }
 
 // New creates a new tool executor. kb may be nil.
-func New(memory *fs.Store, index *bm25.Index, tg *telegram.Bot, sb *docker.Sandbox, email *config.EmailConfig, kb *kobold.Client, logger *slog.Logger, maxTokens int, limits config.LimitsConfig, maxSleep time.Duration) *Executor {
+func New(memory *fs.Store, index *bm25.Index, tg *telegram.Bot, sb *docker.Sandbox, email *config.EmailConfig, kb *kobold.Client, updater *update.Updater, logger *slog.Logger, maxTokens int, limits config.LimitsConfig, maxSleep time.Duration) *Executor {
 	if sb != nil {
 		sb.SetOutputLimit(limits.SandboxOutputChars)
 	}
@@ -917,6 +961,7 @@ func New(memory *fs.Store, index *bm25.Index, tg *telegram.Bot, sb *docker.Sandb
 		sandbox:   sb,
 		email:     email,
 		kobold:    kb,
+		updater:   updater,
 		logger:    logger,
 		maxTokens: maxTokens,
 		limits:    limits,
@@ -1010,6 +1055,12 @@ func (te *Executor) Execute(ctx context.Context, call llm.ToolCall) string {
 		return time.Now().Format("Monday, January 2, 2006 3:04:05 PM MST")
 	case "sleep":
 		return te.sleep(ctx, args)
+	case "get_version":
+		return te.getVersion()
+	case "update_check":
+		return te.updateCheck(ctx)
+	case "update_apply":
+		return te.updateApply(ctx)
 	case "send_message":
 		return te.sendMessage(args)
 	case "email_fetch":
@@ -1776,6 +1827,63 @@ func (te *Executor) sleep(ctx context.Context, argsJSON string) string {
 			}
 		}
 	}
+}
+
+// getVersion returns the running binary's version metadata.
+func (te *Executor) getVersion() string {
+	if te.updater == nil {
+		return "Version: unknown (updater not configured)"
+	}
+	return fmt.Sprintf("Running %s.", version.String())
+}
+
+// updateCheck polls GitHub releases for newer versions without
+// applying anything. Returns a human-readable summary suitable for
+// the LLM.
+func (te *Executor) updateCheck(ctx context.Context) string {
+	if te.updater == nil || !te.updater.Enabled() {
+		return "Error: self-update is not enabled in this deployment."
+	}
+	state := te.updater.Check(ctx)
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Current version: %s\n", state.CurrentVersion)
+	if state.LatestVersion != "" {
+		fmt.Fprintf(&sb, "Latest released:  %s\n", state.LatestVersion)
+	}
+	fmt.Fprintf(&sb, "Update available: %v\n", state.UpdateAvailable)
+	fmt.Fprintf(&sb, "Last checked:     %s\n", state.LastChecked.UTC().Format(time.RFC1123))
+	if state.Note != "" {
+		fmt.Fprintf(&sb, "Note: %s\n", state.Note)
+	}
+	if state.Err != nil {
+		fmt.Fprintf(&sb, "Error: %s\n", state.Err)
+	}
+	if state.UpdateAvailable {
+		sb.WriteString("\nCall update_apply to download and install the new version. " +
+			"This will trigger graceful shutdown so the new binary takes over.")
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+// updateApply triggers the full apply pipeline (download, verify,
+// swap, signal shutdown). Synchronous from the LLM's perspective:
+// returns once the apply finishes (success) or fails. On success the
+// agent enters graceful shutdown immediately afterward, so this is
+// effectively the agent's last tool call before the new binary takes
+// over.
+func (te *Executor) updateApply(ctx context.Context) string {
+	if te.updater == nil || !te.updater.Enabled() {
+		return "Error: self-update is not enabled in this deployment."
+	}
+	res, err := te.updater.Apply(ctx)
+	if err != nil {
+		return fmt.Sprintf("Update apply failed: %s", err)
+	}
+	return fmt.Sprintf("Update applied: %s -> %s. The agent is now shutting down "+
+		"to load the new binary. Save anything important to memory in your "+
+		"next response; the shutdown sequence is about to start.",
+		res.FromVersion, res.ToVersion)
 }
 
 func (te *Executor) memoryEdit(argsJSON string) string {

--- a/internal/update/apply.go
+++ b/internal/update/apply.go
@@ -1,0 +1,232 @@
+package update
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// apply is the apply-update pipeline:
+//  1. Download the matching tarball asset to a temp file in the binary's
+//     directory (so the eventual rename is on the same filesystem and
+//     therefore atomic).
+//  2. Download SHA256SUMS, verify the tarball's hash matches its line.
+//  3. Extract the inner faultline binary to <binaryPath>.new.
+//  4. chmod +x the .new file.
+//  5. Rename current binary to .previous (one-deep rollback slot).
+//  6. Rename .new to current.
+//
+// On any failure after step 5, attempts to restore from .previous so a
+// half-applied update doesn't leave the deploy broken.
+func (u *Updater) apply(ctx context.Context, rel *Release) (*Result, error) {
+	current := u.cfg.BinaryPath
+	if current == "" {
+		return nil, errors.New("binary path not configured")
+	}
+
+	tagBare := strings.TrimPrefix(rel.TagName, "v")
+	assetName := AssetName(tagBare)
+
+	asset := rel.FindAsset(assetName)
+	if asset == nil {
+		return nil, fmt.Errorf("release %s has no asset matching %q", rel.TagName, assetName)
+	}
+	checksums := rel.FindAsset(ChecksumsName)
+	if checksums == nil {
+		return nil, fmt.Errorf("release %s has no %s asset", rel.TagName, ChecksumsName)
+	}
+
+	binDir := filepath.Dir(current)
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		return nil, fmt.Errorf("ensure bin dir: %w", err)
+	}
+
+	tarPath := current + ".tar.tmp"
+	newPath := current + ".new"
+	prevPath := current + ".previous"
+
+	// Always clean up the tarball; .new only on failure.
+	defer os.Remove(tarPath)
+
+	// 1. Download tarball.
+	if err := downloadTo(ctx, u.gh, asset.BrowserDownloadURL, tarPath); err != nil {
+		return nil, err
+	}
+
+	// 2. Download checksums and verify.
+	wantSum, err := fetchExpectedSum(ctx, u.gh, checksums.BrowserDownloadURL, assetName)
+	if err != nil {
+		return nil, err
+	}
+	gotSum, err := fileSha256(tarPath)
+	if err != nil {
+		return nil, fmt.Errorf("hash tarball: %w", err)
+	}
+	if gotSum != wantSum {
+		return nil, fmt.Errorf("checksum mismatch for %s: got %s, want %s",
+			assetName, gotSum, wantSum)
+	}
+
+	// 3. Extract the faultline binary into <current>.new.
+	if err := extractBinary(tarPath, newPath); err != nil {
+		_ = os.Remove(newPath)
+		return nil, err
+	}
+
+	// 4. chmod +x. Fail-safe: clean up .new if we can't make it
+	// executable.
+	if err := os.Chmod(newPath, 0o755); err != nil {
+		_ = os.Remove(newPath)
+		return nil, fmt.Errorf("chmod new binary: %w", err)
+	}
+
+	// 5. Move current -> .previous (one-deep rollback slot). os.Rename
+	// overwrites destination on Linux, so any stale .previous from a
+	// prior update is replaced atomically.
+	if err := os.Rename(current, prevPath); err != nil {
+		_ = os.Remove(newPath)
+		return nil, fmt.Errorf("rotate current to previous: %w", err)
+	}
+
+	// 6. Move .new -> current. On failure, rollback by restoring
+	// .previous to current so the deploy keeps running on the old
+	// binary.
+	if err := os.Rename(newPath, current); err != nil {
+		if rbErr := os.Rename(prevPath, current); rbErr != nil {
+			return nil, errors.Join(
+				fmt.Errorf("install new binary failed: %w", err),
+				fmt.Errorf("rollback failed: %w; deploy is broken", rbErr),
+			)
+		}
+		return nil, fmt.Errorf("install new binary: %w", err)
+	}
+
+	return &Result{
+		FromVersion: u.currentVersion(),
+		ToVersion:   rel.TagName,
+		BinaryPath:  current,
+	}, nil
+}
+
+// downloadTo streams a URL to a file. The file is created with 0644
+// permissions; chmod happens later on the extracted binary, not the
+// tarball.
+func downloadTo(ctx context.Context, gh *githubClient, url, path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	defer f.Close()
+
+	if err := gh.download(ctx, url, f); err != nil {
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("sync temp file: %w", err)
+	}
+	return nil
+}
+
+// fileSha256 returns the lowercase hex SHA-256 of the file at path.
+func fileSha256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// fetchExpectedSum downloads SHA256SUMS and finds the entry matching
+// assetName. SHA256SUMS lines look like:
+//
+//	abc123...  faultline_1.0.0_linux_x86_64.tar.gz
+//
+// (two-space separator). Returns the expected hex digest.
+func fetchExpectedSum(ctx context.Context, gh *githubClient, url, assetName string) (string, error) {
+	var buf strings.Builder
+	if err := gh.download(ctx, url, &buf); err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(buf.String(), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		// Last field is the filename, first field is the digest.
+		// goreleaser writes "<digest>  <filename>" but tolerate
+		// any whitespace between.
+		if fields[len(fields)-1] == assetName {
+			return strings.ToLower(fields[0]), nil
+		}
+	}
+	return "", fmt.Errorf("%s not listed in SHA256SUMS", assetName)
+}
+
+// extractBinary reads tarPath (a .tar.gz archive) and writes the
+// faultline binary inside it to outPath. Other files in the archive
+// (LICENSE, README.md, AGENTS.md, config.example.toml) are ignored --
+// the deployed binary is the only thing the updater swaps.
+func extractBinary(tarPath, outPath string) error {
+	f, err := os.Open(tarPath)
+	if err != nil {
+		return fmt.Errorf("open tarball: %w", err)
+	}
+	defer f.Close()
+
+	gzr, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("gzip: %w", err)
+	}
+	defer gzr.Close()
+
+	tr := tar.NewReader(gzr)
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("tar read: %w", err)
+		}
+		// goreleaser tarballs are flat (no nested directories), but be
+		// safe and only consider the basename. We accept exactly
+		// "faultline" as the binary entry.
+		if filepath.Base(hdr.Name) != "faultline" || hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		out, err := os.OpenFile(outPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+		if err != nil {
+			return fmt.Errorf("create new binary: %w", err)
+		}
+		// Cap copy at the header's size to avoid a malicious archive
+		// claiming a tiny file but streaming forever.
+		if _, err := io.CopyN(out, tr, hdr.Size); err != nil {
+			out.Close()
+			_ = os.Remove(outPath)
+			return fmt.Errorf("extract binary: %w", err)
+		}
+		if err := out.Close(); err != nil {
+			return fmt.Errorf("close new binary: %w", err)
+		}
+		return nil
+	}
+	return errors.New("tarball did not contain a faultline binary")
+}

--- a/internal/update/apply_test.go
+++ b/internal/update/apply_test.go
@@ -1,0 +1,145 @@
+package update
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestExtractBinary(t *testing.T) {
+	dir := t.TempDir()
+	tarPath := filepath.Join(dir, "fixture.tar.gz")
+	wantContent := []byte("#!/bin/sh\necho old\n")
+
+	writeTarball(t, tarPath, map[string][]byte{
+		"LICENSE":             []byte("license text"),
+		"README.md":           []byte("readme"),
+		"faultline":           wantContent,
+		"config.example.toml": []byte("# example"),
+	})
+
+	outPath := filepath.Join(dir, "faultline.new")
+	if err := extractBinary(tarPath, outPath); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, wantContent) {
+		t.Errorf("extracted content mismatch\n got: %q\nwant: %q", got, wantContent)
+	}
+}
+
+func TestExtractBinary_MissingBinary(t *testing.T) {
+	dir := t.TempDir()
+	tarPath := filepath.Join(dir, "no-binary.tar.gz")
+	writeTarball(t, tarPath, map[string][]byte{
+		"LICENSE":   []byte("license"),
+		"README.md": []byte("readme"),
+	})
+
+	err := extractBinary(tarPath, filepath.Join(dir, "out"))
+	if err == nil || !strings.Contains(err.Error(), "did not contain") {
+		t.Errorf("expected 'did not contain' error, got %v", err)
+	}
+}
+
+func TestFetchExpectedSum(t *testing.T) {
+	body := `abc123def456  faultline_1.0.0_linux_x86_64.tar.gz
+fedcba654321  faultline_1.0.0_linux_arm64.tar.gz
+`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	gh := newGitHubClient("o/r")
+	gh.apiBase = srv.URL
+
+	got, err := fetchExpectedSum(t.Context(), gh, srv.URL, "faultline_1.0.0_linux_arm64.tar.gz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "fedcba654321" {
+		t.Errorf("got %q, want fedcba654321", got)
+	}
+}
+
+func TestFetchExpectedSum_NotListed(t *testing.T) {
+	body := `abc123  some-other-file.tar.gz`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+	gh := newGitHubClient("o/r")
+	gh.apiBase = srv.URL
+
+	_, err := fetchExpectedSum(t.Context(), gh, srv.URL, "missing.tar.gz")
+	if err == nil || !strings.Contains(err.Error(), "not listed") {
+		t.Errorf("expected 'not listed' error, got %v", err)
+	}
+}
+
+func TestFileSha256(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "f")
+	content := []byte("hello world")
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := fileSha256(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := sha256Hex(content)
+	if got != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+}
+
+// writeTarball creates a .tar.gz at path containing the given files.
+func writeTarball(t *testing.T, path string, files map[string][]byte) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	gzw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gzw)
+	for name, content := range files {
+		hdr := &tar.Header{
+			Name: name,
+			Mode: 0o644,
+			Size: int64(len(content)),
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(content); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gzw.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func sha256Hex(b []byte) string {
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:])
+}

--- a/internal/update/asset.go
+++ b/internal/update/asset.go
@@ -1,0 +1,33 @@
+package update
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// AssetName returns the goreleaser-produced archive name for the
+// running platform and a given semver-shaped version string. The
+// version is the bare semver ("1.2.3", no leading "v") because that's
+// what goreleaser embeds in archive names.
+//
+// Mirrors the name_template in .goreleaser.yaml:
+//
+//	{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ x86_64 | arm | .Arch }}
+//
+// where amd64 is rewritten to x86_64 to match the Linux convention.
+func AssetName(version string) string {
+	return fmt.Sprintf("faultline_%s_%s_%s.tar.gz", version, runtime.GOOS, archLabel(runtime.GOARCH))
+}
+
+// archLabel maps a Go GOARCH value to the label goreleaser writes into
+// archive names.
+func archLabel(arch string) string {
+	if arch == "amd64" {
+		return "x86_64"
+	}
+	return arch
+}
+
+// ChecksumsName is the SHA256SUMS asset filename goreleaser publishes.
+// Constant; goreleaser doesn't template the version into it.
+const ChecksumsName = "SHA256SUMS"

--- a/internal/update/asset_test.go
+++ b/internal/update/asset_test.go
@@ -1,0 +1,34 @@
+package update
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestAssetName_MatchesGoreleaserConvention(t *testing.T) {
+	got := AssetName("1.2.3")
+	if !strings.HasPrefix(got, "faultline_1.2.3_") {
+		t.Errorf("missing version prefix in %q", got)
+	}
+	if !strings.HasSuffix(got, ".tar.gz") {
+		t.Errorf("missing extension in %q", got)
+	}
+	if !strings.Contains(got, runtime.GOOS) {
+		t.Errorf("%q missing os %q", got, runtime.GOOS)
+	}
+}
+
+func TestArchLabel(t *testing.T) {
+	cases := map[string]string{
+		"amd64": "x86_64",
+		"arm64": "arm64",
+		"arm":   "arm",
+		"386":   "386",
+	}
+	for in, want := range cases {
+		if got := archLabel(in); got != want {
+			t.Errorf("archLabel(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/update/github.go
+++ b/internal/update/github.go
@@ -1,0 +1,144 @@
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// githubClient is a tiny client for the subset of GitHub releases API
+// the updater needs. No external SDK because we only consume two
+// endpoints and want to control timeouts + auth knobs.
+type githubClient struct {
+	apiBase string // default https://api.github.com; overridden in tests
+	repo    string // "owner/name"
+	http    *http.Client
+}
+
+func newGitHubClient(repo string) *githubClient {
+	return &githubClient{
+		apiBase: "https://api.github.com",
+		repo:    repo,
+		http: &http.Client{
+			// Long enough for slow networks; short enough to fail fast on
+			// dead hosts.
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// Release is the trimmed-down GitHub release shape we consume. Fields
+// not used here (body, author, etc.) are ignored on decode.
+type Release struct {
+	TagName    string         `json:"tag_name"`
+	Name       string         `json:"name"`
+	Prerelease bool           `json:"prerelease"`
+	Draft      bool           `json:"draft"`
+	HTMLURL    string         `json:"html_url"`
+	Assets     []ReleaseAsset `json:"assets"`
+}
+
+// ReleaseAsset is one downloadable artifact attached to a release.
+type ReleaseAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+	Size               int64  `json:"size"`
+}
+
+// FindAsset returns the asset matching name, or nil.
+func (r *Release) FindAsset(name string) *ReleaseAsset {
+	for i := range r.Assets {
+		if r.Assets[i].Name == name {
+			return &r.Assets[i]
+		}
+	}
+	return nil
+}
+
+// Latest fetches the latest non-draft release. When allowPrerelease is
+// false and the latest is a prerelease, returns nil with no error
+// (the caller treats this as "no eligible release available").
+func (c *githubClient) Latest(ctx context.Context, allowPrerelease bool) (*Release, error) {
+	rel, err := c.getRelease(ctx, "/releases/latest")
+	if err != nil {
+		return nil, err
+	}
+	if rel == nil {
+		return nil, nil // 404, no release published yet
+	}
+	if rel.Draft {
+		return nil, nil
+	}
+	if rel.Prerelease && !allowPrerelease {
+		return nil, nil
+	}
+	return rel, nil
+}
+
+func (c *githubClient) getRelease(ctx context.Context, path string) (*Release, error) {
+	url := c.apiBase + "/repos/" + c.repo + path
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	// Pin to v3 (current stable) explicitly; future-proofing.
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("User-Agent", "faultline-updater")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("github releases: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		// Repo or release missing. Treat as "no release available"
+		// rather than an error so a misconfigured repo doesn't crash
+		// the updater on every poll.
+		return nil, nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("github releases: HTTP %d: %s",
+			resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var rel Release
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return nil, fmt.Errorf("decode release: %w", err)
+	}
+	return &rel, nil
+}
+
+// download fetches a URL into out, with progress and a context-bound
+// HTTP request. Caller is responsible for closing out.
+func (c *githubClient) download(ctx context.Context, url string, out io.Writer) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/octet-stream")
+	req.Header.Set("User-Agent", "faultline-updater")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("download %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("download %s: HTTP %d: %s",
+			url, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	if _, err := io.Copy(out, resp.Body); err != nil {
+		return fmt.Errorf("read body: %w", err)
+	}
+	return nil
+}

--- a/internal/update/github_test.go
+++ b/internal/update/github_test.go
@@ -1,0 +1,89 @@
+package update
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLatest_FiltersDraft(t *testing.T) {
+	srv := mockGitHub(t, `{"tag_name":"v1.0.0","name":"v1.0.0","draft":true,"prerelease":false,"assets":[]}`)
+	c := newGitHubClient("o/r")
+	c.apiBase = srv.URL
+	rel, err := c.Latest(context.Background(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rel != nil {
+		t.Errorf("draft release should be filtered out, got %+v", rel)
+	}
+}
+
+func TestLatest_FiltersPrereleaseByDefault(t *testing.T) {
+	srv := mockGitHub(t, `{"tag_name":"v1.0.0-rc.1","name":"v1.0.0-rc.1","prerelease":true,"assets":[]}`)
+	c := newGitHubClient("o/r")
+	c.apiBase = srv.URL
+	rel, err := c.Latest(context.Background(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rel != nil {
+		t.Errorf("prerelease should be filtered, got %+v", rel)
+	}
+}
+
+func TestLatest_AllowPrerelease(t *testing.T) {
+	srv := mockGitHub(t, `{"tag_name":"v1.0.0-rc.1","name":"v1.0.0-rc.1","prerelease":true,"assets":[]}`)
+	c := newGitHubClient("o/r")
+	c.apiBase = srv.URL
+	rel, err := c.Latest(context.Background(), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rel == nil {
+		t.Fatal("expected prerelease to be returned when allowed")
+	}
+	if rel.TagName != "v1.0.0-rc.1" {
+		t.Errorf("got tag %q", rel.TagName)
+	}
+}
+
+func TestLatest_NotFoundIsNotError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.NotFound(w, nil)
+	}))
+	defer srv.Close()
+	c := newGitHubClient("o/r")
+	c.apiBase = srv.URL
+	rel, err := c.Latest(context.Background(), false)
+	if err != nil {
+		t.Errorf("404 should not error, got %v", err)
+	}
+	if rel != nil {
+		t.Errorf("expected nil release on 404, got %+v", rel)
+	}
+}
+
+func TestRelease_FindAsset(t *testing.T) {
+	r := &Release{Assets: []ReleaseAsset{
+		{Name: "alpha.tar.gz"},
+		{Name: "beta.tar.gz"},
+	}}
+	if a := r.FindAsset("beta.tar.gz"); a == nil || a.Name != "beta.tar.gz" {
+		t.Errorf("FindAsset returned %+v", a)
+	}
+	if a := r.FindAsset("missing"); a != nil {
+		t.Errorf("expected nil for missing asset, got %+v", a)
+	}
+}
+
+func mockGitHub(t *testing.T, releaseJSON string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(releaseJSON))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}

--- a/internal/update/semver.go
+++ b/internal/update/semver.go
@@ -1,0 +1,44 @@
+package update
+
+import (
+	"strings"
+
+	"golang.org/x/mod/semver"
+)
+
+// IsNewer reports whether candidate (e.g. "v1.2.3") is strictly newer
+// than current (e.g. "v1.2.0"). Both inputs are normalized so a missing
+// "v" prefix is tolerated. Non-semver inputs (e.g. the "dev" placeholder
+// from a local build) are treated as the oldest possible version, so any
+// real release tag wins -- this is the right behavior because we want
+// dev builds to upgrade to real releases when self-update is enabled.
+func IsNewer(candidate, current string) bool {
+	c := normalize(candidate)
+	cur := normalize(current)
+
+	if !semver.IsValid(c) {
+		return false
+	}
+	if !semver.IsValid(cur) {
+		return true
+	}
+	return semver.Compare(c, cur) > 0
+}
+
+// IsPrerelease reports whether tag (e.g. "v1.2.3-rc.1") is a prerelease.
+func IsPrerelease(tag string) bool {
+	return semver.Prerelease(normalize(tag)) != ""
+}
+
+// normalize ensures a "v" prefix on tag-shaped strings so semver.* works.
+// Empty input is returned as-is and validity-checked by callers.
+func normalize(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if !strings.HasPrefix(s, "v") {
+		return "v" + s
+	}
+	return s
+}

--- a/internal/update/semver_test.go
+++ b/internal/update/semver_test.go
@@ -1,0 +1,55 @@
+package update
+
+import "testing"
+
+func TestIsNewer(t *testing.T) {
+	cases := []struct {
+		candidate string
+		current   string
+		want      bool
+	}{
+		{"v1.2.3", "v1.2.0", true},
+		{"v1.2.3", "v1.2.3", false},
+		{"v1.2.0", "v1.2.3", false},
+		{"v2.0.0", "v1.99.99", true},
+		// no v prefix tolerated
+		{"1.2.3", "1.2.0", true},
+		{"1.2.0", "v1.2.3", false},
+		// dev / non-semver current means anything wins
+		{"v1.0.0", "dev", true},
+		{"v0.1.0", "dev", true},
+		// dev candidate is never newer
+		{"dev", "v1.0.0", false},
+		{"dev", "dev", false},
+		// prerelease compares correctly
+		{"v1.0.0", "v1.0.0-rc.1", true},
+		{"v1.0.0-rc.2", "v1.0.0-rc.1", true},
+	}
+	for _, tc := range cases {
+		got := IsNewer(tc.candidate, tc.current)
+		if got != tc.want {
+			t.Errorf("IsNewer(%q, %q) = %v, want %v",
+				tc.candidate, tc.current, got, tc.want)
+		}
+	}
+}
+
+func TestIsPrerelease(t *testing.T) {
+	cases := []struct {
+		tag  string
+		want bool
+	}{
+		{"v1.0.0", false},
+		{"v1.0.0-rc.1", true},
+		{"v1.0.0-alpha", true},
+		{"v1.0.0-beta.3", true},
+		{"1.0.0", false},
+		{"1.0.0-rc.1", true},
+	}
+	for _, tc := range cases {
+		got := IsPrerelease(tc.tag)
+		if got != tc.want {
+			t.Errorf("IsPrerelease(%q) = %v, want %v", tc.tag, got, tc.want)
+		}
+	}
+}

--- a/internal/update/updater.go
+++ b/internal/update/updater.go
@@ -1,0 +1,297 @@
+// Package update polls GitHub releases for newer faultline versions,
+// downloads and verifies new release binaries, atomically swaps them
+// into place, and signals the agent loop to shut down so the new
+// binary takes effect.
+//
+// All decisions are baked into the code -- the LLM does not drive
+// updates. The agent's update_check / update_apply tools just kick
+// off the same code path the polling goroutine runs.
+package update
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/matjam/faultline/internal/version"
+)
+
+// Memory is the subset of the agent's memory store the updater uses.
+// *fs.Store satisfies it. Defined here so the updater package doesn't
+// import the memory adapter.
+type Memory interface {
+	Append(path, content string) error
+}
+
+// Result describes the outcome of a successful apply. The agent loop
+// receives a pointer to this through its shutdown channel, and main
+// uses it to decide what to do post-shutdown (exit / self-exec /
+// command).
+type Result struct {
+	FromVersion string
+	ToVersion   string
+	BinaryPath  string // absolute path of the now-installed new binary
+	AppliedAt   time.Time
+}
+
+// State is a snapshot of the updater's view of the world. Returned by
+// Check and State() for the update_check tool.
+type State struct {
+	LastChecked     time.Time
+	CurrentVersion  string
+	LatestVersion   string // empty if no eligible release found
+	UpdateAvailable bool
+	Note            string // human-readable; empty unless something noteworthy happened
+	Err             error  // non-nil when the last check failed
+}
+
+// Config bundles the runtime knobs. Mirrors config.UpdateConfig but
+// uses concrete time.Duration so the update package doesn't import the
+// config package.
+type Config struct {
+	Enabled         bool
+	CheckInterval   time.Duration
+	GitHubRepo      string
+	AllowPrerelease bool
+	BinaryPath      string
+	// RestartMode and RestartCommand are read by main.go after Result
+	// returns; the updater itself doesn't run them.
+}
+
+// TriggerShutdown is the callback main.go provides so the updater can
+// initiate graceful shutdown. The Result tells main which restart mode
+// to dispatch to. nil means "shut down without an update reason"
+// (used for signal-driven shutdown elsewhere; updater never passes
+// nil).
+type TriggerShutdown func(*Result)
+
+// Updater orchestrates polling and applies. Constructed once in main,
+// shared with tools via its public Check/Apply methods.
+type Updater struct {
+	cfg     Config
+	logger  *slog.Logger
+	memory  Memory
+	gh      *githubClient
+	trigger TriggerShutdown
+
+	// state is the most recent Check result. atomic.Pointer so
+	// State() and Check() callers don't need a lock.
+	state atomic.Pointer[State]
+
+	// mu serializes apply attempts. Polling and operator-triggered
+	// applies funnel through here so two updates can't race.
+	mu sync.Mutex
+
+	// applied is set once an apply has succeeded. After this point
+	// further apply attempts no-op until restart, because the binary
+	// has already been swapped and we're about to shut down.
+	applied atomic.Bool
+}
+
+// New constructs an Updater. cfg.Enabled = false is allowed; tools
+// querying State() still work, but Run, Check, and Apply are no-ops.
+func New(cfg Config, memory Memory, trigger TriggerShutdown, logger *slog.Logger) *Updater {
+	return &Updater{
+		cfg:     cfg,
+		logger:  logger,
+		memory:  memory,
+		gh:      newGitHubClient(cfg.GitHubRepo),
+		trigger: trigger,
+	}
+}
+
+// Enabled reports whether the updater will do work. Tools use this to
+// decide whether to advertise update_check / update_apply.
+func (u *Updater) Enabled() bool { return u.cfg.Enabled }
+
+// CurrentVersion returns the version baked into this binary at build
+// time. Convenience wrapper for the get_version tool.
+func (u *Updater) CurrentVersion() string { return u.currentVersion() }
+
+func (u *Updater) currentVersion() string { return version.Version }
+
+// State returns the last cached check result without doing I/O.
+// Returns a zero State (with empty version fields) if no check has
+// run yet.
+func (u *Updater) State() State {
+	if s := u.state.Load(); s != nil {
+		return *s
+	}
+	return State{CurrentVersion: u.currentVersion()}
+}
+
+// Run starts the polling loop. Blocks until ctx is canceled. Safe to
+// call when Enabled() is false; returns immediately in that case.
+func (u *Updater) Run(ctx context.Context) {
+	if !u.cfg.Enabled {
+		u.logger.Info("updater disabled, skipping poll loop")
+		return
+	}
+	u.logger.Info("updater started",
+		"repo", u.cfg.GitHubRepo,
+		"interval", u.cfg.CheckInterval,
+		"current_version", u.currentVersion(),
+	)
+
+	// First check happens after a short delay rather than immediately,
+	// to avoid hammering GitHub in tight start/restart loops.
+	timer := time.NewTimer(30 * time.Second)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			if u.applied.Load() {
+				return // an apply already triggered shutdown; stop polling
+			}
+			// Errors here are already logged inside checkAndMaybeApply
+			// via u.logger; the polling loop just retries on the next
+			// tick.
+			_, _ = u.checkAndMaybeApply(ctx, false)
+			timer.Reset(u.cfg.CheckInterval)
+		}
+	}
+}
+
+// Check forces an immediate poll of GitHub releases without applying
+// anything. Used by the update_check tool. Updates State() with the
+// result.
+func (u *Updater) Check(ctx context.Context) State {
+	if !u.cfg.Enabled {
+		return State{
+			CurrentVersion: u.currentVersion(),
+			Note:           "updater disabled in config",
+		}
+	}
+	return u.check(ctx)
+}
+
+// Apply forces an immediate apply attempt. Used by the update_apply
+// tool. Returns the Result on success; an error on failure or when
+// no update is available.
+func (u *Updater) Apply(ctx context.Context) (*Result, error) {
+	if !u.cfg.Enabled {
+		return nil, errors.New("updater is disabled in config")
+	}
+	if u.applied.Load() {
+		return nil, errors.New("an update was already applied this session; agent is shutting down")
+	}
+	return u.checkAndMaybeApply(ctx, true)
+}
+
+// check performs the GitHub fetch and updates u.state. Returns the
+// State that was stored.
+func (u *Updater) check(ctx context.Context) State {
+	now := time.Now()
+	rel, err := u.gh.Latest(ctx, u.cfg.AllowPrerelease)
+	s := State{
+		LastChecked:    now,
+		CurrentVersion: u.currentVersion(),
+	}
+	if err != nil {
+		s.Err = err
+		s.Note = fmt.Sprintf("check failed: %s", err)
+		u.logger.Warn("update check failed", "error", err)
+		u.state.Store(&s)
+		return s
+	}
+	if rel == nil {
+		s.Note = "no eligible release available"
+		u.state.Store(&s)
+		return s
+	}
+	s.LatestVersion = rel.TagName
+	s.UpdateAvailable = IsNewer(rel.TagName, u.currentVersion())
+	if s.UpdateAvailable {
+		s.Note = fmt.Sprintf("update available: %s", rel.TagName)
+	} else {
+		s.Note = "up to date"
+	}
+	u.state.Store(&s)
+	return s
+}
+
+// checkAndMaybeApply runs a check and, if force=true OR a newer
+// version is available during a scheduled poll, runs apply. Returns
+// the apply Result when it ran; returns (nil, nil) for a check that
+// did not need to apply; returns (nil, err) on apply failure.
+func (u *Updater) checkAndMaybeApply(ctx context.Context, force bool) (*Result, error) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	if u.applied.Load() {
+		return nil, errors.New("update already applied; pending restart")
+	}
+
+	state := u.check(ctx)
+	if state.Err != nil {
+		return nil, state.Err
+	}
+	if !state.UpdateAvailable && !force {
+		return nil, nil
+	}
+	if !state.UpdateAvailable && force {
+		return nil, fmt.Errorf("no update available (current: %s, latest: %s)",
+			state.CurrentVersion, state.LatestVersion)
+	}
+
+	// Re-fetch the full release for asset URLs. Latest() already gave
+	// us one, but we need a Release pointer in scope for apply().
+	rel, err := u.gh.Latest(ctx, u.cfg.AllowPrerelease)
+	if err != nil {
+		return nil, fmt.Errorf("re-fetch release for apply: %w", err)
+	}
+	if rel == nil {
+		return nil, errors.New("release disappeared between check and apply")
+	}
+
+	u.logger.Info("applying update",
+		"from", state.CurrentVersion,
+		"to", rel.TagName,
+		"asset", AssetName(rel.TagName))
+
+	res, err := u.apply(ctx, rel)
+	if err != nil {
+		u.logger.Error("update apply failed", "error", err)
+		return nil, err
+	}
+	res.AppliedAt = time.Now()
+
+	u.recordHistory(res)
+	u.applied.Store(true)
+
+	u.logger.Info("update applied; signaling shutdown",
+		"from", res.FromVersion,
+		"to", res.ToVersion)
+	if u.trigger != nil {
+		u.trigger(res)
+	}
+	return res, nil
+}
+
+// recordHistory appends a one-paragraph entry to meta/version-history.md
+// in the memory store so the agent (post-restart) can discover that
+// it just updated. Best-effort; log on failure but don't roll back the
+// update for it.
+func (u *Updater) recordHistory(res *Result) {
+	if u.memory == nil {
+		return
+	}
+	entry := fmt.Sprintf(`
+## %s -> %s (%s)
+
+- Applied: %s
+- Binary: %s
+`, res.FromVersion, res.ToVersion, res.AppliedAt.UTC().Format(time.RFC3339),
+		res.AppliedAt.UTC().Format(time.RFC1123),
+		res.BinaryPath)
+	if err := u.memory.Append("meta/version-history.md", entry); err != nil {
+		u.logger.Warn("could not append to version-history.md", "error", err)
+	}
+}


### PR DESCRIPTION
Third (and final) PR of the auto-deploy plan. With #6, #7, and #12 already landed, releases are cut automatically by `release-please` and goreleaser publishes binaries on every tag. This PR adds the agent-side half: a background goroutine that polls those releases and orchestrates self-update.

The LLM does not decide whether to update. The agent has `update_check` / `update_apply` tools that just kick off the same code path the polling goroutine runs.

## `internal/update/`

| File | What it does |
|------|--------------|
| `semver.go` | `IsNewer` / `IsPrerelease` wrappers around `golang.org/x/mod/semver`. Non-semver "current" (e.g. `dev` from a local build) is treated as oldest, so dev builds upgrade to real releases when self-update is enabled. |
| `asset.go` | `AssetName(version)` builds the goreleaser-produced archive name for the running platform. `amd64` is rewritten to `x86_64` to match the goreleaser convention. |
| `github.go` | Tiny client for `GET /repos/<repo>/releases/latest` + asset downloads. Filters drafts and (by default) prereleases. 404 returns `(nil, nil)` so a misconfigured repo doesn't crash the polling loop. |
| `apply.go` | Download → verify SHA256 → extract inner binary → atomic swap. One-deep rollback via `<binary>.previous`. On rename failure after the rotate step, restores `.previous` to current so the deploy keeps running on the old binary. |
| `updater.go` | `Updater` with `Run` (polling loop, first check 30s after start, then every `cfg.CheckInterval`), `Check` (force on-demand poll), `Apply` (force apply attempt). Mutex-serialized; `applied` atomic flag prevents repeat applies in a session. |

## Restart modes

```toml
[update]
restart_mode = "exit"   # default
```

| Mode | Behavior | Use case |
|------|----------|----------|
| `exit` | Save state and `os.Exit(0)`; supervisor respawns the unit. | systemd, Docker, Kubernetes, runit, supervisord — anything with `Restart=always`. |
| `self-exec` | Save state and `syscall.Exec` the new binary, replacing the current process image. Same PID. | Bare-process runs (tmux, screen, manual `./faultline`). |
| `command` | Save state, run a configured command detached, exit. | Custom orchestrators. |

## Tools

| Name | Description | Always advertised? |
|------|-------------|--------------------|
| `get_version` | One-line version + commit + build time | Yes |
| `update_check` | Poll GitHub releases without applying | Only when `[update].enabled = true` |
| `update_apply` | Run the full pipeline + trigger shutdown | Only when `[update].enabled = true` |

## Config

```toml
[update]
enabled          = false              # opt in
check_interval   = "1h"
github_repo      = "matjam/faultline"
restart_mode     = "exit"             # exit | self-exec | command
restart_command  = ""                 # only for restart_mode = "command"
allow_prerelease = false
binary_path      = ""                 # default: os.Executable()
```

`config.example.toml` has the heavily-commented version.

## Side effects

- **`meta/version-history.md`** — appended on every successful update so the agent (post-restart) can discover that it just updated. Best-effort; failure is logged but doesn't roll back the apply.
- **System prompt** — `internal/prompts/templates/system.md` advertises the three new tools.
- **README + AGENTS.md** — Self-update feature section in README; `internal/update/` package description in AGENTS.md.

## Tests

- `IsNewer` / `IsPrerelease` semver compare, including `dev` fallback and prerelease ordering.
- Asset name generation per-arch (with the amd64 → x86_64 rewrite).
- GitHub API: draft filtering, prerelease filtering, prerelease allow-list, 404 returning nil.
- `extractBinary`: tarball produces correct content; missing binary returns clear error.
- `fetchExpectedSum`: parses goreleaser's SHA256SUMS format; rejects unlisted assets.
- `fileSha256`: matches `crypto/sha256` directly.

End-to-end testing against the real `v1.0.0` release happens on the deployment box once this lands.

## Verified locally

```
$ go build -o /tmp/faultline ./cmd/faultline && /tmp/faultline -version
dev (1739d61)
```

Build, vet, lint, and test all green across all packages.
