### PR TITLE
feat: add semantic memory search with persisted vector index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
-faultline
+# Built binary at repo root. Anchored with leading slash so the rule
+# doesn't also swallow the cmd/faultline/ source directory or any
+# future "faultline" file/directory deeper in the tree.
+/faultline

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,14 +25,18 @@ faultline/
       templates/              the embedded *.md defaults
     tools/                    tool registry & dispatcher
       executor.go             Executor + all tool handlers
+      vector.go               Embedder interface + per-mutation reindex helpers
       wiki.go                 wiki_fetch tool
       html_test.go            HTML-to-markdown converter tests
     search/bm25/              pure-Go BM25 search index
+    search/vector/            pure-Go in-memory vector index + binary
+                              serialization (FVEC v1) for semantic search
     llm/                      shared LLM types (Message, Tool, ChatRequest, ...)
                               + heuristic token estimator
     adapters/
       llm/openai/             OpenAI-compatible HTTP client + ChatLogger
       llm/kobold/             KoboldCpp extras (tokencount, abort, perf)
+      embeddings/openai/      OpenAI-compatible /v1/embeddings client
       memory/fs/              filesystem-backed Memory adapter
       operator/telegram/      Telegram bot for collaborator messaging
       sandbox/docker/         Docker-based Python sandbox
@@ -79,8 +83,10 @@ cmd/faultline/main.go
         +-> Tool dispatch (delegated to tools.Executor):
         |     +-> web_fetch        (HTTP + HTML-to-markdown + TTL cache)
         |     +-> wiki_fetch       (MediaWiki API + cache)
-        |     +-> memory_*         (fs.Store)
-        |     +-> memory_search    (bm25.Index)
+        |     +-> memory_*         (fs.Store; mutations also re-embed
+        |                            into vector.Index when enabled)
+        |     +-> memory_search    (bm25.Index, plus vector.Index when
+        |                            embeddings configured: dual sections)
         |     +-> send_message     (operator port: telegram.Bot)
         |     +-> sandbox_*        (docker.Sandbox)
         |     +-> email_fetch      (short-lived imap.Client per call)
@@ -149,6 +155,7 @@ The hexagon. Pure domain logic with no I/O outside what the ports allow.
 `tools.Executor` and all tool handlers. The largest package by line count.
 
 - **`executor.go`**: `Executor` struct, `New()` constructor, `ToolDefs()` (tool registry advertised to the LLM), `Execute()` central dispatch, web fetching with custom HTML-to-markdown converter (~400 lines), `webCache` with TTL eviction, all `memory_*` / `sandbox_*` / utility (`get_time`, `sleep`, `send_message`, `context_status`) handlers.
+- **`vector.go`**: `Embedder` interface (consumer-side; defined here rather than in `agent/ports.go` because the agent loop never embeds), per-mutation reindex helpers (`reindexVector`, `removeVector`, `removeVectorPrefix`, `renameVector`, `reindexVectorDir`), path-exclusion logic (skip `prompts/` and `.trash/`), `truncateForEmbedding` cap, dual-mode `memory_search` description selector. The mutation hooks called from `executor.go` are no-ops when the feature is disabled, so the dispatcher code is identical regardless of operator config.
 - **`wiki.go`**: `wiki_fetch` tool (MediaWiki API + plain-text extraction + cache).
 - **`html_test.go`**: HTML-to-markdown conversion tests.
 
@@ -159,6 +166,26 @@ The Executor depends on adapter packages directly (memory/fs, sandbox/docker, op
 Pure-Go BM25 search index. `bm25.Index` (with `Build`, `Update`, `Remove`, `RemovePrefix`, `Search`) and `bm25.Result` (path/content/score). Standard k1=1.5, b=0.75. In-memory only -- rebuilt from disk on startup and after each context compaction.
 
 `bm25.Result` is also reused by the memory adapter for non-scored returns (RecentFiles, AllFiles); Score is left at zero in those cases. This is a small shared type, not a violation of the dependency direction (memory imports bm25, never the reverse).
+
+### internal/search/vector/
+
+Pure-Go in-memory vector index keyed by string paths. `vector.Index` provides `Upsert`, `Remove`, `RemovePrefix`, `Rename`, `Search`, plus `Save`/`Load` against a custom binary format ("FVEC v1") so embeddings persist across restarts.
+
+- Brute-force cosine similarity over a `map[string][]float32`. At Faultline's scale (low-thousands of files, 1536-dim vectors) flat scan is sub-millisecond; HNSW/IVF was ruled out as overkill.
+- Vectors are L2-normalised on Upsert so Search can use plain dot products.
+- Binary format: `magic[4]="FVEC" | version[4] | dim[4] | count[4] | model_len[2] | model[N] | records[count]{path_len[2], path[N], vec[dim*4]}`. Deterministic ordering (paths sorted on save) for byte-stable diffs in tests.
+- `ErrModelMismatch` returned by `Load` when the on-disk dim or model differs from what the in-memory index was constructed for; caller is expected to `Reset` and re-embed.
+- `ErrCorrupt` returned for unreadable / wrong-magic / inconsistent files; caller is expected to rename the file aside (mirroring the `state/jsonfile` pattern) and continue with an empty index.
+- `Dirty()` is an atomic the persistence loop polls; cleared by `Save`.
+
+### internal/adapters/embeddings/openai/
+
+`openai.Client` is a hand-rolled HTTP client for `/v1/embeddings`. Deliberately separate from `internal/adapters/llm/openai/` even though both target OpenAI-compatible servers — different endpoint, different request/response shape, different failure modes.
+
+- `New(url, apiKey, model, timeout, logger)` constructs the client; `Probe(ctx)` sends a single-input embed call to discover the model's dim. `Dim()` returns 0 until probe succeeds.
+- `Embed(ctx, []string)` returns one vector per input in input order. Defensive `sort.Slice` on `index` field of the response so order is preserved even with non-OpenAI servers that return out of order.
+- Per-call timeout is applied via a child context derived from the caller's `ctx`, not from `http.Client.Timeout`, so callers can use a long ambient context for batch operations and still bound individual calls.
+- Probe failure is **not** fatal at startup; main.go logs the error loudly and continues with semantic search disabled. The agent runs fine without it.
 
 ### internal/llm/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,9 @@ cmd/faultline/main.go
         |     +-> context_status   (token usage + kobold.Client.Perf if detected)
         |     +-> get_time         (current timestamp)
         |     +-> sleep            (suspend N seconds, interrupted by operator messages)
+        |     +-> rebuild_indexes  (force full rebuild of bm25 and/or vector index;
+        |                            shared helper in tools/vector.go also drives
+        |                            startup reconcile from main.go)
         |
         +-> Graceful shutdown (on first SIGINT)
               +-> Inject shutdown prompt
@@ -163,7 +166,13 @@ The Executor depends on adapter packages directly (memory/fs, sandbox/docker, op
 
 ### internal/search/bm25/
 
-Pure-Go BM25 search index. `bm25.Index` (with `Build`, `Update`, `Remove`, `RemovePrefix`, `Search`) and `bm25.Result` (path/content/score). Standard k1=1.5, b=0.75. In-memory only -- rebuilt from disk on startup and after each context compaction.
+Pure-Go BM25 search index. `bm25.Index` (with `Build`, `Update`, `Remove`, `RemovePrefix`, `Search`) and `bm25.Result` (path/content/score). Standard k1=1.5, b=0.75. In-memory only.
+
+Lifecycle:
+- **Built from disk on startup** in `agent.initializeContext` via `Build(memory.AllFiles())`.
+- **Rebuilt after every context compaction** in `agent.rebuildContext` (same `Build` call) — guards against drift accumulating across long-running sessions.
+- **Updated incrementally on every memory mutation** (`memory_write`, `memory_edit`, `memory_append`, `memory_insert`, `memory_delete`, `memory_move`, `memory_restore`) by the tool dispatcher. The index is always in sync with on-disk memory between rebuilds.
+- **Force-rebuildable on demand** via the `rebuild_indexes` tool, which the LLM is told to use only when the operator asks or when it observes inconsistency between search results and known disk state.
 
 `bm25.Result` is also reused by the memory adapter for non-scored returns (RecentFiles, AllFiles); Score is left at zero in those cases. This is a small shared type, not a violation of the dependency direction (memory imports bm25, never the reverse).
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ When `[email]` is configured, the agent gets an `email_fetch` tool that opens a 
 |----------|-------|
 | **Internet** | `web_fetch`, `wiki_fetch` |
 | **Memory** | `memory_read`, `memory_write`, `memory_edit`, `memory_append`, `memory_insert`, `memory_delete`, `memory_move`, `memory_restore`, `memory_list`, `memory_list_trash`, `memory_empty_trash`, `memory_search` (BM25 + semantic when `[embeddings]` enabled), `memory_grep` |
-| **System** | `context_status`, `get_time`, `sleep`, `send_message`, `get_version` |
+| **System** | `context_status`, `get_time`, `sleep`, `send_message`, `get_version`, `rebuild_indexes` |
 | **Self-update** (when enabled) | `update_check`, `update_apply` |
 | **Sandbox** (when enabled) | `sandbox_write`, `sandbox_read`, `sandbox_edit`, `sandbox_append`, `sandbox_insert`, `sandbox_delete`, `sandbox_rename`, `sandbox_list`, `sandbox_execute`, `sandbox_shell`, `sandbox_install_package`, `sandbox_upgrade_package`, `sandbox_remove_package`, `sandbox_list_packages` |
 | **Email** (when configured) | `email_fetch` |

--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ The agent stores knowledge as markdown files in a configurable directory. All fi
 
 An in-memory BM25 search index is built from all memory files on startup and rebuilt during context compaction. The agent uses this to find relevant memories by keyword.
 
+### Semantic Search (optional)
+
+When `[embeddings]` is configured with an OpenAI-compatible endpoint and model, Faultline also embeds every memory file (excluding `prompts/` and `.trash/`) into an in-memory vector index, persisted to `<memory>/.vector/index.bin` in a custom binary format so embeddings aren't recomputed on restart. Memory mutations (write/edit/append/insert/restore) trigger a synchronous re-embed of the affected file. Failures are logged but never block the write — the vector index is best-effort enrichment, not source of truth.
+
+The `memory_search` tool then returns BOTH lexical (BM25) and semantic results in clearly labeled sections per query, so the LLM can pick whichever is more relevant. When embeddings are disabled, `memory_search` falls back to the original BM25-only output. The default model is `text-embedding-3-small` (1536 dim, ~$0.02/1M tokens — indexing 10k typical memory files is ~$0.10 one-time).
+
+If you change the embedding model, the on-disk index records the prior model name and is automatically discarded and rebuilt on next startup.
+
 ### Web Browsing
 
 The agent can fetch web pages, which are converted from HTML to readable markdown text. Results are cached with a TTL to avoid redundant fetches. Long pages can be paginated with offset/length parameters.
@@ -161,7 +169,7 @@ When `[email]` is configured, the agent gets an `email_fetch` tool that opens a 
 | Category | Tools |
 |----------|-------|
 | **Internet** | `web_fetch`, `wiki_fetch` |
-| **Memory** | `memory_read`, `memory_write`, `memory_edit`, `memory_append`, `memory_insert`, `memory_delete`, `memory_move`, `memory_restore`, `memory_list`, `memory_list_trash`, `memory_empty_trash`, `memory_search`, `memory_grep` |
+| **Memory** | `memory_read`, `memory_write`, `memory_edit`, `memory_append`, `memory_insert`, `memory_delete`, `memory_move`, `memory_restore`, `memory_list`, `memory_list_trash`, `memory_empty_trash`, `memory_search` (BM25 + semantic when `[embeddings]` enabled), `memory_grep` |
 | **System** | `context_status`, `get_time`, `sleep`, `send_message`, `get_version` |
 | **Self-update** (when enabled) | `update_check`, `update_apply` |
 | **Sandbox** (when enabled) | `sandbox_write`, `sandbox_read`, `sandbox_edit`, `sandbox_append`, `sandbox_insert`, `sandbox_delete`, `sandbox_rename`, `sandbox_list`, `sandbox_execute`, `sandbox_shell`, `sandbox_install_package`, `sandbox_upgrade_package`, `sandbox_remove_package`, `sandbox_list_packages` |

--- a/cmd/faultline/embeddings.go
+++ b/cmd/faultline/embeddings.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	openaiembed "github.com/matjam/faultline/internal/adapters/embeddings/openai"
+	"github.com/matjam/faultline/internal/adapters/memory/fs"
+	"github.com/matjam/faultline/internal/config"
+	"github.com/matjam/faultline/internal/search/vector"
+	"github.com/matjam/faultline/internal/tools"
+)
+
+// vectorPersistInterval is how often the persistence loop checks the
+// dirty flag and flushes if set. Bounded data-loss window between
+// crashes. Tuned long enough that bulk ingests don't churn the disk
+// but short enough to avoid losing significant work.
+const vectorPersistInterval = 30 * time.Second
+
+// vectorIndexPath returns the on-disk location of the persisted vector
+// index for a given memory root.
+func vectorIndexPath(memoryDir string) string {
+	return filepath.Join(memoryDir, ".vector", "index.bin")
+}
+
+// setupEmbeddings constructs and probes the embeddings client, then
+// builds an in-memory vector index, loads any prior on-disk state, and
+// runs a startup reconcile pass that embeds any memory file lacking a
+// vector. On any failure beyond the probe, returns nil/nil — the
+// agent runs with semantic search disabled rather than failing to
+// start over an optional feature.
+func setupEmbeddings(ctx context.Context, cfg *config.Config, memory *fs.Store, logger *slog.Logger) (tools.Embedder, *vector.Index) {
+	logger.Info("embeddings: setup starting",
+		slog.String("url", cfg.Embeddings.URL),
+		slog.String("model", cfg.Embeddings.Model))
+
+	client := openaiembed.New(
+		cfg.Embeddings.URL,
+		cfg.Embeddings.APIKey,
+		cfg.Embeddings.Model,
+		cfg.Embeddings.Timeout.Duration(),
+		logger,
+	)
+
+	probeCtx, cancel := context.WithTimeout(ctx, cfg.Embeddings.Timeout.Duration()+5*time.Second)
+	defer cancel()
+	if err := client.Probe(probeCtx); err != nil {
+		logger.Warn("embeddings: probe failed; semantic search disabled for this session",
+			slog.String("err", err.Error()))
+		return nil, nil
+	}
+
+	dim := client.Dim()
+	idx := vector.New(dim, cfg.Embeddings.Model)
+
+	indexPath := vectorIndexPath(cfg.Agent.MemoryDir)
+	if err := idx.Load(indexPath); err != nil {
+		switch {
+		case errors.Is(err, vector.ErrModelMismatch):
+			logger.Info("embeddings: on-disk index has different model/dim; rebuilding from scratch",
+				slog.String("path", indexPath))
+			idx.Reset(dim, cfg.Embeddings.Model)
+		case errors.Is(err, vector.ErrCorrupt):
+			// Move aside and continue with a fresh index, mirroring
+			// the pattern used by jsonfile state.
+			bad := fmt.Sprintf("%s.bad-%d", indexPath, time.Now().Unix())
+			logger.Warn("embeddings: on-disk index corrupt; renaming aside and rebuilding",
+				slog.String("path", indexPath),
+				slog.String("moved_to", bad),
+				slog.String("err", err.Error()))
+			_ = os.Rename(indexPath, bad)
+			idx.Reset(dim, cfg.Embeddings.Model)
+		default:
+			logger.Warn("embeddings: load failed; rebuilding from scratch",
+				slog.String("err", err.Error()))
+			idx.Reset(dim, cfg.Embeddings.Model)
+		}
+	} else {
+		logger.Info("embeddings: loaded on-disk index",
+			slog.Int("vectors", idx.Len()),
+			slog.Int("dim", dim))
+	}
+
+	// Reconcile: embed any memory file that's not in the index.
+	// Skipped for files in operational paths (prompts/, .trash/).
+	if err := reconcileVectorIndex(ctx, client, idx, memory, cfg.Embeddings.BatchSize, logger); err != nil {
+		logger.Warn("embeddings: reconcile incomplete; continuing with partial index",
+			slog.String("err", err.Error()))
+	}
+
+	return client, idx
+}
+
+// reconcileVectorIndex finds memory files lacking a vector and embeds
+// them in batches. Files larger than the per-input cap are truncated
+// (see tools/vector.go for the cap). Empty files are skipped.
+//
+// Returns the first error encountered; partial progress is preserved
+// in the index either way.
+func reconcileVectorIndex(ctx context.Context, embedder tools.Embedder, idx *vector.Index, memory *fs.Store, batchSize int, logger *slog.Logger) error {
+	all, err := memory.AllFiles()
+	if err != nil {
+		return fmt.Errorf("list memory files: %w", err)
+	}
+
+	type pending struct {
+		path string
+		text string
+	}
+	var queue []pending
+
+	for path, content := range all {
+		if !shouldReconcile(path) {
+			continue
+		}
+		if idx.Has(path) {
+			continue
+		}
+		text := strings.TrimSpace(content)
+		if text == "" {
+			continue
+		}
+		// Mirror the cap applied by tool-side reindex so reconciled
+		// vectors are produced from the same prefix of content.
+		if len(text) > 30000 {
+			text = text[:30000]
+		}
+		queue = append(queue, pending{path: path, text: text})
+	}
+
+	if len(queue) == 0 {
+		logger.Info("embeddings: index is up to date, nothing to reconcile")
+		return nil
+	}
+
+	logger.Info("embeddings: reconcile pass embedding missing files",
+		slog.Int("count", len(queue)),
+		slog.Int("batch_size", batchSize))
+
+	if batchSize <= 0 {
+		batchSize = 100
+	}
+
+	embedded := 0
+	for i := 0; i < len(queue); i += batchSize {
+		end := i + batchSize
+		if end > len(queue) {
+			end = len(queue)
+		}
+		batch := queue[i:end]
+
+		texts := make([]string, len(batch))
+		for j, p := range batch {
+			texts[j] = p.text
+		}
+
+		// Each batch gets a fresh context derived from ctx so a
+		// hung server can't stall reconcile indefinitely.
+		batchCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+		vecs, err := embedder.Embed(batchCtx, texts)
+		cancel()
+		if err != nil {
+			return fmt.Errorf("embed batch starting at %d: %w", i, err)
+		}
+		if len(vecs) != len(batch) {
+			return fmt.Errorf("embed batch starting at %d: got %d vecs for %d inputs", i, len(vecs), len(batch))
+		}
+		for j, p := range batch {
+			if err := idx.Upsert(p.path, vecs[j]); err != nil {
+				logger.Warn("embeddings: reconcile upsert failed; continuing",
+					slog.String("path", p.path),
+					slog.String("err", err.Error()))
+				continue
+			}
+			embedded++
+		}
+
+		// Bail out early on cancellation (graceful shutdown) so we
+		// don't keep hammering the API for files the operator no
+		// longer cares about.
+		select {
+		case <-ctx.Done():
+			logger.Info("embeddings: reconcile canceled mid-pass",
+				slog.Int("embedded", embedded),
+				slog.Int("total", len(queue)))
+			return ctx.Err()
+		default:
+		}
+	}
+
+	logger.Info("embeddings: reconcile complete",
+		slog.Int("embedded", embedded),
+		slog.Int("total", len(queue)))
+	return nil
+}
+
+// shouldReconcile mirrors tools.shouldIndexPath. Duplicated here
+// because main can't import tools internals; keep the two predicates
+// in sync if either is updated.
+func shouldReconcile(path string) bool {
+	if path == "" {
+		return false
+	}
+	if strings.HasPrefix(path, "prompts/") || path == "prompts" {
+		return false
+	}
+	if fs.IsTrashPath(path) {
+		return false
+	}
+	return true
+}
+
+// runVectorPersistence flushes the index to disk every
+// vectorPersistInterval if it has been mutated since the last flush.
+// Exits cleanly when ctx is canceled (shutdown).
+func runVectorPersistence(ctx context.Context, idx *vector.Index, path string, logger *slog.Logger) {
+	t := time.NewTicker(vectorPersistInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if !idx.Dirty() {
+				continue
+			}
+			if err := idx.Save(path); err != nil {
+				logger.Warn("embeddings: periodic save failed",
+					slog.String("err", err.Error()))
+				continue
+			}
+			logger.Debug("embeddings: index flushed",
+				slog.Int("vectors", idx.Len()),
+				slog.String("path", path))
+		}
+	}
+}
+
+// flushVectorIndex performs a final synchronous flush at shutdown.
+// Called from main.go via defer so the very latest mutations survive
+// a clean exit.
+func flushVectorIndex(idx *vector.Index, path string, logger *slog.Logger) {
+	if !idx.Dirty() {
+		return
+	}
+	if err := idx.Save(path); err != nil {
+		logger.Warn("embeddings: shutdown save failed",
+			slog.String("err", err.Error()))
+		return
+	}
+	logger.Info("embeddings: index flushed at shutdown",
+		slog.Int("vectors", idx.Len()),
+		slog.String("path", path))
+}

--- a/cmd/faultline/embeddings.go
+++ b/cmd/faultline/embeddings.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	openaiembed "github.com/matjam/faultline/internal/adapters/embeddings/openai"
@@ -89,131 +88,14 @@ func setupEmbeddings(ctx context.Context, cfg *config.Config, memory *fs.Store, 
 
 	// Reconcile: embed any memory file that's not in the index.
 	// Skipped for files in operational paths (prompts/, .trash/).
-	if err := reconcileVectorIndex(ctx, client, idx, memory, cfg.Embeddings.BatchSize, logger); err != nil {
+	// The shared helper in internal/tools is also used by the
+	// rebuild_indexes tool with full-rebuild semantics.
+	if _, err := tools.ReconcileVectorIndex(ctx, client, idx, memory, cfg.Embeddings.BatchSize, logger); err != nil {
 		logger.Warn("embeddings: reconcile incomplete; continuing with partial index",
 			slog.String("err", err.Error()))
 	}
 
 	return client, idx
-}
-
-// reconcileVectorIndex finds memory files lacking a vector and embeds
-// them in batches. Files larger than the per-input cap are truncated
-// (see tools/vector.go for the cap). Empty files are skipped.
-//
-// Returns the first error encountered; partial progress is preserved
-// in the index either way.
-func reconcileVectorIndex(ctx context.Context, embedder tools.Embedder, idx *vector.Index, memory *fs.Store, batchSize int, logger *slog.Logger) error {
-	all, err := memory.AllFiles()
-	if err != nil {
-		return fmt.Errorf("list memory files: %w", err)
-	}
-
-	type pending struct {
-		path string
-		text string
-	}
-	var queue []pending
-
-	for path, content := range all {
-		if !shouldReconcile(path) {
-			continue
-		}
-		if idx.Has(path) {
-			continue
-		}
-		text := strings.TrimSpace(content)
-		if text == "" {
-			continue
-		}
-		// Mirror the cap applied by tool-side reindex so reconciled
-		// vectors are produced from the same prefix of content.
-		if len(text) > 30000 {
-			text = text[:30000]
-		}
-		queue = append(queue, pending{path: path, text: text})
-	}
-
-	if len(queue) == 0 {
-		logger.Info("embeddings: index is up to date, nothing to reconcile")
-		return nil
-	}
-
-	logger.Info("embeddings: reconcile pass embedding missing files",
-		slog.Int("count", len(queue)),
-		slog.Int("batch_size", batchSize))
-
-	if batchSize <= 0 {
-		batchSize = 100
-	}
-
-	embedded := 0
-	for i := 0; i < len(queue); i += batchSize {
-		end := i + batchSize
-		if end > len(queue) {
-			end = len(queue)
-		}
-		batch := queue[i:end]
-
-		texts := make([]string, len(batch))
-		for j, p := range batch {
-			texts[j] = p.text
-		}
-
-		// Each batch gets a fresh context derived from ctx so a
-		// hung server can't stall reconcile indefinitely.
-		batchCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
-		vecs, err := embedder.Embed(batchCtx, texts)
-		cancel()
-		if err != nil {
-			return fmt.Errorf("embed batch starting at %d: %w", i, err)
-		}
-		if len(vecs) != len(batch) {
-			return fmt.Errorf("embed batch starting at %d: got %d vecs for %d inputs", i, len(vecs), len(batch))
-		}
-		for j, p := range batch {
-			if err := idx.Upsert(p.path, vecs[j]); err != nil {
-				logger.Warn("embeddings: reconcile upsert failed; continuing",
-					slog.String("path", p.path),
-					slog.String("err", err.Error()))
-				continue
-			}
-			embedded++
-		}
-
-		// Bail out early on cancellation (graceful shutdown) so we
-		// don't keep hammering the API for files the operator no
-		// longer cares about.
-		select {
-		case <-ctx.Done():
-			logger.Info("embeddings: reconcile canceled mid-pass",
-				slog.Int("embedded", embedded),
-				slog.Int("total", len(queue)))
-			return ctx.Err()
-		default:
-		}
-	}
-
-	logger.Info("embeddings: reconcile complete",
-		slog.Int("embedded", embedded),
-		slog.Int("total", len(queue)))
-	return nil
-}
-
-// shouldReconcile mirrors tools.shouldIndexPath. Duplicated here
-// because main can't import tools internals; keep the two predicates
-// in sync if either is updated.
-func shouldReconcile(path string) bool {
-	if path == "" {
-		return false
-	}
-	if strings.HasPrefix(path, "prompts/") || path == "prompts" {
-		return false
-	}
-	if fs.IsTrashPath(path) {
-		return false
-	}
-	return true
 }
 
 // runVectorPersistence flushes the index to disk every

--- a/cmd/faultline/main.go
+++ b/cmd/faultline/main.go
@@ -229,7 +229,8 @@ func main() {
 		defer flushVectorIndex(vIndex, vectorPath, logger)
 	}
 
-	toolExec := tools.New(memory, index, tg, sb, email, kb, updater, embedder, vIndex, logger,
+	toolExec := tools.New(memory, index, tg, sb, email, kb, updater, embedder, vIndex,
+		cfg.Embeddings.BatchSize, logger,
 		cfg.Agent.MaxTokens, cfg.Limits, cfg.Agent.MaxSleep.Duration())
 	defer toolExec.Close()
 

--- a/cmd/faultline/main.go
+++ b/cmd/faultline/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/matjam/faultline/internal/log"
 	"github.com/matjam/faultline/internal/prompts"
 	"github.com/matjam/faultline/internal/search/bm25"
+	"github.com/matjam/faultline/internal/search/vector"
 	"github.com/matjam/faultline/internal/tools"
 	"github.com/matjam/faultline/internal/update"
 	"github.com/matjam/faultline/internal/version"
@@ -211,7 +212,24 @@ func main() {
 	}, memory, closeShutdown, logger)
 	go updater.Run(ctx)
 
-	toolExec := tools.New(memory, index, tg, sb, email, kb, updater, logger,
+	// Embeddings + vector index. Optional; failure on probe disables
+	// the feature for this session but doesn't stop the agent — the
+	// core loop is fully functional with BM25-only search.
+	var embedder tools.Embedder
+	var vIndex *vector.Index
+	if cfg.Embeddings.Active() {
+		embedder, vIndex = setupEmbeddings(ctx, cfg, memory, logger)
+	}
+	if vIndex != nil {
+		// Persistence loop runs for the lifetime of the agent. It
+		// flushes the index when dirty on a 30s tick, plus a final
+		// flush on shutdown via defer below.
+		vectorPath := vectorIndexPath(cfg.Agent.MemoryDir)
+		go runVectorPersistence(ctx, vIndex, vectorPath, logger)
+		defer flushVectorIndex(vIndex, vectorPath, logger)
+	}
+
+	toolExec := tools.New(memory, index, tg, sb, email, kb, updater, embedder, vIndex, logger,
 		cfg.Agent.MaxTokens, cfg.Limits, cfg.Agent.MaxSleep.Duration())
 	defer toolExec.Close()
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -211,3 +211,55 @@ memory_search_result_chars = 6000
 # output should be written to /output/ in the script and read back with
 # sandbox_read.
 sandbox_output_chars = 64000
+
+# ---------------------------------------------------------------------------
+# [embeddings] — semantic search (optional).
+#
+# When enabled, every memory file (except .trash/ and prompts/) is embedded
+# via an OpenAI-compatible /v1/embeddings endpoint and stored in an
+# in-memory vector index that is persisted to <memory_dir>/.vector/index.bin
+# in a custom binary format. memory_search then returns BOTH BM25 (lexical)
+# and semantic results in clearly labeled sections so the LLM can pick
+# whichever is more relevant per query.
+#
+# Memory writes (memory_write / edit / append / insert / restore) trigger a
+# synchronous re-embed of the affected file. Per-mutation latency goes up by
+# ~50–200ms but search is always current. Embed failures are logged but do
+# NOT block the memory write — the vector index is best-effort enrichment,
+# not source of truth.
+#
+# Disabled by default. With OpenAI's text-embedding-3-small at $0.02/1M
+# tokens, indexing 10k typical memory files is roughly $0.10 one-time.
+# ---------------------------------------------------------------------------
+[embeddings]
+# Master toggle. When false, no embeddings client is constructed and
+# memory_search is BM25-only. The other fields below are ignored.
+enabled = false
+
+# OpenAI-compatible API base URL ending in /v1. The adapter appends
+# "/embeddings". Works with OpenAI, Ollama, LM Studio, vLLM, and anything
+# else speaking the same wire shape.
+url = "https://api.openai.com/v1"
+
+# Bearer token. Required for OpenAI; leave empty for local servers that
+# don't authenticate. Treat this as a secret — don't commit a populated
+# config.toml.
+api_key = ""
+
+# Embedding model identifier. text-embedding-3-small is OpenAI's current
+# cost/quality sweet spot (1536 dim, $0.02/1M tokens). text-embedding-3-large
+# (3072 dim, $0.13/1M) is overkill for memory search.
+#
+# If you change this, the on-disk vector index records the old model name
+# and will be discarded + rebuilt automatically on next startup.
+model = "text-embedding-3-small"
+
+# Per-request HTTP timeout. Longer than the chat completion default because
+# batch embedding requests can be larger and the API is occasionally slow.
+timeout = "30s"
+
+# Maximum texts per /v1/embeddings call during the startup reconcile pass
+# and any bulk re-indexing. Per-mutation embeds always send a single text
+# and ignore this. OpenAI accepts up to 2048 inputs per call but smaller
+# batches keep individual failures localized.
+batch_size = 100

--- a/internal/adapters/embeddings/openai/client.go
+++ b/internal/adapters/embeddings/openai/client.go
@@ -1,0 +1,227 @@
+// Package openai is the OpenAI-compatible /v1/embeddings adapter. It
+// implements the embeddings interface used by the tools dispatcher to
+// turn memory text and search queries into dense vectors.
+//
+// Hand-rolled HTTP, no SDK, mirroring internal/adapters/llm/openai/.
+// This package is deliberately separate from the chat-completions
+// adapter even though both target OpenAI-compatible servers — they
+// have different endpoints, different request shapes, different
+// failure modes, and conflating them would muddle the architecture.
+package openai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Client is an OpenAI-compatible embeddings client. Safe for concurrent
+// use; the underlying http.Client is the only mutable shared state.
+type Client struct {
+	apiURL  string // base URL ending in /v1 (no trailing slash)
+	apiKey  string
+	model   string
+	timeout time.Duration
+	http    *http.Client
+	logger  *slog.Logger
+
+	// dim is the vector dimensionality reported by the endpoint. Set
+	// by Probe and immutable thereafter. Guarded by dimMu so Dim() can
+	// be called safely before Probe completes (it returns 0 until set).
+	dimMu sync.RWMutex
+	dim   int
+}
+
+// New constructs an embeddings client. The dim is unknown until Probe is
+// called; until then Dim() returns 0.
+//
+// apiURL must include the version prefix (e.g. "/v1"); "/embeddings" is
+// appended internally. apiKey may be empty for endpoints that don't
+// require auth. model is the embedding model identifier ("text-embedding-3-small",
+// "nomic-embed-text", etc.).
+//
+// timeout is applied per HTTP request (set on the request context, not
+// the http.Client itself, so callers can use a longer ambient context
+// for batch operations and still bound individual calls).
+func New(apiURL, apiKey, model string, timeout time.Duration, logger *slog.Logger) *Client {
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Client{
+		apiURL:  strings.TrimRight(apiURL, "/"),
+		apiKey:  apiKey,
+		model:   model,
+		timeout: timeout,
+		http:    &http.Client{},
+		logger:  logger,
+	}
+}
+
+// Model returns the embedding model identifier this client was
+// constructed with.
+func (c *Client) Model() string { return c.model }
+
+// Dim returns the vector dimensionality, or 0 if Probe has not yet
+// been called successfully.
+func (c *Client) Dim() int {
+	c.dimMu.RLock()
+	defer c.dimMu.RUnlock()
+	return c.dim
+}
+
+// Probe makes a single embedding request to discover the model's
+// vector dimensionality. Must be called once before Dim() returns a
+// useful value.
+//
+// Returns an error if the endpoint is unreachable, the response is
+// malformed, or the response embedding has zero length. Callers should
+// treat probe failure as "embeddings unavailable for this session"
+// (log loudly, disable the feature) rather than fatal — the agent can
+// run without semantic search.
+func (c *Client) Probe(ctx context.Context) error {
+	vecs, err := c.Embed(ctx, []string{"ping"})
+	if err != nil {
+		return fmt.Errorf("embeddings: probe: %w", err)
+	}
+	if len(vecs) != 1 || len(vecs[0]) == 0 {
+		return errors.New("embeddings: probe returned empty vector")
+	}
+	dim := len(vecs[0])
+
+	c.dimMu.Lock()
+	c.dim = dim
+	c.dimMu.Unlock()
+
+	c.logger.Info("embeddings: probe ok",
+		slog.String("model", c.model),
+		slog.Int("dim", dim))
+	return nil
+}
+
+// embedRequest is the wire shape POSTed to /v1/embeddings. encoding_format
+// is set to "float" explicitly even though it's the default — some
+// non-OpenAI servers default to "base64" and we want raw floats.
+type embedRequest struct {
+	Input          []string `json:"input"`
+	Model          string   `json:"model"`
+	EncodingFormat string   `json:"encoding_format,omitempty"`
+}
+
+// embedResponse is the wire shape returned by /v1/embeddings.
+type embedResponse struct {
+	Object string `json:"object"`
+	Data   []struct {
+		Object    string    `json:"object"`
+		Index     int       `json:"index"`
+		Embedding []float32 `json:"embedding"`
+	} `json:"data"`
+	Model string `json:"model"`
+	Usage struct {
+		PromptTokens int `json:"prompt_tokens"`
+		TotalTokens  int `json:"total_tokens"`
+	} `json:"usage"`
+	// Error response shape (some compatible servers).
+	Error *struct {
+		Message string `json:"message"`
+		Type    string `json:"type"`
+		Code    string `json:"code"`
+	} `json:"error,omitempty"`
+}
+
+// Embed returns one vector per input string, in input order.
+//
+// The per-call timeout configured at New() is applied via a context
+// derived from ctx. Caller cancellation propagates as well.
+//
+// Empty input returns an empty result without making a network call.
+func (c *Client) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+
+	body, err := json.Marshal(embedRequest{
+		Input:          texts,
+		Model:          c.model,
+		EncodingFormat: "float",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("embeddings: marshal request: %w", err)
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	url := c.apiURL + "/embeddings"
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("embeddings: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("embeddings: HTTP: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("embeddings: read response: %w", err)
+	}
+
+	if resp.StatusCode/100 != 2 {
+		// Try to surface the server's error message if it sent one in
+		// the standard shape; otherwise return a snippet of the raw
+		// body for diagnosis.
+		var er embedResponse
+		if jerr := json.Unmarshal(respBody, &er); jerr == nil && er.Error != nil && er.Error.Message != "" {
+			return nil, fmt.Errorf("embeddings: HTTP %d: %s", resp.StatusCode, er.Error.Message)
+		}
+		snippet := string(respBody)
+		if len(snippet) > 200 {
+			snippet = snippet[:200] + "..."
+		}
+		return nil, fmt.Errorf("embeddings: HTTP %d: %s", resp.StatusCode, snippet)
+	}
+
+	var er embedResponse
+	if err := json.Unmarshal(respBody, &er); err != nil {
+		return nil, fmt.Errorf("embeddings: decode response: %w", err)
+	}
+	if er.Error != nil && er.Error.Message != "" {
+		// Some servers return 200 with an error body. Treat that as a
+		// failure rather than silently returning empty data.
+		return nil, fmt.Errorf("embeddings: server error: %s", er.Error.Message)
+	}
+	if len(er.Data) != len(texts) {
+		return nil, fmt.Errorf("embeddings: response count mismatch: got %d, want %d", len(er.Data), len(texts))
+	}
+
+	// Defensive: sort by index so ordering matches input even if the
+	// server returns out of order.
+	sort.Slice(er.Data, func(i, j int) bool { return er.Data[i].Index < er.Data[j].Index })
+
+	out := make([][]float32, len(er.Data))
+	for i, d := range er.Data {
+		if len(d.Embedding) == 0 {
+			return nil, fmt.Errorf("embeddings: empty vector at index %d", i)
+		}
+		out[i] = d.Embedding
+	}
+	return out, nil
+}

--- a/internal/adapters/embeddings/openai/client_test.go
+++ b/internal/adapters/embeddings/openai/client_test.go
@@ -1,0 +1,214 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fixedDimServer returns a stub /v1/embeddings server that emits a
+// deterministic vector of the requested dimensionality for each input.
+func fixedDimServer(t *testing.T, dim int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("unexpected method: %s", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/embeddings") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var req embedRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		if req.Model == "" {
+			t.Errorf("expected model in request")
+		}
+
+		resp := embedResponse{Object: "list", Model: req.Model}
+		for i, txt := range req.Input {
+			vec := make([]float32, dim)
+			// Deterministic but distinct: vec[0] depends on the input,
+			// rest is constant. Useful for asserting which input got
+			// which vector.
+			vec[0] = float32(len(txt))
+			resp.Data = append(resp.Data, struct {
+				Object    string    `json:"object"`
+				Index     int       `json:"index"`
+				Embedding []float32 `json:"embedding"`
+			}{Object: "embedding", Index: i, Embedding: vec})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+func TestEmbedSingle(t *testing.T) {
+	srv := fixedDimServer(t, 4)
+	defer srv.Close()
+
+	c := New(srv.URL+"/v1", "", "test-model", time.Second, nil)
+	vecs, err := c.Embed(context.Background(), []string{"hello"})
+	if err != nil {
+		t.Fatalf("embed: %v", err)
+	}
+	if len(vecs) != 1 {
+		t.Fatalf("want 1 vector, got %d", len(vecs))
+	}
+	if len(vecs[0]) != 4 {
+		t.Errorf("dim: want 4 got %d", len(vecs[0]))
+	}
+	if vecs[0][0] != 5 { // len("hello")
+		t.Errorf("vec[0]: want 5 got %f", vecs[0][0])
+	}
+}
+
+func TestEmbedBatch(t *testing.T) {
+	srv := fixedDimServer(t, 3)
+	defer srv.Close()
+
+	c := New(srv.URL+"/v1", "", "m", time.Second, nil)
+	vecs, err := c.Embed(context.Background(), []string{"a", "bb", "ccc"})
+	if err != nil {
+		t.Fatalf("embed: %v", err)
+	}
+	if len(vecs) != 3 {
+		t.Fatalf("want 3 vectors, got %d", len(vecs))
+	}
+	if vecs[0][0] != 1 || vecs[1][0] != 2 || vecs[2][0] != 3 {
+		t.Errorf("ordering broken: vec[0][0]=%v vec[1][0]=%v vec[2][0]=%v",
+			vecs[0][0], vecs[1][0], vecs[2][0])
+	}
+}
+
+func TestEmbedEmptyInput(t *testing.T) {
+	c := New("http://localhost:1", "", "m", time.Second, nil)
+	vecs, err := c.Embed(context.Background(), nil)
+	if err != nil {
+		t.Errorf("empty input should not error, got %v", err)
+	}
+	if vecs != nil {
+		t.Errorf("expected nil result, got %v", vecs)
+	}
+}
+
+func TestEmbedCountMismatch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Always returns one entry regardless of input length.
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","model":"m","data":[{"object":"embedding","index":0,"embedding":[0.1,0.2]}]}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL+"/v1", "", "m", time.Second, nil)
+	_, err := c.Embed(context.Background(), []string{"a", "b"})
+	if err == nil || !strings.Contains(err.Error(), "count mismatch") {
+		t.Errorf("expected count mismatch error, got %v", err)
+	}
+}
+
+func TestEmbedAuthHeader(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","model":"m","data":[{"object":"embedding","index":0,"embedding":[0.1]}]}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL+"/v1", "secret-key", "m", time.Second, nil)
+	_, _ = c.Embed(context.Background(), []string{"x"})
+	if gotAuth != "Bearer secret-key" {
+		t.Errorf("auth header: got %q want %q", gotAuth, "Bearer secret-key")
+	}
+}
+
+func TestEmbedNoAuthHeaderWhenKeyEmpty(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","model":"m","data":[{"object":"embedding","index":0,"embedding":[0.1]}]}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL+"/v1", "", "m", time.Second, nil)
+	_, _ = c.Embed(context.Background(), []string{"x"})
+	if gotAuth != "" {
+		t.Errorf("auth header should be unset when key is empty, got %q", gotAuth)
+	}
+}
+
+func TestEmbedHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"message":"invalid api key","type":"auth"}}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL+"/v1", "", "m", time.Second, nil)
+	_, err := c.Embed(context.Background(), []string{"x"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "invalid api key") {
+		t.Errorf("expected wrapped server message, got %v", err)
+	}
+}
+
+func TestEmbedReturnsOrderedByIndex(t *testing.T) {
+	// Server returns data in reversed order with explicit indices;
+	// client must reorder.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"object":"list","model":"m",
+			"data":[
+				{"object":"embedding","index":2,"embedding":[3.0]},
+				{"object":"embedding","index":0,"embedding":[1.0]},
+				{"object":"embedding","index":1,"embedding":[2.0]}
+			]
+		}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL+"/v1", "", "m", time.Second, nil)
+	vecs, err := c.Embed(context.Background(), []string{"a", "b", "c"})
+	if err != nil {
+		t.Fatalf("embed: %v", err)
+	}
+	if vecs[0][0] != 1 || vecs[1][0] != 2 || vecs[2][0] != 3 {
+		t.Errorf("expected vectors reordered by index, got %v", vecs)
+	}
+}
+
+func TestProbeSetsDim(t *testing.T) {
+	srv := fixedDimServer(t, 1536)
+	defer srv.Close()
+
+	c := New(srv.URL+"/v1", "", "test-embedding-3-small", time.Second, nil)
+	if c.Dim() != 0 {
+		t.Errorf("dim before probe: want 0 got %d", c.Dim())
+	}
+	if err := c.Probe(context.Background()); err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if c.Dim() != 1536 {
+		t.Errorf("dim after probe: want 1536 got %d", c.Dim())
+	}
+}
+
+func TestProbeFailsOnUnreachable(t *testing.T) {
+	c := New("http://127.0.0.1:1/v1", "", "m", 100*time.Millisecond, nil)
+	err := c.Probe(context.Background())
+	if err == nil {
+		t.Errorf("expected probe failure on unreachable host")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,11 @@ type Config struct {
 	Email    EmailConfig    `toml:"email"`
 	Limits   LimitsConfig   `toml:"limits"`
 	Update   UpdateConfig   `toml:"update"`
+
+	// Embeddings is optional; when Enabled, semantic search is added
+	// alongside BM25 in memory_search and memory mutations re-embed
+	// the affected file synchronously.
+	Embeddings EmbeddingsConfig `toml:"embeddings"`
 }
 
 // APIConfig holds LLM API connection settings.
@@ -172,6 +177,56 @@ type UpdateConfig struct {
 	BinaryPath string `toml:"binary_path"`
 }
 
+// EmbeddingsConfig holds optional semantic-search settings. When
+// Enabled, the agent constructs an OpenAI-compatible embeddings
+// client, builds an in-memory vector index of memory files (persisted
+// to disk in a custom binary format), and surfaces a "Semantic
+// results" section in memory_search alongside the existing BM25
+// "Lexical results" section.
+//
+// The LLM does not see the embeddings directly; it only sees ranked
+// path/score lists. The mechanism is best-effort enrichment — embed
+// failures are logged but never block memory writes.
+type EmbeddingsConfig struct {
+	// Enabled toggles the entire feature. When false, no embeddings
+	// client is constructed, no vector index is loaded, and
+	// memory_search is BM25-only.
+	Enabled bool `toml:"enabled"`
+
+	// URL is the OpenAI-compatible API base URL ending in /v1 (no
+	// trailing slash). The adapter appends "/embeddings". Defaults to
+	// the public OpenAI endpoint.
+	URL string `toml:"url"`
+
+	// APIKey is sent as a Bearer token. Required for OpenAI; may be
+	// empty for local servers (Ollama, LM Studio, vLLM) that don't
+	// authenticate.
+	APIKey string `toml:"api_key"`
+
+	// Model is the embedding model identifier (e.g.
+	// "text-embedding-3-small", "nomic-embed-text"). The vector
+	// index records this on disk; if it changes, the index is
+	// discarded and rebuilt on next startup.
+	Model string `toml:"model"`
+
+	// Timeout is applied per HTTP request. Zero falls back to 30s.
+	Timeout duration `toml:"timeout"`
+
+	// BatchSize is the maximum number of texts per /v1/embeddings
+	// call during the startup reconcile pass and bulk re-indexing.
+	// Per-mutation embeds always send a single text. Zero falls back
+	// to 100.
+	BatchSize int `toml:"batch_size"`
+}
+
+// Enabled is a struct-receiver alias so callers can write
+// `cfg.Embeddings.Active()` without checking both Enabled and the
+// minimum required fields. Returns true only when the feature is
+// turned on AND has the bare minimum to function.
+func (e EmbeddingsConfig) Active() bool {
+	return e.Enabled && e.URL != "" && e.Model != ""
+}
+
 // EmailConfig holds optional IMAP email connection settings.
 type EmailConfig struct {
 	Host     string `toml:"host"`
@@ -243,6 +298,13 @@ func Default() *Config {
 			GitHubRepo:    "matjam/faultline",
 			RestartMode:   "exit",
 		},
+		Embeddings: EmbeddingsConfig{
+			Enabled:   false,
+			URL:       "https://api.openai.com/v1",
+			Model:     "text-embedding-3-small",
+			Timeout:   duration(30 * time.Second),
+			BatchSize: 100,
+		},
 	}
 }
 
@@ -271,6 +333,15 @@ func Load(path string) (*Config, error) {
 	// set update.enabled = false.
 	if cfg.Update.CheckInterval.Duration() <= 0 {
 		cfg.Update.CheckInterval = duration(1 * time.Hour)
+	}
+
+	// Embeddings: backfill defaults when the operator enables the
+	// feature but leaves these fields zero.
+	if cfg.Embeddings.Timeout.Duration() <= 0 {
+		cfg.Embeddings.Timeout = duration(30 * time.Second)
+	}
+	if cfg.Embeddings.BatchSize <= 0 {
+		cfg.Embeddings.BatchSize = 100
 	}
 
 	return cfg, nil

--- a/internal/prompts/templates/system.md
+++ b/internal/prompts/templates/system.md
@@ -11,7 +11,7 @@ Your goal is to learn about the world and become a positive force in it. How you
 - **memory_read(path, offset, lines)** — Read a memory file. Optional offset and lines for partial reads.
 - **memory_write(path, content)** — Write or overwrite a memory file. Creates directories automatically.
 - **memory_list(directory)** — List files and directories. Use '' for root.
-- **memory_search(query, modified_after, modified_before)** — Search all memories by keyword relevance. Optional date filters (YYYY-MM-DD).
+- **memory_search(query, modified_after, modified_before)** — Search all memories. When semantic search is configured, returns two clearly labeled sections: lexical (BM25 keyword) and semantic (embedding similarity). Pick whichever is more relevant for the query, or read both. Optional date filters (YYYY-MM-DD) apply to both sections.
 - **memory_grep(path, pattern)** — Regex search within a single file.
 - **memory_edit(path, old_string, new_string, replace_all)** — Find and replace exact strings in a file.
 - **memory_append(path, content)** — Append to end of a file. Creates it if it does not exist.

--- a/internal/prompts/templates/system.md
+++ b/internal/prompts/templates/system.md
@@ -28,6 +28,7 @@ Your goal is to learn about the world and become a positive force in it. How you
 - **sleep(seconds)** — Pause your loop for N seconds without burning context. Operator messages interrupt immediately. Bounded by a configured maximum.
 - **send_message(text)** — Send a message to your collaborator via Telegram (if configured).
 - **get_version()** — Print the running binary's version, commit SHA, and build time. Useful right after an update to confirm what version is now running.
+- **rebuild_indexes(scope)** — Force a full rebuild of memory search indexes from disk. Use ONLY when the operator asks, or when you observe a clear inconsistency between memory_search results and known disk state. Both indexes are kept in sync incrementally on every memory mutation; routine rebuilds are wasteful (BM25 is cheap, but vector rebuild re-embeds every file via the embeddings API and incurs cost on paid endpoints). Scope: 'all' (default), 'lexical' (BM25 only), 'semantic' (vector only).
 - **update_check()** — (when self-update is enabled) Poll GitHub for newer releases. Read-only; does not apply anything.
 - **update_apply()** — (when self-update is enabled) Download and install the latest release, then trigger graceful shutdown so the new binary takes over. The agent restarts under whatever process supervisor or restart strategy the operator configured.
 

--- a/internal/search/vector/serialize.go
+++ b/internal/search/vector/serialize.go
@@ -1,0 +1,385 @@
+package vector
+
+import (
+	"bufio"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// File format ("FVEC v1"):
+//
+//   magic[4]      = "FVEC"
+//   version[4]    = uint32 LE                  (= fileVersion)
+//   dim[4]        = uint32 LE
+//   count[4]      = uint32 LE
+//   model_len[2]  = uint16 LE
+//   model[N]      = UTF-8 bytes (no NUL terminator)
+//   records[count]:
+//     path_len[2] = uint16 LE
+//     path[N]     = UTF-8 bytes
+//     vector      = dim × float32 LE (raw IEEE-754 bits)
+//
+// Total per record: 2 + len(path) + dim*4 bytes. For a 1536-dim
+// vector with a 60-char path that's ~6.2 KB; 10k vectors ≈ 62 MB on
+// disk which is fine.
+//
+// Atomic write: we write to "<path>.tmp" and rename over <path>.
+// Corrupt files are not auto-deleted by the package itself; callers
+// (e.g. main.go) should rename them aside with a ".bad-<unix>" suffix
+// and continue with a fresh index, mirroring the pattern in
+// internal/adapters/state/jsonfile.
+
+const (
+	fileMagic   = "FVEC"
+	fileVersion = uint32(1)
+
+	// maxModelLen is the largest model identifier we'll accept on
+	// load. Anything larger almost certainly indicates a corrupt or
+	// foreign file.
+	maxModelLen = 1024
+
+	// maxPathLen is the largest path we'll accept per record.
+	maxPathLen = 4096
+
+	// maxDim is a sanity bound on the per-vector dimensionality. The
+	// largest practical OpenAI embedding today is 3072 dim
+	// (text-embedding-3-large); 8192 leaves headroom for future
+	// models without permitting absurd values.
+	maxDim = 8192
+)
+
+// ErrModelMismatch is returned by Load when the on-disk index was
+// produced by a different embedding model or dimensionality than the
+// in-memory Index expects. The caller should Reset the index and
+// re-embed all sources.
+var ErrModelMismatch = errors.New("vector: on-disk index has a different model or dim")
+
+// ErrCorrupt is returned by Load when the file does not start with the
+// FVEC magic, has a future version, or has internal inconsistencies.
+// The caller should rename the file aside and continue with an empty
+// index.
+var ErrCorrupt = errors.New("vector: index file is corrupt or unrecognized")
+
+// Save writes the index to path. The write is atomic: data goes to
+// "<path>.tmp" and is renamed over <path> on success.
+//
+// On success the dirty flag is cleared.
+func (idx *Index) Save(path string) error {
+	if path == "" {
+		return errors.New("vector: save path is empty")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("vector: mkdir parent: %w", err)
+	}
+
+	tmp := path + ".tmp"
+	f, err := os.Create(tmp)
+	if err != nil {
+		return fmt.Errorf("vector: create temp: %w", err)
+	}
+	// On any error after this point, do best-effort cleanup of the
+	// temp file.
+	cleanup := func() { _ = os.Remove(tmp) }
+
+	bw := bufio.NewWriter(f)
+
+	idx.mu.RLock()
+	dim := idx.dim
+	model := idx.model
+	// Snapshot keys so we can write in deterministic order. Sorted
+	// output makes byte-level comparison meaningful in tests and
+	// keeps diffs reviewable if anyone ever inspects the file.
+	paths := make([]string, 0, len(idx.vectors))
+	for p := range idx.vectors {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	count := uint32(len(paths))
+	idx.mu.RUnlock()
+
+	if dim < 0 || dim > maxDim {
+		_ = f.Close()
+		cleanup()
+		return fmt.Errorf("vector: refusing to save with dim=%d", dim)
+	}
+	if len(model) > maxModelLen {
+		_ = f.Close()
+		cleanup()
+		return fmt.Errorf("vector: model identifier too long (%d bytes)", len(model))
+	}
+
+	// Header.
+	if _, err := bw.WriteString(fileMagic); err != nil {
+		_ = f.Close()
+		cleanup()
+		return fmt.Errorf("vector: write magic: %w", err)
+	}
+	if err := writeU32(bw, fileVersion); err != nil {
+		_ = f.Close()
+		cleanup()
+		return err
+	}
+	if err := writeU32(bw, uint32(dim)); err != nil {
+		_ = f.Close()
+		cleanup()
+		return err
+	}
+	if err := writeU32(bw, count); err != nil {
+		_ = f.Close()
+		cleanup()
+		return err
+	}
+	if err := writeU16(bw, uint16(len(model))); err != nil {
+		_ = f.Close()
+		cleanup()
+		return err
+	}
+	if _, err := bw.WriteString(model); err != nil {
+		_ = f.Close()
+		cleanup()
+		return fmt.Errorf("vector: write model: %w", err)
+	}
+
+	// Records. Re-take the read lock for the duration of the dump.
+	// This blocks Upsert/Remove for the duration of a Save, which is
+	// acceptable: typical Save is well under 100ms even for tens of
+	// thousands of vectors, and Save is only called from the
+	// persistence loop or shutdown, not the hot path.
+	idx.mu.RLock()
+	for _, p := range paths {
+		v, ok := idx.vectors[p]
+		if !ok {
+			// Concurrent Remove between snapshot and now. Skip it
+			// and decrement the count we wrote to the header.
+			continue
+		}
+		if len(v) != dim {
+			idx.mu.RUnlock()
+			_ = f.Close()
+			cleanup()
+			return fmt.Errorf("vector: internal error: vector for %q has dim %d, want %d", p, len(v), dim)
+		}
+		if len(p) > maxPathLen {
+			idx.mu.RUnlock()
+			_ = f.Close()
+			cleanup()
+			return fmt.Errorf("vector: path too long: %d bytes", len(p))
+		}
+		if err := writeU16(bw, uint16(len(p))); err != nil {
+			idx.mu.RUnlock()
+			_ = f.Close()
+			cleanup()
+			return err
+		}
+		if _, err := bw.WriteString(p); err != nil {
+			idx.mu.RUnlock()
+			_ = f.Close()
+			cleanup()
+			return fmt.Errorf("vector: write path: %w", err)
+		}
+		if err := writeFloat32s(bw, v); err != nil {
+			idx.mu.RUnlock()
+			_ = f.Close()
+			cleanup()
+			return err
+		}
+	}
+	idx.mu.RUnlock()
+
+	if err := bw.Flush(); err != nil {
+		_ = f.Close()
+		cleanup()
+		return fmt.Errorf("vector: flush: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		cleanup()
+		return fmt.Errorf("vector: fsync: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("vector: close: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		cleanup()
+		return fmt.Errorf("vector: rename into place: %w", err)
+	}
+
+	idx.dirty.Store(false)
+	return nil
+}
+
+// Load replaces the index contents with the file at path. If the file
+// does not exist, Load returns nil and leaves the index untouched
+// (treat as "no prior state").
+//
+// If the on-disk model/dim does not match the index's configured
+// model/dim, Load returns ErrModelMismatch; the caller should call
+// Reset and re-embed.
+//
+// If the file is unreadable or fails the format checks, Load returns
+// an error wrapping ErrCorrupt. The caller is responsible for renaming
+// the bad file aside before continuing.
+func (idx *Index) Load(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("vector: open: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	br := bufio.NewReader(f)
+
+	// Header. corruptf wraps ErrCorrupt together with any underlying
+	// I/O error so callers can errors.Is(err, ErrCorrupt) regardless of
+	// where the failure happened. errors.Join keeps both in the chain
+	// without smuggling errors through a non-%w verb.
+	corruptf := func(format string, args ...any) error {
+		return errors.Join(ErrCorrupt, fmt.Errorf(format, args...))
+	}
+
+	magic := make([]byte, 4)
+	if _, err := io.ReadFull(br, magic); err != nil {
+		return corruptf("read magic: %w", err)
+	}
+	if string(magic) != fileMagic {
+		return corruptf("magic %q != %q", string(magic), fileMagic)
+	}
+	version, err := readU32(br)
+	if err != nil {
+		return corruptf("read version: %w", err)
+	}
+	if version != fileVersion {
+		return corruptf("version %d unsupported (want %d)", version, fileVersion)
+	}
+	dim32, err := readU32(br)
+	if err != nil {
+		return corruptf("read dim: %w", err)
+	}
+	if dim32 == 0 || dim32 > maxDim {
+		return corruptf("implausible dim %d", dim32)
+	}
+	dim := int(dim32)
+
+	count, err := readU32(br)
+	if err != nil {
+		return corruptf("read count: %w", err)
+	}
+
+	modelLen, err := readU16(br)
+	if err != nil {
+		return corruptf("read model_len: %w", err)
+	}
+	if int(modelLen) > maxModelLen {
+		return corruptf("model_len %d exceeds limit", modelLen)
+	}
+	modelBytes := make([]byte, modelLen)
+	if _, err := io.ReadFull(br, modelBytes); err != nil {
+		return corruptf("read model: %w", err)
+	}
+	model := string(modelBytes)
+
+	// Mismatch check before allocating any record memory.
+	if dim != idx.dim || model != idx.model {
+		return fmt.Errorf("%w: file has dim=%d model=%q, want dim=%d model=%q",
+			ErrModelMismatch, dim, model, idx.dim, idx.model)
+	}
+
+	// Records.
+	loaded := make(map[string][]float32, count)
+	for i := uint32(0); i < count; i++ {
+		pathLen, err := readU16(br)
+		if err != nil {
+			return corruptf("record %d read path_len: %w", i, err)
+		}
+		if int(pathLen) > maxPathLen || pathLen == 0 {
+			return corruptf("record %d implausible path_len %d", i, pathLen)
+		}
+		pathBytes := make([]byte, pathLen)
+		if _, err := io.ReadFull(br, pathBytes); err != nil {
+			return corruptf("record %d read path: %w", i, err)
+		}
+		vec := make([]float32, dim)
+		if err := readFloat32s(br, vec); err != nil {
+			return corruptf("record %d read vector: %w", i, err)
+		}
+		loaded[string(pathBytes)] = vec
+	}
+
+	// Trailing data is allowed (forward compatibility), but we
+	// don't try to interpret it.
+	idx.mu.Lock()
+	idx.vectors = loaded
+	idx.mu.Unlock()
+	idx.dirty.Store(false)
+	return nil
+}
+
+// --- low-level helpers ----------------------------------------------------
+
+func writeU16(w io.Writer, v uint16) error {
+	var buf [2]byte
+	binary.LittleEndian.PutUint16(buf[:], v)
+	_, err := w.Write(buf[:])
+	if err != nil {
+		return fmt.Errorf("vector: write u16: %w", err)
+	}
+	return nil
+}
+
+func writeU32(w io.Writer, v uint32) error {
+	var buf [4]byte
+	binary.LittleEndian.PutUint32(buf[:], v)
+	_, err := w.Write(buf[:])
+	if err != nil {
+		return fmt.Errorf("vector: write u32: %w", err)
+	}
+	return nil
+}
+
+func writeFloat32s(w io.Writer, vs []float32) error {
+	buf := make([]byte, 4*len(vs))
+	for i, v := range vs {
+		binary.LittleEndian.PutUint32(buf[i*4:], math.Float32bits(v))
+	}
+	_, err := w.Write(buf)
+	if err != nil {
+		return fmt.Errorf("vector: write float32s: %w", err)
+	}
+	return nil
+}
+
+func readU16(r io.Reader) (uint16, error) {
+	var buf [2]byte
+	if _, err := io.ReadFull(r, buf[:]); err != nil {
+		return 0, err
+	}
+	return binary.LittleEndian.Uint16(buf[:]), nil
+}
+
+func readU32(r io.Reader) (uint32, error) {
+	var buf [4]byte
+	if _, err := io.ReadFull(r, buf[:]); err != nil {
+		return 0, err
+	}
+	return binary.LittleEndian.Uint32(buf[:]), nil
+}
+
+func readFloat32s(r io.Reader, dst []float32) error {
+	buf := make([]byte, 4*len(dst))
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return err
+	}
+	for i := range dst {
+		dst[i] = math.Float32frombits(binary.LittleEndian.Uint32(buf[i*4:]))
+	}
+	return nil
+}

--- a/internal/search/vector/vector.go
+++ b/internal/search/vector/vector.go
@@ -1,0 +1,287 @@
+// Package vector is a pure-Go in-memory vector index over text
+// documents keyed by string paths. It supports brute-force cosine
+// similarity search and persists to disk in a custom binary format
+// (see serialize.go) so we don't recompute embeddings on every
+// restart.
+//
+// At Faultline's scale (thousands of files, ~1536-dim vectors) flat
+// scan is sub-millisecond per query and avoids the operational
+// complexity of HNSW/IVF approximate-nearest-neighbor structures.
+//
+// Used as the semantic-search backend for the memory adapter; the
+// lexical (BM25) and semantic results are returned separately by
+// memory_search so the LLM can pick the more relevant set.
+package vector
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+// Result is a single semantic search hit. Score is the cosine
+// similarity in [-1, 1]; values closer to 1 are more similar. For
+// L2-normalised vectors (which the index always produces) cosine
+// similarity equals the dot product.
+type Result struct {
+	Path  string  `json:"path"`
+	Score float32 `json:"score"`
+}
+
+// Index is an in-memory vector index. Vectors are L2-normalised on
+// Upsert so Search can use plain dot products.
+//
+// Concurrency: read/write operations are guarded by an RWMutex.
+// Search takes the read lock; Upsert/Remove/RemovePrefix/Build take
+// the write lock. The dirty flag is an atomic so callers (e.g. a
+// persistence goroutine) can poll it without contending the main
+// lock.
+type Index struct {
+	mu      sync.RWMutex
+	vectors map[string][]float32
+
+	// dim is the vector dimensionality. All vectors in the index must
+	// have this length. Set on first Upsert (or via Reset/Load); a
+	// later Upsert with a mismatched dim is a programming error and
+	// returns an error rather than corrupting the index.
+	dim int
+
+	// model is a free-form identifier for the embedding model that
+	// produced the vectors. Persisted so Load can detect a
+	// model/dim mismatch and signal the caller to re-embed.
+	model string
+
+	// dirty is set on every mutation and cleared on Save. A
+	// background persistence loop polls it to decide whether to
+	// flush.
+	dirty atomic.Bool
+}
+
+// New returns a new empty Index for vectors of the given dimensionality
+// produced by the named model. Both fields are persisted in the binary
+// format and used to detect mismatches at Load time.
+func New(dim int, model string) *Index {
+	return &Index{
+		vectors: make(map[string][]float32),
+		dim:     dim,
+		model:   model,
+	}
+}
+
+// Dim returns the vector dimensionality the index was constructed for.
+func (idx *Index) Dim() int { return idx.dim }
+
+// Model returns the embedding model identifier the index was
+// constructed for.
+func (idx *Index) Model() string { return idx.model }
+
+// Len returns the number of vectors currently in the index.
+func (idx *Index) Len() int {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+	return len(idx.vectors)
+}
+
+// Has reports whether the given path is currently indexed.
+func (idx *Index) Has(path string) bool {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+	_, ok := idx.vectors[path]
+	return ok
+}
+
+// Paths returns a snapshot of all indexed paths in unspecified order.
+// Useful for the startup reconcile pass that detects which memory
+// files lack a vector.
+func (idx *Index) Paths() []string {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+	out := make([]string, 0, len(idx.vectors))
+	for p := range idx.vectors {
+		out = append(out, p)
+	}
+	return out
+}
+
+// Dirty reports whether the index has been mutated since the last
+// successful Save.
+func (idx *Index) Dirty() bool { return idx.dirty.Load() }
+
+// Upsert adds or replaces the vector for the given path. The vector is
+// L2-normalised in place before storage so Search can use plain dot
+// products.
+//
+// Returns an error if the vector's length does not match the index's
+// configured dim, or if the vector is all-zero (cannot be normalised).
+func (idx *Index) Upsert(path string, vec []float32) error {
+	if path == "" {
+		return errors.New("vector: path is empty")
+	}
+	if len(vec) != idx.dim {
+		return fmt.Errorf("vector: dim mismatch for %q: got %d, want %d", path, len(vec), idx.dim)
+	}
+
+	// Make a defensive copy so callers can reuse their slice.
+	cp := make([]float32, len(vec))
+	copy(cp, vec)
+	if err := normalize(cp); err != nil {
+		return fmt.Errorf("vector: cannot normalise vector for %q: %w", path, err)
+	}
+
+	idx.mu.Lock()
+	idx.vectors[path] = cp
+	idx.mu.Unlock()
+	idx.dirty.Store(true)
+	return nil
+}
+
+// Remove deletes the entry for the given path if present. Returns true
+// if a vector was actually removed.
+func (idx *Index) Remove(path string) bool {
+	idx.mu.Lock()
+	_, ok := idx.vectors[path]
+	if ok {
+		delete(idx.vectors, path)
+	}
+	idx.mu.Unlock()
+	if ok {
+		idx.dirty.Store(true)
+	}
+	return ok
+}
+
+// RemovePrefix deletes all entries whose path is exactly equal to or
+// starts with prefix + "/". A trailing slash on prefix is normalised
+// away. Returns the number of entries removed.
+func (idx *Index) RemovePrefix(prefix string) int {
+	prefix = strings.TrimSuffix(prefix, "/")
+	pfx := prefix + "/"
+
+	idx.mu.Lock()
+	n := 0
+	for p := range idx.vectors {
+		if p == prefix || strings.HasPrefix(p, pfx) {
+			delete(idx.vectors, p)
+			n++
+		}
+	}
+	idx.mu.Unlock()
+	if n > 0 {
+		idx.dirty.Store(true)
+	}
+	return n
+}
+
+// Rename moves the vector currently keyed at oldPath to newPath. If
+// oldPath is not indexed this is a no-op. If newPath already exists it
+// is overwritten. Returns true if a vector was actually renamed.
+//
+// Useful for memory_move: the file content is unchanged so the
+// embedding is unchanged; we just swap the key.
+func (idx *Index) Rename(oldPath, newPath string) bool {
+	if oldPath == newPath {
+		return false
+	}
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	v, ok := idx.vectors[oldPath]
+	if !ok {
+		return false
+	}
+	delete(idx.vectors, oldPath)
+	idx.vectors[newPath] = v
+	idx.dirty.Store(true)
+	return true
+}
+
+// Reset replaces the index contents with a fresh, empty map and sets
+// the dim and model. Used when Load detects a model/dim mismatch and
+// the caller needs to rebuild from scratch.
+func (idx *Index) Reset(dim int, model string) {
+	idx.mu.Lock()
+	idx.vectors = make(map[string][]float32)
+	idx.dim = dim
+	idx.model = model
+	idx.mu.Unlock()
+	idx.dirty.Store(true)
+}
+
+// Search returns up to k results ranked by descending cosine
+// similarity. Results with score below minScore are dropped. If
+// filter is non-nil, only paths for which filter(path) returns true
+// are considered.
+//
+// The query vector is normalised in place by Search; callers do not
+// need to normalise it themselves but should not assume the slice is
+// preserved unchanged.
+func (idx *Index) Search(query []float32, k int, minScore float32, filter func(string) bool) ([]Result, error) {
+	if len(query) != idx.dim {
+		return nil, fmt.Errorf("vector: query dim mismatch: got %d, want %d", len(query), idx.dim)
+	}
+	if k <= 0 {
+		return nil, nil
+	}
+	if err := normalize(query); err != nil {
+		return nil, fmt.Errorf("vector: cannot normalise query: %w", err)
+	}
+
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+
+	if len(idx.vectors) == 0 {
+		return nil, nil
+	}
+
+	// Single pass: compute scores, keep top-k via partial sort.
+	out := make([]Result, 0, len(idx.vectors))
+	for path, v := range idx.vectors {
+		if filter != nil && !filter(path) {
+			continue
+		}
+		score := dot(query, v)
+		if score < minScore {
+			continue
+		}
+		out = append(out, Result{Path: path, Score: score})
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Score > out[j].Score
+	})
+
+	if len(out) > k {
+		out = out[:k]
+	}
+	return out, nil
+}
+
+// dot computes the dot product of two equal-length vectors. Caller
+// guarantees lengths match.
+func dot(a, b []float32) float32 {
+	var s float32
+	for i := range a {
+		s += a[i] * b[i]
+	}
+	return s
+}
+
+// normalize divides v in place by its L2 norm. Returns an error if v
+// is the zero vector (norm is exactly 0).
+func normalize(v []float32) error {
+	var sumSq float64
+	for _, x := range v {
+		sumSq += float64(x) * float64(x)
+	}
+	if sumSq == 0 {
+		return errors.New("zero vector")
+	}
+	inv := float32(1.0 / math.Sqrt(sumSq))
+	for i := range v {
+		v[i] *= inv
+	}
+	return nil
+}

--- a/internal/search/vector/vector_test.go
+++ b/internal/search/vector/vector_test.go
@@ -1,0 +1,324 @@
+package vector
+
+import (
+	"errors"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// approxEqual reports whether a and b are within tol.
+func approxEqual(a, b, tol float32) bool {
+	d := a - b
+	if d < 0 {
+		d = -d
+	}
+	return d <= tol
+}
+
+func TestUpsertAndSearch(t *testing.T) {
+	idx := New(3, "test-model")
+
+	// Three orthogonal vectors. After normalisation they remain
+	// orthogonal; cosine similarity is the dot product.
+	if err := idx.Upsert("x", []float32{1, 0, 0}); err != nil {
+		t.Fatalf("upsert x: %v", err)
+	}
+	if err := idx.Upsert("y", []float32{0, 1, 0}); err != nil {
+		t.Fatalf("upsert y: %v", err)
+	}
+	if err := idx.Upsert("z", []float32{0, 0, 1}); err != nil {
+		t.Fatalf("upsert z: %v", err)
+	}
+
+	results, err := idx.Search([]float32{1, 0, 0}, 3, 0, nil)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("want 3 results, got %d", len(results))
+	}
+	if results[0].Path != "x" {
+		t.Errorf("top result should be x, got %q", results[0].Path)
+	}
+	if !approxEqual(results[0].Score, 1.0, 1e-6) {
+		t.Errorf("top score should be ~1.0, got %f", results[0].Score)
+	}
+}
+
+func TestSearchMinScore(t *testing.T) {
+	idx := New(2, "m")
+	_ = idx.Upsert("near", []float32{1, 0.1})
+	_ = idx.Upsert("far", []float32{0, 1})
+
+	// Query along x-axis. "near" has high cosine; "far" has near-zero.
+	results, err := idx.Search([]float32{1, 0}, 5, 0.5, nil)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(results) != 1 || results[0].Path != "near" {
+		t.Errorf("expected only 'near' above min_score 0.5, got %+v", results)
+	}
+}
+
+func TestSearchFilter(t *testing.T) {
+	idx := New(2, "m")
+	_ = idx.Upsert("a/foo", []float32{1, 0})
+	_ = idx.Upsert("b/bar", []float32{1, 0})
+
+	results, _ := idx.Search([]float32{1, 0}, 5, 0, func(p string) bool {
+		return p == "a/foo"
+	})
+	if len(results) != 1 || results[0].Path != "a/foo" {
+		t.Errorf("filter should restrict to a/foo, got %+v", results)
+	}
+}
+
+func TestUpsertReplacesExisting(t *testing.T) {
+	idx := New(2, "m")
+	_ = idx.Upsert("p", []float32{1, 0})
+	_ = idx.Upsert("p", []float32{0, 1})
+
+	if got := idx.Len(); got != 1 {
+		t.Errorf("len after replace: want 1 got %d", got)
+	}
+
+	// Query along x-axis should now miss (we wrote a y-axis vector).
+	results, _ := idx.Search([]float32{1, 0}, 5, 0.5, nil)
+	if len(results) != 0 {
+		t.Errorf("after replace, query along old direction should miss, got %+v", results)
+	}
+}
+
+func TestUpsertDimMismatch(t *testing.T) {
+	idx := New(3, "m")
+	if err := idx.Upsert("x", []float32{1, 0}); err == nil {
+		t.Errorf("expected dim mismatch error")
+	}
+}
+
+func TestUpsertZeroVector(t *testing.T) {
+	idx := New(3, "m")
+	if err := idx.Upsert("x", []float32{0, 0, 0}); err == nil {
+		t.Errorf("expected zero-vector error")
+	}
+}
+
+func TestRemove(t *testing.T) {
+	idx := New(2, "m")
+	_ = idx.Upsert("a", []float32{1, 0})
+	if !idx.Remove("a") {
+		t.Errorf("remove should return true for existing key")
+	}
+	if idx.Has("a") {
+		t.Errorf("a should be gone after remove")
+	}
+	if idx.Remove("a") {
+		t.Errorf("second remove should return false")
+	}
+}
+
+func TestRemovePrefix(t *testing.T) {
+	idx := New(2, "m")
+	_ = idx.Upsert("a/x", []float32{1, 0})
+	_ = idx.Upsert("a/y", []float32{0, 1})
+	_ = idx.Upsert("a", []float32{1, 1})  // exact-prefix match
+	_ = idx.Upsert("ab", []float32{1, 1}) // sibling, must NOT be removed
+	_ = idx.Upsert("b/x", []float32{1, 0})
+
+	n := idx.RemovePrefix("a")
+	if n != 3 {
+		t.Errorf("RemovePrefix count: want 3 got %d", n)
+	}
+	if !idx.Has("ab") {
+		t.Errorf("'ab' should not be removed by prefix 'a'")
+	}
+	if !idx.Has("b/x") {
+		t.Errorf("'b/x' should not be removed by prefix 'a'")
+	}
+}
+
+func TestRename(t *testing.T) {
+	idx := New(2, "m")
+	_ = idx.Upsert("old", []float32{1, 0})
+	if !idx.Rename("old", "new") {
+		t.Errorf("rename should succeed")
+	}
+	if idx.Has("old") {
+		t.Errorf("old key should be gone")
+	}
+	if !idx.Has("new") {
+		t.Errorf("new key should exist")
+	}
+	// Search should still find via the new key.
+	results, _ := idx.Search([]float32{1, 0}, 1, 0.5, nil)
+	if len(results) != 1 || results[0].Path != "new" {
+		t.Errorf("search after rename: %+v", results)
+	}
+}
+
+func TestSaveLoadRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "index.bin")
+
+	src := New(4, "test-model-v1")
+	_ = src.Upsert("alpha.md", []float32{1, 0, 0, 0})
+	_ = src.Upsert("beta/gamma.md", []float32{0, 1, 0, 0})
+	_ = src.Upsert("d", []float32{0.5, 0.5, 0.5, 0.5})
+
+	if err := src.Save(path); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if src.Dirty() {
+		t.Errorf("dirty flag should be cleared after save")
+	}
+
+	dst := New(4, "test-model-v1")
+	if err := dst.Load(path); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	if dst.Len() != 3 {
+		t.Errorf("len after load: want 3 got %d", dst.Len())
+	}
+
+	srcPaths := src.Paths()
+	dstPaths := dst.Paths()
+	sort.Strings(srcPaths)
+	sort.Strings(dstPaths)
+	for i, p := range srcPaths {
+		if dstPaths[i] != p {
+			t.Errorf("paths[%d] differ: %q vs %q", i, p, dstPaths[i])
+		}
+	}
+
+	// Spot-check one vector roundtripped exactly.
+	results, _ := dst.Search([]float32{1, 0, 0, 0}, 1, 0.5, nil)
+	if len(results) != 1 || results[0].Path != "alpha.md" {
+		t.Errorf("search after load: %+v", results)
+	}
+	if !approxEqual(results[0].Score, 1.0, 1e-6) {
+		t.Errorf("score after load: want ~1.0 got %f", results[0].Score)
+	}
+}
+
+func TestLoadNonexistentIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	idx := New(2, "m")
+	_ = idx.Upsert("a", []float32{1, 0})
+
+	err := idx.Load(filepath.Join(dir, "does-not-exist.bin"))
+	if err != nil {
+		t.Errorf("loading nonexistent file should be a no-op, got %v", err)
+	}
+	if idx.Len() != 1 {
+		t.Errorf("index should be untouched, len=%d", idx.Len())
+	}
+}
+
+func TestLoadModelMismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "index.bin")
+
+	src := New(4, "model-A")
+	_ = src.Upsert("x", []float32{1, 0, 0, 0})
+	if err := src.Save(path); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	dst := New(4, "model-B")
+	err := dst.Load(path)
+	if !errors.Is(err, ErrModelMismatch) {
+		t.Errorf("expected ErrModelMismatch, got %v", err)
+	}
+}
+
+func TestLoadDimMismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "index.bin")
+
+	src := New(4, "m")
+	_ = src.Upsert("x", []float32{1, 0, 0, 0})
+	if err := src.Save(path); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	dst := New(8, "m")
+	err := dst.Load(path)
+	if !errors.Is(err, ErrModelMismatch) {
+		t.Errorf("expected ErrModelMismatch on dim change, got %v", err)
+	}
+}
+
+func TestLoadCorrupt(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "index.bin")
+	if err := os.WriteFile(path, []byte("not a real index"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	idx := New(4, "m")
+	err := idx.Load(path)
+	if !errors.Is(err, ErrCorrupt) {
+		t.Errorf("expected ErrCorrupt, got %v", err)
+	}
+}
+
+func TestNormalizationIsApplied(t *testing.T) {
+	idx := New(3, "m")
+	// Length-2 vector along x. After normalisation, dot with (1,0,0)
+	// should be exactly 1.0 (within float tol).
+	_ = idx.Upsert("p", []float32{2, 0, 0})
+
+	results, _ := idx.Search([]float32{1, 0, 0}, 1, 0, nil)
+	if len(results) != 1 {
+		t.Fatalf("expected one result")
+	}
+	if !approxEqual(results[0].Score, 1.0, 1e-6) {
+		t.Errorf("normalised dot should be ~1.0, got %f", results[0].Score)
+	}
+
+	// Sanity check on raw normalize helper.
+	v := []float32{3, 4}
+	if err := normalize(v); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if !approxEqual(float32(math.Sqrt(float64(v[0]*v[0]+v[1]*v[1]))), 1.0, 1e-6) {
+		t.Errorf("normalised vector length not ~1.0: %v", v)
+	}
+}
+
+func TestDirtyFlag(t *testing.T) {
+	idx := New(2, "m")
+	if idx.Dirty() {
+		t.Errorf("fresh index should not be dirty")
+	}
+	_ = idx.Upsert("a", []float32{1, 0})
+	if !idx.Dirty() {
+		t.Errorf("dirty should be set after Upsert")
+	}
+
+	dir := t.TempDir()
+	if err := idx.Save(filepath.Join(dir, "i.bin")); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if idx.Dirty() {
+		t.Errorf("dirty should be cleared after Save")
+	}
+
+	idx.Remove("a")
+	if !idx.Dirty() {
+		t.Errorf("dirty should be set after Remove")
+	}
+}
+
+func TestSearchDimMismatch(t *testing.T) {
+	idx := New(3, "m")
+	_ = idx.Upsert("x", []float32{1, 0, 0})
+
+	if _, err := idx.Search([]float32{1, 0}, 1, 0, nil); err == nil {
+		t.Errorf("expected dim mismatch error")
+	}
+}

--- a/internal/tools/executor.go
+++ b/internal/tools/executor.go
@@ -520,6 +520,35 @@ func (te *Executor) ToolDefs() []llm.Tool {
 				},
 			},
 		},
+		{
+			Type: llm.ToolTypeFunction,
+			Function: &llm.FunctionDef{
+				Name: "rebuild_indexes",
+				Description: "Force a full rebuild of memory search indexes from the current state of disk. " +
+					"Both the BM25 lexical index and (when semantic search is configured) the vector index are normally " +
+					"kept in sync incrementally on every memory mutation, plus BM25 is rebuilt automatically on every " +
+					"context compaction. You should NOT call this tool routinely.\n\n" +
+					"Use it ONLY when:\n" +
+					"  - The operator/collaborator explicitly asks you to rebuild the indexes.\n" +
+					"  - You observe a clear inconsistency between memory_search results and known disk state " +
+					"(e.g. a file you just wrote isn't appearing, or search returns a path you've already deleted).\n\n" +
+					"BM25 rebuild is fast (milliseconds) and free. Vector rebuild re-embeds every eligible memory " +
+					"file via the embeddings API; this can take seconds to minutes depending on memory size and " +
+					"throughput, and incurs API cost on paid endpoints. Choose 'lexical' if you only suspect the " +
+					"BM25 index is wrong; 'semantic' if you only suspect the vector index is wrong; 'all' if both " +
+					"or you're unsure. The tool returns counts, timing, and any error encountered.",
+				Parameters: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"scope": map[string]interface{}{
+							"type":        "string",
+							"description": "Which indexes to rebuild. 'all' rebuilds both. 'lexical' rebuilds BM25 only. 'semantic' rebuilds the vector index only.",
+							"enum":        []string{"all", "lexical", "semantic"},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	// update_check / update_apply only when self-update is enabled in
@@ -934,46 +963,51 @@ func indexKey(path string) string {
 
 // Executor handles executing tool calls.
 type Executor struct {
-	memory        *fs.Store
-	index         *bm25.Index
-	telegram      *telegram.Bot
-	sandbox       *docker.Sandbox
-	email         *config.EmailConfig
-	kobold        *kobold.Client  // optional; nil means no perf info in context_status
-	updater       *update.Updater // optional; always non-nil but Enabled() may be false
-	embedder      Embedder        // optional; nil means semantic search disabled
-	vIndex        *vector.Index   // optional; nil means semantic search disabled
-	logger        *slog.Logger
-	http          *http.Client
-	cache         *webCache
-	maxTokens     int
-	currentTokens int
-	limits        config.LimitsConfig
-	maxSleep      time.Duration // upper bound for the `sleep` tool
+	memory         *fs.Store
+	index          *bm25.Index
+	telegram       *telegram.Bot
+	sandbox        *docker.Sandbox
+	email          *config.EmailConfig
+	kobold         *kobold.Client  // optional; nil means no perf info in context_status
+	updater        *update.Updater // optional; always non-nil but Enabled() may be false
+	embedder       Embedder        // optional; nil means semantic search disabled
+	vIndex         *vector.Index   // optional; nil means semantic search disabled
+	embedBatchSize int             // batch size for bulk embed calls (rebuild_indexes); 0 -> default
+	logger         *slog.Logger
+	http           *http.Client
+	cache          *webCache
+	maxTokens      int
+	currentTokens  int
+	limits         config.LimitsConfig
+	maxSleep       time.Duration // upper bound for the `sleep` tool
 }
 
 // New creates a new tool executor. kb, embedder, and vIndex may be nil.
 // embedder and vIndex must be both nil (feature off) or both non-nil
 // (feature on); main.go is responsible for that pairing.
-func New(memory *fs.Store, index *bm25.Index, tg *telegram.Bot, sb *docker.Sandbox, email *config.EmailConfig, kb *kobold.Client, updater *update.Updater, embedder Embedder, vIndex *vector.Index, logger *slog.Logger, maxTokens int, limits config.LimitsConfig, maxSleep time.Duration) *Executor {
+//
+// embedBatchSize is the batch size used by the rebuild_indexes tool;
+// values <= 0 fall back to a sensible default inside the build helper.
+func New(memory *fs.Store, index *bm25.Index, tg *telegram.Bot, sb *docker.Sandbox, email *config.EmailConfig, kb *kobold.Client, updater *update.Updater, embedder Embedder, vIndex *vector.Index, embedBatchSize int, logger *slog.Logger, maxTokens int, limits config.LimitsConfig, maxSleep time.Duration) *Executor {
 	if sb != nil {
 		sb.SetOutputLimit(limits.SandboxOutputChars)
 	}
 	return &Executor{
-		memory:    memory,
-		index:     index,
-		telegram:  tg,
-		sandbox:   sb,
-		email:     email,
-		kobold:    kb,
-		updater:   updater,
-		embedder:  embedder,
-		vIndex:    vIndex,
-		logger:    logger,
-		maxTokens: maxTokens,
-		limits:    limits,
-		maxSleep:  maxSleep,
-		cache:     newWebCache(60 * time.Second),
+		memory:         memory,
+		index:          index,
+		telegram:       tg,
+		sandbox:        sb,
+		email:          email,
+		kobold:         kb,
+		updater:        updater,
+		embedder:       embedder,
+		vIndex:         vIndex,
+		embedBatchSize: embedBatchSize,
+		logger:         logger,
+		maxTokens:      maxTokens,
+		limits:         limits,
+		maxSleep:       maxSleep,
+		cache:          newWebCache(60 * time.Second),
 		http: &http.Client{
 			Timeout: 30 * time.Second,
 			Transport: &http.Transport{
@@ -1064,6 +1098,8 @@ func (te *Executor) Execute(ctx context.Context, call llm.ToolCall) string {
 		return te.sleep(ctx, args)
 	case "get_version":
 		return te.getVersion()
+	case "rebuild_indexes":
+		return te.rebuildIndexes(ctx, args)
 	case "update_check":
 		return te.updateCheck(ctx)
 	case "update_apply":

--- a/internal/tools/executor.go
+++ b/internal/tools/executor.go
@@ -29,6 +29,7 @@ import (
 	"github.com/matjam/faultline/internal/config"
 	"github.com/matjam/faultline/internal/llm"
 	"github.com/matjam/faultline/internal/search/bm25"
+	"github.com/matjam/faultline/internal/search/vector"
 	"github.com/matjam/faultline/internal/update"
 	"github.com/matjam/faultline/internal/version"
 )
@@ -269,7 +270,7 @@ func (te *Executor) ToolDefs() []llm.Tool {
 			Type: llm.ToolTypeFunction,
 			Function: &llm.FunctionDef{
 				Name:        "memory_search",
-				Description: "Search across all memory files by keyword relevance (BM25). Returns up to 5 results, each with: file path, relevance score, and content. Long results are clipped with a hint pointing back at memory_read so you can load the full file. Use this to find memories by topic when you don't know the exact file path. Optionally filter by file modification date.",
+				Description: te.memorySearchDescription(),
 				Parameters: map[string]interface{}{
 					"type": "object",
 					"properties": map[string]interface{}{
@@ -940,6 +941,8 @@ type Executor struct {
 	email         *config.EmailConfig
 	kobold        *kobold.Client  // optional; nil means no perf info in context_status
 	updater       *update.Updater // optional; always non-nil but Enabled() may be false
+	embedder      Embedder        // optional; nil means semantic search disabled
+	vIndex        *vector.Index   // optional; nil means semantic search disabled
 	logger        *slog.Logger
 	http          *http.Client
 	cache         *webCache
@@ -949,8 +952,10 @@ type Executor struct {
 	maxSleep      time.Duration // upper bound for the `sleep` tool
 }
 
-// New creates a new tool executor. kb may be nil.
-func New(memory *fs.Store, index *bm25.Index, tg *telegram.Bot, sb *docker.Sandbox, email *config.EmailConfig, kb *kobold.Client, updater *update.Updater, logger *slog.Logger, maxTokens int, limits config.LimitsConfig, maxSleep time.Duration) *Executor {
+// New creates a new tool executor. kb, embedder, and vIndex may be nil.
+// embedder and vIndex must be both nil (feature off) or both non-nil
+// (feature on); main.go is responsible for that pairing.
+func New(memory *fs.Store, index *bm25.Index, tg *telegram.Bot, sb *docker.Sandbox, email *config.EmailConfig, kb *kobold.Client, updater *update.Updater, embedder Embedder, vIndex *vector.Index, logger *slog.Logger, maxTokens int, limits config.LimitsConfig, maxSleep time.Duration) *Executor {
 	if sb != nil {
 		sb.SetOutputLimit(limits.SandboxOutputChars)
 	}
@@ -962,6 +967,8 @@ func New(memory *fs.Store, index *bm25.Index, tg *telegram.Bot, sb *docker.Sandb
 		email:     email,
 		kobold:    kb,
 		updater:   updater,
+		embedder:  embedder,
+		vIndex:    vIndex,
 		logger:    logger,
 		maxTokens: maxTokens,
 		limits:    limits,
@@ -1030,7 +1037,7 @@ func (te *Executor) Execute(ctx context.Context, call llm.ToolCall) string {
 	case "memory_list":
 		return te.memoryList(args)
 	case "memory_search":
-		return te.memorySearch(args)
+		return te.memorySearch(ctx, args)
 	case "memory_delete":
 		return te.memoryDelete(args)
 	case "memory_restore":
@@ -1265,8 +1272,9 @@ func (te *Executor) memoryWrite(argsJSON string) string {
 		return fmt.Sprintf("Error: %s", err)
 	}
 
-	// Update search index
+	// Update search indexes (BM25 always; vector index iff enabled).
 	te.index.Update(indexKey(args.Path), args.Content)
+	te.reindexVector(args.Path, args.Content)
 
 	te.logger.Info("memory written", "path", args.Path, "size", len(args.Content))
 	return fmt.Sprintf("Successfully wrote %d bytes to %s", len(args.Content), args.Path)
@@ -1329,7 +1337,18 @@ func formatBytes(b int64) string {
 	}
 }
 
-func (te *Executor) memorySearch(argsJSON string) string {
+// memorySearchResultLimit is the per-section result count. Both BM25
+// and (when enabled) semantic each return up to this many; total
+// results returned to the LLM may be up to 2x.
+const memorySearchResultLimit = 5
+
+// memorySearchSemanticMinScore is the cosine similarity floor for
+// semantic results. Below this they're noisy enough to hurt more than
+// help. Tuned empirically; OpenAI text-embedding-3-small produces
+// scores in roughly [0.1, 0.9] for in-domain queries.
+const memorySearchSemanticMinScore = 0.30
+
+func (te *Executor) memorySearch(ctx context.Context, argsJSON string) string {
 	var args struct {
 		Query          string `json:"query"`
 		ModifiedAfter  string `json:"modified_after"`
@@ -1343,7 +1362,8 @@ func (te *Executor) memorySearch(argsJSON string) string {
 		return "Error: query is required"
 	}
 
-	// Build a date filter if either bound is provided.
+	// Build a date filter if either bound is provided. Used by both
+	// search modes so date scoping has consistent semantics.
 	var filter func(string) bool
 	if args.ModifiedAfter != "" || args.ModifiedBefore != "" {
 		var after, before time.Time
@@ -1379,14 +1399,47 @@ func (te *Executor) memorySearch(argsJSON string) string {
 		}
 	}
 
-	results := te.index.Search(args.Query, 5, filter)
-	if len(results) == 0 {
+	lexical := te.index.Search(args.Query, memorySearchResultLimit, filter)
+
+	// Semantic pass — only if embeddings are configured. Errors here
+	// are logged and swallowed; the lexical results still go out.
+	var semantic []vector.Result
+	if te.vectorEnabled() {
+		qvec, err := te.embedQuery(ctx, args.Query)
+		if err != nil {
+			te.logger.Warn("memory_search: embed query failed; lexical only",
+				slog.String("err", err.Error()))
+		} else {
+			res, sErr := te.vIndex.Search(qvec, memorySearchResultLimit, memorySearchSemanticMinScore, filter)
+			if sErr != nil {
+				te.logger.Warn("memory_search: vector search failed; lexical only",
+					slog.String("err", sErr.Error()))
+			} else {
+				semantic = res
+			}
+		}
+	}
+
+	if len(lexical) == 0 && len(semantic) == 0 {
 		return "No matching memories found."
 	}
 
 	var sb strings.Builder
 	limit := te.limits.MemorySearchResultChars
-	for i, r := range results {
+
+	// When semantic is configured, emit clearly labeled sections so
+	// the LLM can pick which set of hits is more relevant. When it's
+	// not, fall back to the original single-list shape so we don't
+	// clutter the output for deployments without embeddings.
+	dualMode := te.vectorEnabled()
+
+	if dualMode {
+		sb.WriteString("=== Lexical results (BM25) ===\n")
+		if len(lexical) == 0 {
+			sb.WriteString("(no matches)\n")
+		}
+	}
+	for i, r := range lexical {
 		content := r.Content
 		total := len(content)
 		var tail string
@@ -1397,6 +1450,33 @@ func (te *Executor) memorySearch(argsJSON string) string {
 		}
 		fmt.Fprintf(&sb, "--- Result %d: %s (score: %.2f) ---\n%s%s\n\n",
 			i+1, r.Path, r.Score, content, tail)
+	}
+
+	if dualMode {
+		sb.WriteString("=== Semantic results ===\n")
+		if len(semantic) == 0 {
+			sb.WriteString("(no matches above similarity threshold)\n")
+		}
+		for i, r := range semantic {
+			// Read the file content for the preview. The vector index
+			// only stores the path + vector, so we go back to disk.
+			// In practice the file is small and this is fast.
+			content, err := te.memory.Read(r.Path)
+			if err != nil {
+				fmt.Fprintf(&sb, "--- Result %d: %s (score: %.2f) ---\n[file unreadable: %s]\n\n",
+					i+1, r.Path, r.Score, err)
+				continue
+			}
+			total := len(content)
+			var tail string
+			if limit > 0 && total > limit {
+				content = content[:limit]
+				tail = fmt.Sprintf("\n[truncated: showing first %d of %d chars; call memory_read with path=%q to read the full file, or with offset=%d to continue from where this preview ends]",
+					limit, total, r.Path, lineCount(content)+1)
+			}
+			fmt.Fprintf(&sb, "--- Result %d: %s (score: %.2f) ---\n%s%s\n\n",
+				i+1, r.Path, r.Score, content, tail)
+		}
 	}
 
 	return sb.String()
@@ -1421,11 +1501,15 @@ func (te *Executor) memoryDelete(argsJSON string) string {
 		return fmt.Sprintf("Error: %s", err)
 	}
 
-	// Remove from search index -- for directories, remove all entries under the path
+	// Remove from search indexes -- for directories, remove all entries
+	// under the path. Both BM25 and the vector index (when enabled) get
+	// the same treatment.
 	if stat != nil && stat.IsDir {
 		te.index.RemovePrefix(indexKey(args.Path + "/"))
+		te.removeVectorPrefix(args.Path)
 	} else {
 		te.index.Remove(indexKey(args.Path))
+		te.removeVector(args.Path)
 	}
 
 	te.logger.Info("memory deleted (moved to trash)", "path", args.Path)
@@ -1453,14 +1537,17 @@ func (te *Executor) memoryRestore(argsJSON string) string {
 		return fmt.Sprintf("Error: %s", err)
 	}
 
-	// Re-index the restored file(s) -- could be a single file or a directory
+	// Re-index the restored file(s) -- could be a single file or a directory.
+	// Both indexes (BM25 and vector) get refreshed.
 	stat, statErr := te.memory.Stat(restoredPath)
 	if statErr == nil && stat.IsDir {
 		te.reindexDir(restoredPath)
+		te.reindexVectorDir(restoredPath)
 	} else {
 		content, readErr := te.memory.Read(restoredPath)
 		if readErr == nil {
 			te.index.Update(indexKey(restoredPath), content)
+			te.reindexVector(restoredPath, content)
 		}
 	}
 
@@ -1541,15 +1628,20 @@ func (te *Executor) memoryMove(argsJSON string) string {
 		return fmt.Sprintf("Error: %s", err)
 	}
 
-	// Update search index: remove old entries, add new ones
+	// Update search indexes: remove old entries, add new ones. Vector
+	// index can rename without re-embedding for files (content unchanged);
+	// directories require a walk because per-file paths changed.
 	if isDir {
 		te.index.RemovePrefix(indexKey(args.Source + "/"))
+		te.removeVectorPrefix(args.Source)
 		te.reindexDir(args.Destination)
+		te.reindexVectorDir(args.Destination)
 	} else {
 		te.index.Remove(indexKey(args.Source))
 		if readErr == nil {
 			te.index.Update(indexKey(args.Destination), oldContent)
 		}
+		te.renameVector(args.Source, args.Destination)
 	}
 
 	te.logger.Info("memory moved", "from", args.Source, "to", args.Destination)
@@ -1909,10 +2001,11 @@ func (te *Executor) memoryEdit(argsJSON string) string {
 		return fmt.Sprintf("Error: %s", err)
 	}
 
-	// Update search index with new content
+	// Update search indexes with new content (BM25 always; vector iff enabled).
 	content, readErr := te.memory.Read(args.Path)
 	if readErr == nil {
 		te.index.Update(indexKey(args.Path), content)
+		te.reindexVector(args.Path, content)
 	}
 
 	te.logger.Info("memory edited", "path", args.Path, "replacements", count)
@@ -1942,10 +2035,11 @@ func (te *Executor) memoryAppend(argsJSON string) string {
 		return fmt.Sprintf("Error: %s", err)
 	}
 
-	// Update search index with new content
+	// Update search indexes with the full file content after append.
 	content, readErr := te.memory.Read(args.Path)
 	if readErr == nil {
 		te.index.Update(indexKey(args.Path), content)
+		te.reindexVector(args.Path, content)
 	}
 
 	te.logger.Info("memory appended", "path", args.Path, "size", len(args.Content))
@@ -1977,10 +2071,11 @@ func (te *Executor) memoryInsert(argsJSON string) string {
 		return fmt.Sprintf("Error: %s", err)
 	}
 
-	// Update search index with new content
+	// Update search indexes with the full file content after insert.
 	content, readErr := te.memory.Read(args.Path)
 	if readErr == nil {
 		te.index.Update(indexKey(args.Path), content)
+		te.reindexVector(args.Path, content)
 	}
 
 	te.logger.Info("memory insert", "path", args.Path, "at_line", args.Line)

--- a/internal/tools/vector.go
+++ b/internal/tools/vector.go
@@ -2,7 +2,9 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"time"
@@ -221,6 +223,249 @@ func (te *Executor) embedQuery(ctx context.Context, query string) ([]float32, er
 // at unexported fields.
 func (te *Executor) VectorIndex() *vector.Index {
 	return te.vIndex
+}
+
+// rebuildIndexes is the handler for the rebuild_indexes tool. It does
+// a full rebuild of one or both search indexes from current disk
+// state and returns a human-readable summary the LLM can pass through
+// to the operator.
+func (te *Executor) rebuildIndexes(ctx context.Context, argsJSON string) string {
+	var args struct {
+		Scope string `json:"scope"`
+	}
+	if argsJSON != "" {
+		if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+			return fmt.Sprintf("Error parsing arguments: %s", err)
+		}
+	}
+
+	scope := strings.ToLower(strings.TrimSpace(args.Scope))
+	if scope == "" {
+		scope = "all"
+	}
+	switch scope {
+	case "all", "lexical", "semantic":
+	default:
+		return fmt.Sprintf("Error: invalid scope %q (expected 'all', 'lexical', or 'semantic')", args.Scope)
+	}
+
+	rebuildLexical := scope == "all" || scope == "lexical"
+	rebuildSemantic := scope == "all" || scope == "semantic"
+
+	var sb strings.Builder
+	sb.WriteString("Index rebuild summary:\n")
+
+	// Lexical (BM25) — always available, always cheap.
+	if rebuildLexical {
+		start := time.Now()
+		docs, err := te.memory.AllFiles()
+		if err != nil {
+			fmt.Fprintf(&sb, "  - BM25 (lexical): FAILED to list memory: %s\n", err)
+		} else {
+			te.index.Build(docs)
+			fmt.Fprintf(&sb, "  - BM25 (lexical): %d documents indexed in %s.\n",
+				len(docs), time.Since(start).Round(time.Millisecond))
+			te.logger.Info("rebuild_indexes: BM25 rebuilt",
+				slog.Int("documents", len(docs)),
+				slog.Duration("duration", time.Since(start)))
+		}
+	}
+
+	// Semantic (vector) — only when configured.
+	if rebuildSemantic {
+		switch {
+		case !te.vectorEnabled():
+			sb.WriteString("  - Vector (semantic): SKIPPED — semantic search is not configured ([embeddings].enabled=false or probe failed at startup).\n")
+		default:
+			res, err := RebuildVectorIndex(ctx, te.embedder, te.vIndex, te.memory, te.embedBatchSize, te.logger)
+			if err != nil {
+				fmt.Fprintf(&sb, "  - Vector (semantic): PARTIAL — %d/%d embedded in %s before failure: %s\n",
+					res.Embedded, res.Eligible, res.Duration.Round(time.Millisecond), err)
+			} else {
+				fmt.Fprintf(&sb, "  - Vector (semantic): %d documents embedded in %s (%d eligible files; ineligible=prompts/.trash/empty).\n",
+					res.Embedded, res.Duration.Round(time.Millisecond), res.Eligible)
+			}
+		}
+	}
+
+	if !rebuildLexical && !rebuildSemantic {
+		// Defensive; the validation above prevents this.
+		return "Error: nothing to rebuild for the given scope."
+	}
+
+	sb.WriteString("\nNote: incremental updates from memory_write/edit/append/insert/delete/move/restore keep both indexes in sync between rebuilds. ")
+	sb.WriteString("Avoid calling rebuild_indexes routinely.")
+	return sb.String()
+}
+
+// ShouldIndexMemoryPath reports whether a memory path is eligible for
+// semantic indexing. Exported so main.go's reconcile pass and any
+// future caller can apply the same exclusion rule (skip prompts/ and
+// .trash/) without duplicating the predicate.
+func ShouldIndexMemoryPath(path string) bool {
+	return shouldIndexPath(path)
+}
+
+// vectorBatchTimeout bounds a single /v1/embeddings batch call during
+// bulk reconcile/rebuild. Independent of the per-mutation timeout
+// (vectorEmbedTimeout) because batches can legitimately take longer
+// than a single-file embed; a hung server still can't stall the
+// whole pass forever.
+const vectorBatchTimeout = 60 * time.Second
+
+// VectorBuildResult summarizes a Reconcile/Rebuild pass.
+type VectorBuildResult struct {
+	// Embedded is the number of vectors successfully written this pass.
+	Embedded int
+	// Eligible is the number of memory files that qualified for
+	// embedding (after exclusion of prompts/, .trash/, and empty files).
+	Eligible int
+	// Skipped is the number of eligible files that were already in
+	// the index and not re-embedded. Always 0 for a full Rebuild;
+	// for Reconcile, this is Eligible - Embedded when no errors hit.
+	Skipped int
+	// Duration is wall-clock time for the pass.
+	Duration time.Duration
+}
+
+// ReconcileVectorIndex embeds memory files that are eligible but
+// missing from the index. Files already present are left as-is. Used
+// at startup so a restart with an existing on-disk index doesn't
+// re-pay the embedding cost for files that haven't changed.
+//
+// Empty files are skipped. Files larger than maxEmbedInputBytes are
+// truncated to that prefix (matching the per-mutation reindex
+// behavior). Errors abort the pass; vectors written before the
+// error are preserved in the index.
+func ReconcileVectorIndex(ctx context.Context, embedder Embedder, idx *vector.Index, memory *fs.Store, batchSize int, logger *slog.Logger) (VectorBuildResult, error) {
+	return runVectorBuild(ctx, embedder, idx, memory, batchSize, false, logger)
+}
+
+// RebuildVectorIndex clears the in-memory vector index and re-embeds
+// every eligible memory file from scratch. Used by the
+// rebuild_indexes tool when the LLM observes inconsistency or the
+// operator explicitly asks for a rebuild.
+//
+// The reset uses the embedder's current dim and model identifier, so
+// switching embedders is not the intended use of this function (that
+// happens automatically at startup via ErrModelMismatch).
+func RebuildVectorIndex(ctx context.Context, embedder Embedder, idx *vector.Index, memory *fs.Store, batchSize int, logger *slog.Logger) (VectorBuildResult, error) {
+	idx.Reset(embedder.Dim(), embedder.Model())
+	return runVectorBuild(ctx, embedder, idx, memory, batchSize, true, logger)
+}
+
+// runVectorBuild is the shared embed-and-upsert loop used by both
+// Reconcile (full=false: skip files already in the index) and
+// Rebuild (full=true: index has been cleared so every file qualifies).
+func runVectorBuild(ctx context.Context, embedder Embedder, idx *vector.Index, memory *fs.Store, batchSize int, full bool, logger *slog.Logger) (VectorBuildResult, error) {
+	start := time.Now()
+	res := VectorBuildResult{}
+
+	all, err := memory.AllFiles()
+	if err != nil {
+		return res, fmt.Errorf("list memory files: %w", err)
+	}
+
+	type pending struct {
+		path string
+		text string
+	}
+	var queue []pending
+
+	for path, content := range all {
+		if !ShouldIndexMemoryPath(path) {
+			continue
+		}
+		text := strings.TrimSpace(content)
+		if text == "" {
+			continue
+		}
+		res.Eligible++
+		if !full && idx.Has(path) {
+			res.Skipped++
+			continue
+		}
+		if len(text) > maxEmbedInputBytes {
+			text = text[:maxEmbedInputBytes]
+		}
+		queue = append(queue, pending{path: path, text: text})
+	}
+
+	if len(queue) == 0 {
+		res.Duration = time.Since(start)
+		mode := "reconcile"
+		if full {
+			mode = "rebuild"
+		}
+		logger.Info("vector "+mode+": nothing to do",
+			slog.Int("eligible", res.Eligible),
+			slog.Int("skipped", res.Skipped))
+		return res, nil
+	}
+
+	if batchSize <= 0 {
+		batchSize = 100
+	}
+
+	mode := "reconcile"
+	if full {
+		mode = "rebuild"
+	}
+	logger.Info("vector "+mode+" pass starting",
+		slog.Int("count", len(queue)),
+		slog.Int("batch_size", batchSize))
+
+	for i := 0; i < len(queue); i += batchSize {
+		end := i + batchSize
+		if end > len(queue) {
+			end = len(queue)
+		}
+		batch := queue[i:end]
+
+		texts := make([]string, len(batch))
+		for j, p := range batch {
+			texts[j] = p.text
+		}
+
+		batchCtx, cancel := context.WithTimeout(ctx, vectorBatchTimeout)
+		vecs, err := embedder.Embed(batchCtx, texts)
+		cancel()
+		if err != nil {
+			res.Duration = time.Since(start)
+			return res, fmt.Errorf("embed batch starting at %d: %w", i, err)
+		}
+		if len(vecs) != len(batch) {
+			res.Duration = time.Since(start)
+			return res, fmt.Errorf("embed batch starting at %d: got %d vecs for %d inputs", i, len(vecs), len(batch))
+		}
+		for j, p := range batch {
+			if err := idx.Upsert(p.path, vecs[j]); err != nil {
+				logger.Warn("vector "+mode+": upsert failed; continuing",
+					slog.String("path", p.path),
+					slog.String("err", err.Error()))
+				continue
+			}
+			res.Embedded++
+		}
+
+		select {
+		case <-ctx.Done():
+			res.Duration = time.Since(start)
+			logger.Info("vector "+mode+": canceled mid-pass",
+				slog.Int("embedded", res.Embedded),
+				slog.Int("total", len(queue)))
+			return res, ctx.Err()
+		default:
+		}
+	}
+
+	res.Duration = time.Since(start)
+	logger.Info("vector "+mode+" complete",
+		slog.Int("embedded", res.Embedded),
+		slog.Int("eligible", res.Eligible),
+		slog.Int("skipped", res.Skipped),
+		slog.Duration("duration", res.Duration))
+	return res, nil
 }
 
 // memorySearchDescription returns the LLM-facing description for the

--- a/internal/tools/vector.go
+++ b/internal/tools/vector.go
@@ -1,0 +1,244 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/matjam/faultline/internal/adapters/memory/fs"
+	"github.com/matjam/faultline/internal/search/vector"
+)
+
+// Embedder is the consumer-side contract for an embeddings backend.
+// Implemented by *internal/adapters/embeddings/openai.Client. Defined
+// here (where it's consumed) rather than in the agent's ports.go
+// because the agent loop never embeds — only the tool dispatcher does.
+type Embedder interface {
+	// Embed returns one vector per input string, in input order. An
+	// implementation MUST return either len(texts) vectors or a
+	// non-nil error.
+	Embed(ctx context.Context, texts []string) ([][]float32, error)
+
+	// Dim returns the vector dimensionality. Must be stable for the
+	// lifetime of the embedder; called by the dispatcher to allocate
+	// query buffers.
+	Dim() int
+
+	// Model is a free-form identifier persisted alongside the index
+	// so a model change triggers a rebuild on next startup.
+	Model() string
+}
+
+// maxEmbedInputBytes is the byte-length cap applied to file content
+// before it's sent to the embeddings API. text-embedding-3-small
+// accepts up to 8192 tokens (~30 KB of typical English). We truncate
+// rather than chunk for v1 because:
+//   - typical memory files are well under this limit;
+//   - chunking adds complexity (multi-vector files, score aggregation,
+//     dedup on return) that doesn't pay off until we see real
+//     long-document use cases.
+//
+// When this limit fires, the embedding represents only the prefix.
+// Truncation is logged at debug level.
+const maxEmbedInputBytes = 30000
+
+// vectorEmbedTimeout is the per-mutation embed call timeout.
+// Independent of the per-request timeout in the embedder itself
+// (which applies to bulk reconciles too); this exists so that
+// embed-on-mutation never blocks a memory-write tool for too long
+// even if the configured embeddings.timeout is generous.
+const vectorEmbedTimeout = 30 * time.Second
+
+// vectorEnabled reports whether semantic indexing is wired up. Both
+// the embedder and the index must be non-nil; either being nil is
+// the "feature disabled" path and all helper methods become no-ops.
+func (te *Executor) vectorEnabled() bool {
+	return te.embedder != nil && te.vIndex != nil
+}
+
+// shouldIndexPath reports whether a path is eligible for semantic
+// indexing. Operational paths — the prompts/ tree (self-modifying
+// agent prompts) and the trash — are excluded so semantic search
+// never surfaces them as memory hits.
+func shouldIndexPath(path string) bool {
+	if path == "" {
+		return false
+	}
+	if strings.HasPrefix(path, "prompts/") || path == "prompts" {
+		return false
+	}
+	if fs.IsTrashPath(path) {
+		return false
+	}
+	return true
+}
+
+// truncateForEmbedding returns text trimmed to maxEmbedInputBytes if
+// it would otherwise exceed the embedding model's input limit. Returns
+// the (possibly trimmed) text and a bool indicating whether truncation
+// occurred.
+func truncateForEmbedding(text string) (string, bool) {
+	if len(text) <= maxEmbedInputBytes {
+		return text, false
+	}
+	return text[:maxEmbedInputBytes], true
+}
+
+// reindexVector embeds the current content of the file at path and
+// upserts the result into the vector index. No-op when the feature is
+// disabled, when the path is operational, or when the file content is
+// empty (vector indexing of empty documents would produce a zero
+// vector that can't be normalised).
+//
+// Failure mode: any error is logged at warn and swallowed. The vector
+// index is best-effort enrichment; a failed embed never blocks the
+// memory write that triggered it. The unindexed file is reachable on
+// the next mutation or via the startup reconcile pass.
+func (te *Executor) reindexVector(path, content string) {
+	if !te.vectorEnabled() || !shouldIndexPath(indexKey(path)) {
+		return
+	}
+	if strings.TrimSpace(content) == "" {
+		// Don't index empty files — the embedding API typically
+		// rejects empty input and even when it doesn't, the resulting
+		// vector is meaningless. Remove any stale entry.
+		te.vIndex.Remove(indexKey(path))
+		return
+	}
+
+	text, truncated := truncateForEmbedding(content)
+	if truncated {
+		te.logger.Debug("embedding truncated for indexing",
+			slog.String("path", path),
+			slog.Int("orig_bytes", len(content)),
+			slog.Int("sent_bytes", len(text)))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), vectorEmbedTimeout)
+	defer cancel()
+
+	vecs, err := te.embedder.Embed(ctx, []string{text})
+	if err != nil {
+		te.logger.Warn("embed-on-mutation failed; file will remain unindexed",
+			slog.String("path", path),
+			slog.String("err", err.Error()))
+		return
+	}
+	if len(vecs) != 1 {
+		te.logger.Warn("embed-on-mutation returned wrong count",
+			slog.String("path", path),
+			slog.Int("got", len(vecs)))
+		return
+	}
+
+	if err := te.vIndex.Upsert(indexKey(path), vecs[0]); err != nil {
+		te.logger.Warn("vector upsert failed",
+			slog.String("path", path),
+			slog.String("err", err.Error()))
+	}
+}
+
+// removeVector removes the vector for path from the index. No-op when
+// disabled.
+func (te *Executor) removeVector(path string) {
+	if !te.vectorEnabled() {
+		return
+	}
+	te.vIndex.Remove(indexKey(path))
+}
+
+// removeVectorPrefix removes all vectors under a directory prefix.
+// path should be the directory key without a trailing slash; this
+// helper appends one before delegating, matching the BM25 index's
+// RemovePrefix semantics.
+func (te *Executor) removeVectorPrefix(path string) {
+	if !te.vectorEnabled() {
+		return
+	}
+	te.vIndex.RemovePrefix(indexKey(path))
+}
+
+// renameVector moves a vector from oldPath to newPath without re-
+// embedding (the file content hasn't changed). Used after memory_move
+// on individual files.
+func (te *Executor) renameVector(oldPath, newPath string) {
+	if !te.vectorEnabled() {
+		return
+	}
+	te.vIndex.Rename(indexKey(oldPath), indexKey(newPath))
+}
+
+// reindexVectorDir walks all files under the given memory directory
+// and re-embeds each one. Used after directory-level operations
+// (memory_move on a directory, memory_restore of a trashed directory)
+// where individual file paths changed.
+//
+// Errors during the walk or per-file embeds are logged but do not
+// abort the walk; one bad file shouldn't leave the rest unindexed.
+func (te *Executor) reindexVectorDir(dirPath string) {
+	if !te.vectorEnabled() {
+		return
+	}
+	entries, err := te.memory.List(dirPath)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		subPath := dirPath + "/" + e.Name
+		if e.IsDir {
+			te.reindexVectorDir(subPath)
+			continue
+		}
+		content, readErr := te.memory.Read(subPath)
+		if readErr != nil {
+			continue
+		}
+		te.reindexVector(subPath, content)
+	}
+}
+
+// EmbedQuery is a thin wrapper around the embedder for use by the
+// memory_search handler. Returns an error if the embedder is not
+// configured (caller should fall back to lexical-only output).
+func (te *Executor) embedQuery(ctx context.Context, query string) ([]float32, error) {
+	if te.embedder == nil {
+		return nil, errors.New("embeddings disabled")
+	}
+	vecs, err := te.embedder.Embed(ctx, []string{query})
+	if err != nil {
+		return nil, err
+	}
+	if len(vecs) != 1 || len(vecs[0]) == 0 {
+		return nil, errors.New("embed query: empty result")
+	}
+	return vecs[0], nil
+}
+
+// vectorIndex returns the current vector index. May be nil. Provided
+// so wiring code (main.go) can call Save() at shutdown without poking
+// at unexported fields.
+func (te *Executor) VectorIndex() *vector.Index {
+	return te.vIndex
+}
+
+// memorySearchDescription returns the LLM-facing description for the
+// memory_search tool. The description varies based on whether
+// semantic search is wired up so the LLM's mental model matches the
+// tool's actual output shape.
+func (te *Executor) memorySearchDescription() string {
+	if te.vectorEnabled() {
+		return "Search across all memory files. Returns TWO labeled result sections per query: " +
+			"'Lexical results (BM25)' for keyword matches, and 'Semantic results' for meaning-based matches " +
+			"via embedding similarity. Each section has up to 5 results with file path, score, and content. " +
+			"The two sections often surface different files — pick whichever is more relevant for your query, " +
+			"or read both. Use lexical when you remember specific words; use semantic when you remember " +
+			"the topic but not the wording. Long results are clipped with a hint pointing back at memory_read " +
+			"so you can load the full file. Optionally filter by file modification date (applies to both sections)."
+	}
+	return "Search across all memory files by keyword relevance (BM25). Returns up to 5 results, each with: " +
+		"file path, relevance score, and content. Long results are clipped with a hint pointing back at " +
+		"memory_read so you can load the full file. Use this to find memories by topic when you don't know " +
+		"the exact file path. Optionally filter by file modification date."
+}


### PR DESCRIPTION
Adds an opt-in semantic-search layer alongside the existing BM25 index. When `[embeddings]` is configured with an OpenAI-compatible endpoint and model, every memory file (excluding `prompts/` and `.trash/`) is embedded and stored in an in-memory vector index that's persisted to `<memory>/.vector/index.bin` in a custom binary format. `memory_search` then returns BOTH lexical (BM25) and semantic results in clearly labeled sections per query, so the LLM picks whichever is more relevant.

Disabled by default. Falls back to BM25-only output when the feature is off.

## Architecture

- **`internal/search/vector/`** — pure-Go in-memory vector index. Brute-force cosine similarity over `map[string][]float32`. At Faultline's scale (low-thousands of files, 1536-dim vectors) flat scan is sub-millisecond; HNSW/IVF would be overkill. Vectors L2-normalised on `Upsert`. Custom binary format (`FVEC v1`): magic + version + dim + count + model + records. Atomic `Save` via temp+rename. `ErrModelMismatch` triggers a rebuild on model change; `ErrCorrupt` triggers move-aside-and-rebuild (mirrors `state/jsonfile`).
- **`internal/adapters/embeddings/openai/`** — hand-rolled HTTP client for `/v1/embeddings`. Deliberately separate from `internal/adapters/llm/openai/`. `Probe(ctx)` discovers dim with a single embed call; non-fatal at startup.
- **`internal/tools/vector.go`** — `Embedder` interface (consumer-side, since the agent loop never embeds), per-mutation reindex helpers, path-exclusion logic, 30 KB truncation cap, dual-mode `memory_search` description selector.

## Behaviour

- Memory mutations (`memory_write` / `edit` / `append` / `insert` / `restore`) re-embed the affected file synchronously. ~50–200ms latency added; worth it for "search is always current."
- `memory_delete` / `memory_move` keep the indexes in sync — for moves of single files, the vector is renamed (no re-embed; same content, same vector). Directory operations walk the tree.
- Embed failures are logged and swallowed. The vector index is best-effort enrichment, never blocks a memory write.
- Startup reconcile pass embeds any memory file not present in the loaded index, batched to `cfg.Embeddings.BatchSize`. Bulk re-indexing on first enable or after a model change.
- 30s dirty-flag flush loop + final flush on shutdown. Atomic writes via temp+rename.

## Config

```toml
[embeddings]
enabled = false
url = "https://api.openai.com/v1"
api_key = ""
model = "text-embedding-3-small"   # 1536 dim, ~$0.02/1M tokens
timeout = "30s"
batch_size = 100
```

Indexing 10k typical memory files with `text-embedding-3-small` is ~\$0.10 one-time. Works with any OpenAI-compatible server (OpenAI, Ollama, LM Studio, vLLM, llama.cpp).

## Other

- `.gitignore` tightened: `faultline` was matching the `cmd/faultline/` source directory, silently swallowing new files like `cmd/faultline/embeddings.go`. Anchored to `/faultline` to mean the built binary at repo root only.
- Tests: vector index (Upsert/Remove/Search basics, save+load roundtrip, model/dim mismatch detection, corrupt-file detection, dirty flag, prefix removal, rename) + embeddings client (single + batch + ordering + auth + HTTP errors + probe).
- README, AGENTS.md, `config.example.toml`, and the embedded `system.md` prompt all updated.

## Verified

- `go build ./...` clean
- `go test ./...` all green (including new packages)
- `golangci-lint run ./...` 0 issues