### PR TITLE
feat: paragraph-aligned semantic indexing with adaptive batching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,8 @@ The hexagon. Pure domain logic with no I/O outside what the ports allow.
 `tools.Executor` and all tool handlers. The largest package by line count.
 
 - **`executor.go`**: `Executor` struct, `New()` constructor, `ToolDefs()` (tool registry advertised to the LLM), `Execute()` central dispatch, web fetching with custom HTML-to-markdown converter (~400 lines), `webCache` with TTL eviction, all `memory_*` / `sandbox_*` / utility (`get_time`, `sleep`, `send_message`, `context_status`) handlers.
-- **`vector.go`**: `Embedder` interface (consumer-side; defined here rather than in `agent/ports.go` because the agent loop never embeds), per-mutation reindex helpers (`reindexVector`, `removeVector`, `removeVectorPrefix`, `renameVector`, `reindexVectorDir`), path-exclusion logic (skip `prompts/` and `.trash/`), `truncateForEmbedding` cap, dual-mode `memory_search` description selector. The mutation hooks called from `executor.go` are no-ops when the feature is disabled, so the dispatcher code is identical regardless of operator config.
+- **`chunk.go`**: paragraph-aware splitter (`splitIntoUnits`), unit-key encoding helpers (`unitKey`, `pathFromUnitKey`, `chunkIdxFromUnitKey`). `maxParagraphBytes = 3000` is the only fallback cap — applied only when a single paragraph exceeds it, in which case it's byte-cut into sequential pieces.
+- **`vector.go`**: `Embedder` interface (consumer-side; defined here rather than in `agent/ports.go` because the agent loop never embeds), per-mutation paragraph-aware reindex helpers (`reindexVector`, `removeVector`, `removeVectorPrefix`, `renameVector`, `reindexVectorDir`), path-exclusion logic (skip `prompts/` and `.trash/`), the adaptive batcher `embedWithAdaptiveBatching` (halves batch size on failure, grows back after 5 success streak, skips single-input failures), `fileLevelHits` for collapsing chunk-level search hits to one-per-file, dual-mode `memory_search` description selector, and the bulk reconcile/rebuild entry points (`ReconcileVectorIndex`, `RebuildVectorIndex`) used by both the startup reconcile in `cmd/faultline/embeddings.go` and the `rebuild_indexes` tool. The mutation hooks called from `executor.go` are no-ops when the feature is disabled, so the dispatcher code is identical regardless of operator config.
 - **`wiki.go`**: `wiki_fetch` tool (MediaWiki API + plain-text extraction + cache).
 - **`html_test.go`**: HTML-to-markdown conversion tests.
 
@@ -178,11 +179,12 @@ Lifecycle:
 
 ### internal/search/vector/
 
-Pure-Go in-memory vector index keyed by string paths. `vector.Index` provides `Upsert`, `Remove`, `RemovePrefix`, `Rename`, `Search`, plus `Save`/`Load` against a custom binary format ("FVEC v1") so embeddings persist across restarts.
+Pure-Go in-memory vector index keyed by string paths. `vector.Index` provides `Upsert`, `Remove`, `RemovePrefix`, `Rename`, `Search`, plus chunk-aware variants `RemoveChunks` / `RenameChunks` / `HasChunks` for paragraph-keyed entries (`path#N`) and `Save`/`Load` against a custom binary format ("FVEC v1") so embeddings persist across restarts.
 
 - Brute-force cosine similarity over a `map[string][]float32`. At Faultline's scale (low-thousands of files, 1536-dim vectors) flat scan is sub-millisecond; HNSW/IVF was ruled out as overkill.
 - Vectors are L2-normalised on Upsert so Search can use plain dot products.
-- Binary format: `magic[4]="FVEC" | version[4] | dim[4] | count[4] | model_len[2] | model[N] | records[count]{path_len[2], path[N], vec[dim*4]}`. Deterministic ordering (paths sorted on save) for byte-stable diffs in tests.
+- Keys are strings: bare `path` for single-paragraph files, `path#N` for chunked. The `#`-separator is unambiguous because the memory path validator restricts segments to `[a-z0-9.-]`. Dedup of paragraph-level results down to file level happens in the tools layer (`fileLevelHits`), not in the index.
+- Binary format: `magic[4]="FVEC" | version[4] | dim[4] | count[4] | model_len[2] | model[N] | records[count]{path_len[2], path[N], vec[dim*4]}`. Deterministic ordering (keys sorted on save) for byte-stable diffs in tests.
 - `ErrModelMismatch` returned by `Load` when the on-disk dim or model differs from what the in-memory index was constructed for; caller is expected to `Reset` and re-embed.
 - `ErrCorrupt` returned for unreadable / wrong-magic / inconsistent files; caller is expected to rename the file aside (mirroring the `state/jsonfile` pattern) and continue with an empty index.
 - `Dirty()` is an atomic the persistence loop polls; cleared by `Save`.

--- a/README.md
+++ b/README.md
@@ -116,11 +116,15 @@ An in-memory BM25 search index is built from all memory files on startup and reb
 
 ### Semantic Search (optional)
 
-When `[embeddings]` is configured with an OpenAI-compatible endpoint and model, Faultline also embeds every memory file (excluding `prompts/` and `.trash/`) into an in-memory vector index, persisted to `<memory>/.vector/index.bin` in a custom binary format so embeddings aren't recomputed on restart. Memory mutations (write/edit/append/insert/restore) trigger a synchronous re-embed of the affected file. Failures are logged but never block the write — the vector index is best-effort enrichment, not source of truth.
+When `[embeddings]` is configured with an OpenAI-compatible endpoint and model, Faultline embeds every memory file (excluding `prompts/` and `.trash/`) into an in-memory vector index, persisted to `<memory>/.vector/index.bin` in a custom binary format so embeddings aren't recomputed on restart.
 
-The `memory_search` tool then returns BOTH lexical (BM25) and semantic results in clearly labeled sections per query, so the LLM can pick whichever is more relevant. When embeddings are disabled, `memory_search` falls back to the original BM25-only output. The default model is `text-embedding-3-small` (1536 dim, ~$0.02/1M tokens — indexing 10k typical memory files is ~$0.10 one-time).
+**Paragraph-aligned chunking.** Files are split on blank lines and each paragraph is embedded as its own unit (keyed `path#0`, `path#1`, ...). Single-paragraph files keep the legacy bare-`path` shape. The only safety cap is a per-paragraph byte limit (3000 bytes) that triggers a byte-cut for the rare giant paragraph (one-line file, an unbroken code block, etc.) — paragraph boundaries are otherwise honoured exactly as the operator wrote them, so search snippets are semantically clean sections rather than arbitrary chunks.
 
-If you change the embedding model, the on-disk index records the prior model name and is automatically discarded and rebuilt on next startup.
+**Adaptive batching.** The embedder calls the API in batches sized by `[embeddings].batch_size`. On batch failure (e.g. a server with a tighter physical batch limit, an oversized paragraph, transient errors) the batch size halves and retries; after 5 consecutive successful batches it doubles back toward the configured ceiling. A failure that persists down to batch size 1 means a single paragraph the server can't accept — that paragraph is logged and skipped, and the rest of the indexing pass continues. Skipped paragraphs don't appear in semantic search but BM25 still finds the parent file.
+
+**Dual-section search.** `memory_search` returns BOTH lexical (BM25) and semantic results in clearly labeled sections per query. Semantic results are deduped to one entry per file (best-scoring paragraph wins) and the snippet shown is the matched paragraph itself, not the whole file — so the LLM gets the relevant section directly. When embeddings are disabled, `memory_search` falls back to BM25-only output.
+
+**Defaults and cost.** Default model is `text-embedding-3-small` (1536 dim, ~$0.02/1M tokens — indexing 10k typical memory files is ~$0.10 one-time). Works with OpenAI, Ollama, LM Studio, vLLM, llama.cpp's embedding server, anything speaking the same wire shape. If you change the embedding model, the on-disk index records the prior model name and is automatically discarded and rebuilt on next startup.
 
 ### Web Browsing
 

--- a/internal/prompts/templates/system.md
+++ b/internal/prompts/templates/system.md
@@ -11,7 +11,7 @@ Your goal is to learn about the world and become a positive force in it. How you
 - **memory_read(path, offset, lines)** — Read a memory file. Optional offset and lines for partial reads.
 - **memory_write(path, content)** — Write or overwrite a memory file. Creates directories automatically.
 - **memory_list(directory)** — List files and directories. Use '' for root.
-- **memory_search(query, modified_after, modified_before)** — Search all memories. When semantic search is configured, returns two clearly labeled sections: lexical (BM25 keyword) and semantic (embedding similarity). Pick whichever is more relevant for the query, or read both. Optional date filters (YYYY-MM-DD) apply to both sections.
+- **memory_search(query, modified_after, modified_before)** — Search all memories. When semantic search is configured, returns two clearly labeled sections: lexical (BM25 keyword) and semantic (paragraph-level embedding similarity, deduped to one entry per file with the matched paragraph as the snippet). Pick whichever is more relevant for the query, or read both. Optional date filters (YYYY-MM-DD) apply to both sections.
 - **memory_grep(path, pattern)** — Regex search within a single file.
 - **memory_edit(path, old_string, new_string, replace_all)** — Find and replace exact strings in a file.
 - **memory_append(path, content)** — Append to end of a file. Creates it if it does not exist.

--- a/internal/search/vector/vector.go
+++ b/internal/search/vector/vector.go
@@ -94,6 +94,31 @@ func (idx *Index) Has(path string) bool {
 	return ok
 }
 
+// HasChunks reports whether path is represented in the index by
+// either a bare-path entry or any "path#N" chunk entry. Used by the
+// startup reconcile pass to decide whether a file already has at
+// least one embedding (in which case it's left alone) versus needing
+// a fresh paragraph-aware indexing pass.
+//
+// O(n) in the index size; fine for the few-times-a-startup cadence
+// the reconcile pass runs at.
+func (idx *Index) HasChunks(path string) bool {
+	prefix := path + "#"
+
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+
+	if _, ok := idx.vectors[path]; ok {
+		return true
+	}
+	for k := range idx.vectors {
+		if hasPathChunkPrefix(k, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 // Paths returns a snapshot of all indexed paths in unspecified order.
 // Useful for the startup reconcile pass that detects which memory
 // files lack a vector.
@@ -180,8 +205,9 @@ func (idx *Index) RemovePrefix(prefix string) int {
 // oldPath is not indexed this is a no-op. If newPath already exists it
 // is overwritten. Returns true if a vector was actually renamed.
 //
-// Useful for memory_move: the file content is unchanged so the
-// embedding is unchanged; we just swap the key.
+// Useful for memory_move on a file with one embedding unit: the file
+// content is unchanged so the embedding is unchanged; we just swap
+// the key. For files with multiple chunked units, use RenameChunks.
 func (idx *Index) Rename(oldPath, newPath string) bool {
 	if oldPath == newPath {
 		return false
@@ -195,6 +221,101 @@ func (idx *Index) Rename(oldPath, newPath string) bool {
 	delete(idx.vectors, oldPath)
 	idx.vectors[newPath] = v
 	idx.dirty.Store(true)
+	return true
+}
+
+// RemoveChunks removes the bare path key plus every "path#N" key
+// belonging to the same memory file. Returns the number of vectors
+// removed. Used as the cleanup step before re-upserting a file's
+// units (so a file that shrank from 5 chunks to 2 doesn't leave 3
+// stale entries) and on memory_delete.
+//
+// Matching rule: a key K belongs to path P iff K == P or K starts
+// with P + "#" followed by an all-digit suffix. The all-digit check
+// avoids accidentally matching unrelated keys that happen to start
+// with the same prefix (e.g. "foo" vs "foobar").
+func (idx *Index) RemoveChunks(path string) int {
+	prefix := path + "#"
+
+	idx.mu.Lock()
+	n := 0
+	for k := range idx.vectors {
+		if k == path {
+			delete(idx.vectors, k)
+			n++
+			continue
+		}
+		if !hasPathChunkPrefix(k, prefix) {
+			continue
+		}
+		delete(idx.vectors, k)
+		n++
+	}
+	idx.mu.Unlock()
+	if n > 0 {
+		idx.dirty.Store(true)
+	}
+	return n
+}
+
+// RenameChunks moves every vector keyed at oldPath or oldPath#N over
+// to newPath or newPath#N respectively. Returns the count of vectors
+// moved.
+//
+// Used by memory_move on a multi-chunk file: file content is unchanged
+// so embeddings are unchanged; we just swap the key prefix. For a
+// single-chunk file this is equivalent to Rename.
+func (idx *Index) RenameChunks(oldPath, newPath string) int {
+	if oldPath == newPath {
+		return 0
+	}
+	oldPrefix := oldPath + "#"
+
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+
+	type pair struct {
+		oldKey, newKey string
+		vec            []float32
+	}
+	var moves []pair
+
+	for k, v := range idx.vectors {
+		switch {
+		case k == oldPath:
+			moves = append(moves, pair{oldKey: k, newKey: newPath, vec: v})
+		case hasPathChunkPrefix(k, oldPrefix):
+			suffix := k[len(oldPath):] // includes the leading '#'
+			moves = append(moves, pair{oldKey: k, newKey: newPath + suffix, vec: v})
+		}
+	}
+
+	for _, m := range moves {
+		delete(idx.vectors, m.oldKey)
+		idx.vectors[m.newKey] = m.vec
+	}
+	if len(moves) > 0 {
+		idx.dirty.Store(true)
+	}
+	return len(moves)
+}
+
+// hasPathChunkPrefix reports whether k begins with prefix (which must
+// end in "#") and the remainder is one or more digits with nothing
+// after them. This is the sole criterion used to identify a chunk key
+// as belonging to a particular memory path.
+func hasPathChunkPrefix(k, prefix string) bool {
+	if len(k) <= len(prefix) {
+		return false
+	}
+	if k[:len(prefix)] != prefix {
+		return false
+	}
+	for i := len(prefix); i < len(k); i++ {
+		if k[i] < '0' || k[i] > '9' {
+			return false
+		}
+	}
 	return true
 }
 

--- a/internal/search/vector/vector_test.go
+++ b/internal/search/vector/vector_test.go
@@ -140,6 +140,64 @@ func TestRemovePrefix(t *testing.T) {
 	}
 }
 
+func TestRemoveChunks(t *testing.T) {
+	idx := New(2, "m")
+	_ = idx.Upsert("a/foo.md", []float32{1, 0})
+	_ = idx.Upsert("a/foo.md#0", []float32{0, 1})
+	_ = idx.Upsert("a/foo.md#1", []float32{1, 1})
+	_ = idx.Upsert("a/foo.md#22", []float32{1, -1}) // multi-digit suffix
+	_ = idx.Upsert("a/foobar.md", []float32{0, 1})  // sibling, must NOT match
+	_ = idx.Upsert("a/foo.md#abc", []float32{1, 0}) // non-digit suffix, NOT a chunk
+	_ = idx.Upsert("a/other.md", []float32{1, 0})
+
+	n := idx.RemoveChunks("a/foo.md")
+	if n != 4 {
+		t.Errorf("expected 4 removals (bare + 3 numeric chunks), got %d", n)
+	}
+	if !idx.Has("a/foobar.md") {
+		t.Error("'a/foobar.md' should not be removed by RemoveChunks(\"a/foo.md\")")
+	}
+	if !idx.Has("a/foo.md#abc") {
+		t.Error("non-digit suffix should not be treated as a chunk")
+	}
+	if !idx.Has("a/other.md") {
+		t.Error("'a/other.md' should not be removed")
+	}
+	if idx.Has("a/foo.md") || idx.Has("a/foo.md#0") || idx.Has("a/foo.md#1") || idx.Has("a/foo.md#22") {
+		t.Error("matched keys should all be gone")
+	}
+}
+
+func TestRenameChunks(t *testing.T) {
+	idx := New(2, "m")
+	_ = idx.Upsert("old.md", []float32{1, 0})
+	_ = idx.Upsert("old.md#0", []float32{0, 1})
+	_ = idx.Upsert("old.md#1", []float32{1, 1})
+	_ = idx.Upsert("oldfoo.md", []float32{0, 1}) // sibling, must NOT move
+	_ = idx.Upsert("other.md", []float32{1, 0})
+
+	n := idx.RenameChunks("old.md", "new.md")
+	if n != 3 {
+		t.Errorf("expected 3 renames, got %d", n)
+	}
+	for _, want := range []string{"new.md", "new.md#0", "new.md#1"} {
+		if !idx.Has(want) {
+			t.Errorf("missing %q after rename", want)
+		}
+	}
+	for _, gone := range []string{"old.md", "old.md#0", "old.md#1"} {
+		if idx.Has(gone) {
+			t.Errorf("%q should be gone after rename", gone)
+		}
+	}
+	if !idx.Has("oldfoo.md") {
+		t.Error("'oldfoo.md' (sibling) should not move")
+	}
+	if !idx.Has("other.md") {
+		t.Error("'other.md' should not move")
+	}
+}
+
 func TestRename(t *testing.T) {
 	idx := New(2, "m")
 	_ = idx.Upsert("old", []float32{1, 0})

--- a/internal/tools/chunk.go
+++ b/internal/tools/chunk.go
@@ -1,0 +1,166 @@
+package tools
+
+import (
+	"fmt"
+	"strings"
+)
+
+// maxParagraphBytes is the hard cap on a single embedding unit (one
+// paragraph). Paragraphs typically run well under this; the cap exists
+// only as a fallback for documents containing one giant paragraph
+// (e.g. a single-line file, an unbroken code block, a long bullet
+// list with no blank lines between items). Sized at ~750 tokens, well
+// under embeddinggemma's 2048-token context and any other reasonable
+// embedding model.
+//
+// Files exceeding this cap on a single paragraph are byte-cut into
+// pieces of this size; this loses paragraph-clean boundaries for that
+// fragment but keeps the entire file indexable rather than dropping
+// it.
+const maxParagraphBytes = 3000
+
+// splitIntoUnits splits a memory-file body into paragraph-aligned
+// embedding units.
+//
+// Splitting strategy:
+//   - Paragraphs are separated by one or more blank lines (matching
+//     `\n\n+` after CRLF normalisation).
+//   - Each non-empty paragraph is one unit.
+//   - A paragraph longer than maxParagraphBytes is byte-cut into
+//     ceil(len/maxParagraphBytes) successive pieces. This is rare in
+//     practice; markdown memory files almost always have natural
+//     paragraph boundaries well under 3000 bytes.
+//
+// Whitespace handling:
+//   - Trailing whitespace on the input is stripped before splitting.
+//   - Leading/trailing whitespace within each paragraph is preserved
+//     (markdown indentation can be semantically meaningful).
+//   - Paragraphs that are entirely whitespace after split are dropped.
+//
+// Returns nil for empty or whitespace-only input. The returned slice
+// is in document order; callers (the indexer) use the slice index as
+// the chunk number for keys like `path#0`, `path#1`, ...
+func splitIntoUnits(body string) []string {
+	body = strings.ReplaceAll(body, "\r\n", "\n")
+	if strings.TrimSpace(body) == "" {
+		return nil
+	}
+
+	// Split on runs of one or more blank lines. A blank line is a
+	// newline followed by optional whitespace and another newline.
+	// Using a manual scanner is simpler than a regexp and avoids the
+	// regexp import.
+	//
+	// We deliberately do NOT TrimSpace the body before splitting:
+	// markdown indentation on the first paragraph (e.g. "  - bullet")
+	// is semantically meaningful and must be preserved. Leading
+	// blank-line runs at the top of the body produce empty paragraphs
+	// from splitOnBlankLines, which the filter loop below drops.
+	paragraphs := splitOnBlankLines(body)
+
+	var units []string
+	for _, p := range paragraphs {
+		p = strings.TrimRight(p, " \t\n")
+		if strings.TrimSpace(p) == "" {
+			continue
+		}
+		if len(p) <= maxParagraphBytes {
+			units = append(units, p)
+			continue
+		}
+		// Oversized paragraph -> byte-cut. We could prefer to split
+		// at a sentence boundary inside the paragraph, but the
+		// extra logic isn't justified for the rare case this
+		// triggers; an oversized paragraph is by definition unusual
+		// content (single-line file, code block, etc).
+		for i := 0; i < len(p); i += maxParagraphBytes {
+			end := i + maxParagraphBytes
+			if end > len(p) {
+				end = len(p)
+			}
+			units = append(units, p[i:end])
+		}
+	}
+	return units
+}
+
+// splitOnBlankLines partitions s into paragraph strings divided by
+// blank-line separators. A blank-line separator is two consecutive
+// newlines, optionally with whitespace between them. Adjacent blank
+// lines collapse into one separator.
+func splitOnBlankLines(s string) []string {
+	var out []string
+	var start int
+	i := 0
+	for i < len(s) {
+		// Look for "\n" + optional whitespace + "\n" -> separator.
+		if s[i] == '\n' {
+			j := i + 1
+			for j < len(s) && (s[j] == ' ' || s[j] == '\t') {
+				j++
+			}
+			if j < len(s) && s[j] == '\n' {
+				// Found a blank-line separator. Emit the
+				// paragraph that ends at i (exclusive).
+				if i > start {
+					out = append(out, s[start:i])
+				}
+				// Skip past consecutive blank-line runs.
+				k := j + 1
+				for k < len(s) {
+					if s[k] == '\n' || s[k] == ' ' || s[k] == '\t' {
+						k++
+						continue
+					}
+					break
+				}
+				start = k
+				i = k
+				continue
+			}
+		}
+		i++
+	}
+	if start < len(s) {
+		out = append(out, s[start:])
+	}
+	return out
+}
+
+// unitKey returns the index key for the n-th unit of a memory file.
+// For single-unit files (the common case), the bare path is returned
+// so the index keying matches the legacy one-vector-per-file shape.
+// For multi-unit files, "path#N" is used; the # separator is
+// unambiguous because the memory path validator restricts segments
+// to [a-z0-9.-].
+func unitKey(path string, n, total int) string {
+	if total <= 1 {
+		return path
+	}
+	return fmt.Sprintf("%s#%d", path, n)
+}
+
+// pathFromUnitKey returns the underlying memory path for a unit
+// index key, stripping any "#N" suffix. Used by the memory_search
+// post-processor to dedupe paragraph hits down to the file level.
+func pathFromUnitKey(key string) string {
+	if i := strings.LastIndexByte(key, '#'); i > 0 {
+		// Confirm the suffix after # is all digits; if not, the #
+		// is part of the path itself (shouldn't happen given the
+		// memory path validator, but be defensive).
+		suffix := key[i+1:]
+		if suffix != "" && allDigits(suffix) {
+			return key[:i]
+		}
+	}
+	return key
+}
+
+func allDigits(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/tools/chunk_test.go
+++ b/internal/tools/chunk_test.go
@@ -1,0 +1,144 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSplitIntoUnits_Empty(t *testing.T) {
+	cases := []string{"", "   ", "\n\n", "\t \n  \n"}
+	for _, c := range cases {
+		if got := splitIntoUnits(c); got != nil {
+			t.Errorf("splitIntoUnits(%q) = %v, want nil", c, got)
+		}
+	}
+}
+
+func TestSplitIntoUnits_Single(t *testing.T) {
+	got := splitIntoUnits("just one paragraph, no blank lines")
+	if len(got) != 1 {
+		t.Fatalf("want 1 unit, got %d", len(got))
+	}
+	if got[0] != "just one paragraph, no blank lines" {
+		t.Errorf("unit content: %q", got[0])
+	}
+}
+
+func TestSplitIntoUnits_Multiple(t *testing.T) {
+	body := "first paragraph here\n\nsecond paragraph here\n\nthird"
+	got := splitIntoUnits(body)
+	if len(got) != 3 {
+		t.Fatalf("want 3 units, got %d: %v", len(got), got)
+	}
+	for i, want := range []string{"first paragraph here", "second paragraph here", "third"} {
+		if got[i] != want {
+			t.Errorf("unit[%d] = %q, want %q", i, got[i], want)
+		}
+	}
+}
+
+func TestSplitIntoUnits_AdjacentBlankLines(t *testing.T) {
+	body := "alpha\n\n\n\nbeta"
+	got := splitIntoUnits(body)
+	if len(got) != 2 {
+		t.Fatalf("multiple blank lines should collapse to one separator; got %d units: %v", len(got), got)
+	}
+}
+
+func TestSplitIntoUnits_BlankLinesWithWhitespace(t *testing.T) {
+	body := "alpha\n   \nbeta\n\t\ngamma"
+	got := splitIntoUnits(body)
+	if len(got) != 3 {
+		t.Fatalf("blank lines containing whitespace should still separate; got %d units: %v", len(got), got)
+	}
+}
+
+func TestSplitIntoUnits_CRLF(t *testing.T) {
+	body := "line one\r\n\r\nline two\r\n\r\nline three"
+	got := splitIntoUnits(body)
+	if len(got) != 3 {
+		t.Fatalf("CRLF should normalize and split; got %d units: %v", len(got), got)
+	}
+	for i, u := range got {
+		if strings.Contains(u, "\r") {
+			t.Errorf("unit[%d] still contains CR: %q", i, u)
+		}
+	}
+}
+
+func TestSplitIntoUnits_LeadingTrailingWhitespace(t *testing.T) {
+	body := "\n\n\nalpha\n\nbeta\n\n\n"
+	got := splitIntoUnits(body)
+	if len(got) != 2 {
+		t.Fatalf("leading/trailing blank lines should be ignored; got %d: %v", len(got), got)
+	}
+}
+
+func TestSplitIntoUnits_OversizedParagraph(t *testing.T) {
+	huge := strings.Repeat("x", maxParagraphBytes*2+500)
+	body := "small first\n\n" + huge + "\n\nsmall last"
+	got := splitIntoUnits(body)
+	// Expect: small first | huge[0:3000] | huge[3000:6000] | huge[6000:6500] | small last
+	if len(got) != 5 {
+		t.Fatalf("oversized paragraph should byte-cut into 3 pieces; got %d units: %v", len(got), len(got))
+	}
+	if got[0] != "small first" || got[len(got)-1] != "small last" {
+		t.Errorf("non-oversized neighbors should be preserved: first=%q last=%q", got[0], got[len(got)-1])
+	}
+	for i := 1; i <= 3; i++ {
+		if len(got[i]) > maxParagraphBytes {
+			t.Errorf("byte-cut unit[%d] exceeds cap: %d bytes", i, len(got[i]))
+		}
+	}
+	// Byte-cut pieces should reassemble to the original.
+	rejoined := got[1] + got[2] + got[3]
+	if rejoined != huge {
+		t.Errorf("byte-cut pieces don't reassemble (got %d bytes, want %d)", len(rejoined), len(huge))
+	}
+}
+
+func TestSplitIntoUnits_PreservesIndentation(t *testing.T) {
+	// Markdown indentation (lists, code blocks) is meaningful;
+	// splitIntoUnits trims trailing whitespace per paragraph but
+	// must preserve leading indentation.
+	body := "  - bullet one\n  - bullet two\n\nplain paragraph"
+	got := splitIntoUnits(body)
+	if len(got) != 2 {
+		t.Fatalf("got %d units: %v", len(got), got)
+	}
+	if !strings.HasPrefix(got[0], "  - bullet one") {
+		t.Errorf("indentation lost: %q", got[0])
+	}
+}
+
+func TestUnitKey_Single(t *testing.T) {
+	if got := unitKey("notes/foo.md", 0, 1); got != "notes/foo.md" {
+		t.Errorf("single-unit file should use bare path; got %q", got)
+	}
+}
+
+func TestUnitKey_Multi(t *testing.T) {
+	if got := unitKey("notes/foo.md", 0, 5); got != "notes/foo.md#0" {
+		t.Errorf("multi-unit key: %q", got)
+	}
+	if got := unitKey("notes/foo.md", 4, 5); got != "notes/foo.md#4" {
+		t.Errorf("multi-unit last key: %q", got)
+	}
+}
+
+func TestPathFromUnitKey(t *testing.T) {
+	cases := []struct{ key, want string }{
+		{"notes/foo.md", "notes/foo.md"},
+		{"notes/foo.md#0", "notes/foo.md"},
+		{"notes/foo.md#42", "notes/foo.md"},
+		{"a/b#3", "a/b"},
+		// Defensive: trailing # alone or non-numeric suffix isn't a chunk separator.
+		{"oddpath#", "oddpath#"},
+		{"oddpath#abc", "oddpath#abc"},
+	}
+	for _, c := range cases {
+		if got := pathFromUnitKey(c.key); got != c.want {
+			t.Errorf("pathFromUnitKey(%q) = %q, want %q", c.key, got, c.want)
+		}
+	}
+}

--- a/internal/tools/executor.go
+++ b/internal/tools/executor.go
@@ -1384,6 +1384,14 @@ const memorySearchResultLimit = 5
 // scores in roughly [0.1, 0.9] for in-domain queries.
 const memorySearchSemanticMinScore = 0.30
 
+// memorySearchOversample is the multiplier applied to the result
+// limit when querying the (paragraph-keyed) vector index, so the
+// file-level dedup pass has enough chunk hits to surface
+// memorySearchResultLimit distinct files. With limit=5 and
+// oversample=10 we ask the index for 50 chunk hits and dedupe down
+// to the top 5 distinct files.
+const memorySearchOversample = 10
+
 func (te *Executor) memorySearch(ctx context.Context, argsJSON string) string {
 	var args struct {
 		Query          string `json:"query"`
@@ -1439,6 +1447,12 @@ func (te *Executor) memorySearch(ctx context.Context, argsJSON string) string {
 
 	// Semantic pass — only if embeddings are configured. Errors here
 	// are logged and swallowed; the lexical results still go out.
+	//
+	// The vector index is keyed at paragraph granularity (path or
+	// path#N). We oversample by a factor of memorySearchOversample so
+	// the file-level dedup pass below has enough material to choose
+	// from, then collapse to one entry per file keeping each file's
+	// best-scoring chunk.
 	var semantic []vector.Result
 	if te.vectorEnabled() {
 		qvec, err := te.embedQuery(ctx, args.Query)
@@ -1446,12 +1460,23 @@ func (te *Executor) memorySearch(ctx context.Context, argsJSON string) string {
 			te.logger.Warn("memory_search: embed query failed; lexical only",
 				slog.String("err", err.Error()))
 		} else {
-			res, sErr := te.vIndex.Search(qvec, memorySearchResultLimit, memorySearchSemanticMinScore, filter)
+			// The filter sees raw index keys (which may carry a #N
+			// suffix). Strip it so the date filter sees the file
+			// path it expects.
+			vectorFilter := filter
+			if vectorFilter != nil {
+				orig := filter
+				vectorFilter = func(key string) bool {
+					return orig(pathFromUnitKey(key))
+				}
+			}
+			oversample := memorySearchResultLimit * memorySearchOversample
+			res, sErr := te.vIndex.Search(qvec, oversample, memorySearchSemanticMinScore, vectorFilter)
 			if sErr != nil {
 				te.logger.Warn("memory_search: vector search failed; lexical only",
 					slog.String("err", sErr.Error()))
 			} else {
-				semantic = res
+				semantic = fileLevelHits(res, memorySearchResultLimit)
 			}
 		}
 	}
@@ -1494,24 +1519,43 @@ func (te *Executor) memorySearch(ctx context.Context, argsJSON string) string {
 			sb.WriteString("(no matches above similarity threshold)\n")
 		}
 		for i, r := range semantic {
-			// Read the file content for the preview. The vector index
-			// only stores the path + vector, so we go back to disk.
-			// In practice the file is small and this is fast.
-			content, err := te.memory.Read(r.Path)
+			// r.Path is the unit key, possibly with a #N suffix.
+			// Recover the file path for display + memory_read hint
+			// and the chunk index for snippet extraction.
+			filePath := pathFromUnitKey(r.Path)
+			chunkIdx := chunkIdxFromUnitKey(r.Path)
+
+			content, err := te.memory.Read(filePath)
 			if err != nil {
 				fmt.Fprintf(&sb, "--- Result %d: %s (score: %.2f) ---\n[file unreadable: %s]\n\n",
-					i+1, r.Path, r.Score, err)
+					i+1, filePath, r.Score, err)
 				continue
 			}
-			total := len(content)
+
+			// Snippet: the matched paragraph if the file was chunked
+			// and the chunk index is still valid, otherwise the file
+			// content. Files re-split here on each search hit; cheap
+			// for typical sizes and avoids storing snippet text in
+			// the vector index.
+			snippet := content
+			label := filePath
+			if chunkIdx >= 0 {
+				units := splitIntoUnits(content)
+				if chunkIdx < len(units) {
+					snippet = units[chunkIdx]
+					label = fmt.Sprintf("%s [paragraph %d/%d]", filePath, chunkIdx+1, len(units))
+				}
+			}
+
+			total := len(snippet)
 			var tail string
 			if limit > 0 && total > limit {
-				content = content[:limit]
-				tail = fmt.Sprintf("\n[truncated: showing first %d of %d chars; call memory_read with path=%q to read the full file, or with offset=%d to continue from where this preview ends]",
-					limit, total, r.Path, lineCount(content)+1)
+				snippet = snippet[:limit]
+				tail = fmt.Sprintf("\n[truncated: showing first %d of %d chars; call memory_read with path=%q to read the full file]",
+					limit, total, filePath)
 			}
 			fmt.Fprintf(&sb, "--- Result %d: %s (score: %.2f) ---\n%s%s\n\n",
-				i+1, r.Path, r.Score, content, tail)
+				i+1, label, r.Score, snippet, tail)
 		}
 	}
 

--- a/internal/tools/vector.go
+++ b/internal/tools/vector.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -33,25 +35,22 @@ type Embedder interface {
 	Model() string
 }
 
-// maxEmbedInputBytes is the byte-length cap applied to file content
-// before it's sent to the embeddings API. text-embedding-3-small
-// accepts up to 8192 tokens (~30 KB of typical English). We truncate
-// rather than chunk for v1 because:
-//   - typical memory files are well under this limit;
-//   - chunking adds complexity (multi-vector files, score aggregation,
-//     dedup on return) that doesn't pay off until we see real
-//     long-document use cases.
-//
-// When this limit fires, the embedding represents only the prefix.
-// Truncation is logged at debug level.
-const maxEmbedInputBytes = 30000
+// reindexBatchTimeout caps a single per-mutation reindex (one file,
+// possibly several paragraphs). Independent of the per-request HTTP
+// timeout in the embedder; this is the wall-clock budget for the
+// whole adaptive batching loop on one file.
+const reindexBatchTimeout = 60 * time.Second
 
-// vectorEmbedTimeout is the per-mutation embed call timeout.
-// Independent of the per-request timeout in the embedder itself
-// (which applies to bulk reconciles too); this exists so that
-// embed-on-mutation never blocks a memory-write tool for too long
-// even if the configured embeddings.timeout is generous.
-const vectorEmbedTimeout = 30 * time.Second
+// vectorBatchTimeout bounds a single /v1/embeddings call inside the
+// adaptive batcher. A hung server still can't stall a reconcile or a
+// per-mutation reindex forever.
+const vectorBatchTimeout = 60 * time.Second
+
+// batchGrowSuccesses is how many consecutive successful batches the
+// adaptive batcher requires before it tries doubling the current
+// batch size back toward the configured ceiling. Conservative: a
+// single failure on the freshly-doubled size demotes us again.
+const batchGrowSuccesses = 5
 
 // vectorEnabled reports whether semantic indexing is wired up. Both
 // the embedder and the index must be non-nil; either being nil is
@@ -77,84 +76,85 @@ func shouldIndexPath(path string) bool {
 	return true
 }
 
-// truncateForEmbedding returns text trimmed to maxEmbedInputBytes if
-// it would otherwise exceed the embedding model's input limit. Returns
-// the (possibly trimmed) text and a bool indicating whether truncation
-// occurred.
-func truncateForEmbedding(text string) (string, bool) {
-	if len(text) <= maxEmbedInputBytes {
-		return text, false
-	}
-	return text[:maxEmbedInputBytes], true
-}
-
-// reindexVector embeds the current content of the file at path and
-// upserts the result into the vector index. No-op when the feature is
-// disabled, when the path is operational, or when the file content is
-// empty (vector indexing of empty documents would produce a zero
-// vector that can't be normalised).
+// reindexVector splits the file at path into paragraph-aligned units,
+// embeds them via the adaptive batcher, and replaces any prior chunks
+// for that file in the vector index. No-op when the feature is
+// disabled, the path is operational, or the file body is empty.
 //
-// Failure mode: any error is logged at warn and swallowed. The vector
-// index is best-effort enrichment; a failed embed never blocks the
-// memory write that triggered it. The unindexed file is reachable on
-// the next mutation or via the startup reconcile pass.
+// Failure mode: any embed error inside the adaptive batcher is logged
+// and per-paragraph skips are tolerated (the file ends up partially
+// indexed). The vector index is best-effort enrichment; a failed
+// embed never blocks the memory write that triggered it.
 func (te *Executor) reindexVector(path, content string) {
 	if !te.vectorEnabled() || !shouldIndexPath(indexKey(path)) {
 		return
 	}
-	if strings.TrimSpace(content) == "" {
-		// Don't index empty files — the embedding API typically
-		// rejects empty input and even when it doesn't, the resulting
-		// vector is meaningless. Remove any stale entry.
-		te.vIndex.Remove(indexKey(path))
+
+	units := splitIntoUnits(content)
+	if len(units) == 0 {
+		// Empty / whitespace-only file. Drop any prior chunks so
+		// the index doesn't carry a stale embedding for content the
+		// agent has effectively deleted.
+		te.vIndex.RemoveChunks(indexKey(path))
 		return
 	}
 
-	text, truncated := truncateForEmbedding(content)
-	if truncated {
-		te.logger.Debug("embedding truncated for indexing",
-			slog.String("path", path),
-			slog.Int("orig_bytes", len(content)),
-			slog.Int("sent_bytes", len(text)))
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), vectorEmbedTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), reindexBatchTimeout)
 	defer cancel()
 
-	vecs, err := te.embedder.Embed(ctx, []string{text})
+	// Per-mutation: try to embed all units in one shot. The adaptive
+	// batcher will fall back if the server can't take them at once.
+	vecs, skipped, err := embedWithAdaptiveBatching(ctx, te.embedder, units, len(units), te.logger)
 	if err != nil {
-		te.logger.Warn("embed-on-mutation failed; file will remain unindexed",
+		te.logger.Warn("reindex failed",
 			slog.String("path", path),
 			slog.String("err", err.Error()))
-		return
-	}
-	if len(vecs) != 1 {
-		te.logger.Warn("embed-on-mutation returned wrong count",
-			slog.String("path", path),
-			slog.Int("got", len(vecs)))
 		return
 	}
 
-	if err := te.vIndex.Upsert(indexKey(path), vecs[0]); err != nil {
-		te.logger.Warn("vector upsert failed",
+	// Replace any existing chunks for this file with the new ones.
+	// Done AFTER successful embed so a failed reindex doesn't leave
+	// the index in a worse state than before.
+	te.vIndex.RemoveChunks(indexKey(path))
+
+	upserted := 0
+	total := len(units)
+	for i, v := range vecs {
+		if v == nil {
+			continue // skipped paragraph (failed even at batch size 1)
+		}
+		key := unitKey(indexKey(path), i, total)
+		if uerr := te.vIndex.Upsert(key, v); uerr != nil {
+			te.logger.Warn("vector upsert failed",
+				slog.String("key", key),
+				slog.String("err", uerr.Error()))
+			continue
+		}
+		upserted++
+	}
+	if skipped > 0 {
+		te.logger.Warn("reindex partial: some paragraphs could not be embedded",
 			slog.String("path", path),
-			slog.String("err", err.Error()))
+			slog.Int("upserted", upserted),
+			slog.Int("skipped", skipped),
+			slog.Int("total", total))
 	}
 }
 
-// removeVector removes the vector for path from the index. No-op when
-// disabled.
+// removeVector clears every chunk belonging to path from the index.
+// No-op when disabled.
 func (te *Executor) removeVector(path string) {
 	if !te.vectorEnabled() {
 		return
 	}
-	te.vIndex.Remove(indexKey(path))
+	te.vIndex.RemoveChunks(indexKey(path))
 }
 
-// removeVectorPrefix removes all vectors under a directory prefix.
-// path should be the directory key without a trailing slash; this
-// helper appends one before delegating, matching the BM25 index's
-// RemovePrefix semantics.
+// removeVectorPrefix deletes every vector whose key sits under a
+// directory prefix. Chunk keys naturally satisfy this because they
+// are formed as `path#N` and `path` already carries the directory
+// prefix; the underlying RemovePrefix walks all keys with the
+// `<prefix>/` prefix and catches both bare and chunked entries.
 func (te *Executor) removeVectorPrefix(path string) {
 	if !te.vectorEnabled() {
 		return
@@ -162,14 +162,14 @@ func (te *Executor) removeVectorPrefix(path string) {
 	te.vIndex.RemovePrefix(indexKey(path))
 }
 
-// renameVector moves a vector from oldPath to newPath without re-
-// embedding (the file content hasn't changed). Used after memory_move
-// on individual files.
+// renameVector moves all chunks of a file from oldPath to newPath
+// without re-embedding (file content is unchanged). Used after
+// memory_move on a single file.
 func (te *Executor) renameVector(oldPath, newPath string) {
 	if !te.vectorEnabled() {
 		return
 	}
-	te.vIndex.Rename(indexKey(oldPath), indexKey(newPath))
+	te.vIndex.RenameChunks(indexKey(oldPath), indexKey(newPath))
 }
 
 // reindexVectorDir walks all files under the given memory directory
@@ -201,7 +201,7 @@ func (te *Executor) reindexVectorDir(dirPath string) {
 	}
 }
 
-// EmbedQuery is a thin wrapper around the embedder for use by the
+// embedQuery is a thin wrapper around the embedder for use by the
 // memory_search handler. Returns an error if the embedder is not
 // configured (caller should fall back to lexical-only output).
 func (te *Executor) embedQuery(ctx context.Context, query string) ([]float32, error) {
@@ -218,11 +218,32 @@ func (te *Executor) embedQuery(ctx context.Context, query string) ([]float32, er
 	return vecs[0], nil
 }
 
-// vectorIndex returns the current vector index. May be nil. Provided
+// VectorIndex returns the current vector index. May be nil. Provided
 // so wiring code (main.go) can call Save() at shutdown without poking
 // at unexported fields.
 func (te *Executor) VectorIndex() *vector.Index {
 	return te.vIndex
+}
+
+// memorySearchDescription returns the LLM-facing description for the
+// memory_search tool. The description varies based on whether
+// semantic search is wired up so the LLM's mental model matches the
+// tool's actual output shape.
+func (te *Executor) memorySearchDescription() string {
+	if te.vectorEnabled() {
+		return "Search across all memory files. Returns TWO labeled result sections per query: " +
+			"'Lexical results (BM25)' for keyword matches, and 'Semantic results' for meaning-based matches " +
+			"via embedding similarity over paragraph-aligned chunks (the most-similar paragraph of each file " +
+			"is shown as the snippet). Each section has up to 5 results with file path, score, and content. " +
+			"The two sections often surface different files — pick whichever is more relevant for your query, " +
+			"or read both. Use lexical when you remember specific words; use semantic when you remember the " +
+			"topic but not the wording. Long results are clipped with a hint pointing back at memory_read so " +
+			"you can load the full file. Optionally filter by file modification date (applies to both sections)."
+	}
+	return "Search across all memory files by keyword relevance (BM25). Returns up to 5 results, each with: " +
+		"file path, relevance score, and content. Long results are clipped with a hint pointing back at " +
+		"memory_read so you can load the full file. Use this to find memories by topic when you don't know " +
+		"the exact file path. Optionally filter by file modification date."
 }
 
 // rebuildIndexes is the handler for the rebuild_indexes tool. It does
@@ -278,13 +299,7 @@ func (te *Executor) rebuildIndexes(ctx context.Context, argsJSON string) string 
 			sb.WriteString("  - Vector (semantic): SKIPPED — semantic search is not configured ([embeddings].enabled=false or probe failed at startup).\n")
 		default:
 			res, err := RebuildVectorIndex(ctx, te.embedder, te.vIndex, te.memory, te.embedBatchSize, te.logger)
-			if err != nil {
-				fmt.Fprintf(&sb, "  - Vector (semantic): PARTIAL — %d/%d embedded in %s before failure: %s\n",
-					res.Embedded, res.Eligible, res.Duration.Round(time.Millisecond), err)
-			} else {
-				fmt.Fprintf(&sb, "  - Vector (semantic): %d documents embedded in %s (%d eligible files; ineligible=prompts/.trash/empty).\n",
-					res.Embedded, res.Duration.Round(time.Millisecond), res.Eligible)
-			}
+			renderBuildResult(&sb, "Vector (semantic) rebuild", res, err)
 		}
 	}
 
@@ -298,6 +313,25 @@ func (te *Executor) rebuildIndexes(ctx context.Context, argsJSON string) string 
 	return sb.String()
 }
 
+// renderBuildResult formats a VectorBuildResult into the summary
+// builder. Shared by rebuild_indexes (and could be reused if we ever
+// expose reconcile output to the LLM).
+func renderBuildResult(sb *strings.Builder, label string, res VectorBuildResult, err error) {
+	prefix := fmt.Sprintf("  - %s:", label)
+	if err != nil {
+		fmt.Fprintf(sb, "%s PARTIAL — %d files / %d paragraphs embedded in %s before failure (skipped %d): %s\n",
+			prefix, res.FilesEmbedded, res.UnitsEmbedded, res.Duration.Round(time.Millisecond), res.UnitsSkipped, err)
+		return
+	}
+	if res.UnitsSkipped > 0 {
+		fmt.Fprintf(sb, "%s %d files / %d paragraphs embedded in %s. Skipped %d paragraph(s) that the embedder rejected even at batch size 1 — those sections are not in semantic search but BM25 still finds them.\n",
+			prefix, res.FilesEmbedded, res.UnitsEmbedded, res.Duration.Round(time.Millisecond), res.UnitsSkipped)
+		return
+	}
+	fmt.Fprintf(sb, "%s %d files / %d paragraphs embedded in %s.\n",
+		prefix, res.FilesEmbedded, res.UnitsEmbedded, res.Duration.Round(time.Millisecond))
+}
+
 // ShouldIndexMemoryPath reports whether a memory path is eligible for
 // semantic indexing. Exported so main.go's reconcile pass and any
 // future caller can apply the same exclusion rule (skip prompts/ and
@@ -306,37 +340,36 @@ func ShouldIndexMemoryPath(path string) bool {
 	return shouldIndexPath(path)
 }
 
-// vectorBatchTimeout bounds a single /v1/embeddings batch call during
-// bulk reconcile/rebuild. Independent of the per-mutation timeout
-// (vectorEmbedTimeout) because batches can legitimately take longer
-// than a single-file embed; a hung server still can't stall the
-// whole pass forever.
-const vectorBatchTimeout = 60 * time.Second
-
 // VectorBuildResult summarizes a Reconcile/Rebuild pass.
 type VectorBuildResult struct {
-	// Embedded is the number of vectors successfully written this pass.
-	Embedded int
-	// Eligible is the number of memory files that qualified for
-	// embedding (after exclusion of prompts/, .trash/, and empty files).
+	// FilesEmbedded is the number of distinct memory files that have
+	// at least one paragraph successfully indexed in this pass.
+	FilesEmbedded int
+
+	// UnitsEmbedded is the total number of paragraph-aligned units
+	// (chunks) successfully written to the index.
+	UnitsEmbedded int
+
+	// UnitsSkipped is the number of units the embedder rejected even
+	// at batch size 1 — typically a single paragraph exceeding the
+	// model's context. Skipped units are not in the semantic index
+	// but are still searchable via BM25.
+	UnitsSkipped int
+
+	// Eligible is the number of distinct memory files that qualified
+	// for embedding (after exclusion of prompts/, .trash/, empty
+	// files, and — for Reconcile only — files already in the index).
 	Eligible int
-	// Skipped is the number of eligible files that were already in
-	// the index and not re-embedded. Always 0 for a full Rebuild;
-	// for Reconcile, this is Eligible - Embedded when no errors hit.
-	Skipped int
+
 	// Duration is wall-clock time for the pass.
 	Duration time.Duration
 }
 
-// ReconcileVectorIndex embeds memory files that are eligible but
-// missing from the index. Files already present are left as-is. Used
-// at startup so a restart with an existing on-disk index doesn't
-// re-pay the embedding cost for files that haven't changed.
-//
-// Empty files are skipped. Files larger than maxEmbedInputBytes are
-// truncated to that prefix (matching the per-mutation reindex
-// behavior). Errors abort the pass; vectors written before the
-// error are preserved in the index.
+// ReconcileVectorIndex embeds eligible memory files that aren't yet
+// represented in the index. Files already present (any chunk for that
+// path exists) are left as-is. Used at startup so a restart with an
+// existing on-disk index doesn't re-pay the embedding cost for files
+// that haven't changed.
 func ReconcileVectorIndex(ctx context.Context, embedder Embedder, idx *vector.Index, memory *fs.Store, batchSize int, logger *slog.Logger) (VectorBuildResult, error) {
 	return runVectorBuild(ctx, embedder, idx, memory, batchSize, false, logger)
 }
@@ -345,18 +378,26 @@ func ReconcileVectorIndex(ctx context.Context, embedder Embedder, idx *vector.In
 // every eligible memory file from scratch. Used by the
 // rebuild_indexes tool when the LLM observes inconsistency or the
 // operator explicitly asks for a rebuild.
-//
-// The reset uses the embedder's current dim and model identifier, so
-// switching embedders is not the intended use of this function (that
-// happens automatically at startup via ErrModelMismatch).
 func RebuildVectorIndex(ctx context.Context, embedder Embedder, idx *vector.Index, memory *fs.Store, batchSize int, logger *slog.Logger) (VectorBuildResult, error) {
 	idx.Reset(embedder.Dim(), embedder.Model())
 	return runVectorBuild(ctx, embedder, idx, memory, batchSize, true, logger)
 }
 
+// pendingUnit is one paragraph queued for batch embedding.
+type pendingUnit struct {
+	path  string
+	idx   int // chunk index within the file
+	total int // total chunks for that file
+	text  string
+}
+
 // runVectorBuild is the shared embed-and-upsert loop used by both
 // Reconcile (full=false: skip files already in the index) and
 // Rebuild (full=true: index has been cleared so every file qualifies).
+//
+// All paragraphs across all eligible files are fed into one adaptive
+// batcher pass, so the batcher can amortize large batches across
+// files instead of tearing down between them.
 func runVectorBuild(ctx context.Context, embedder Embedder, idx *vector.Index, memory *fs.Store, batchSize int, full bool, logger *slog.Logger) (VectorBuildResult, error) {
 	start := time.Now()
 	res := VectorBuildResult{}
@@ -366,29 +407,34 @@ func runVectorBuild(ctx context.Context, embedder Embedder, idx *vector.Index, m
 		return res, fmt.Errorf("list memory files: %w", err)
 	}
 
-	type pending struct {
-		path string
-		text string
-	}
-	var queue []pending
-
+	var queue []pendingUnit
 	for path, content := range all {
 		if !ShouldIndexMemoryPath(path) {
 			continue
 		}
-		text := strings.TrimSpace(content)
-		if text == "" {
+		if strings.TrimSpace(content) == "" {
+			continue
+		}
+		// "Already in the index" for chunked files means any chunk
+		// is present; for legacy single-vector files it means the
+		// bare path is present.
+		if !full && idx.HasChunks(path) {
+			res.Eligible++
+			continue
+		}
+		units := splitIntoUnits(content)
+		if len(units) == 0 {
 			continue
 		}
 		res.Eligible++
-		if !full && idx.Has(path) {
-			res.Skipped++
-			continue
+		for i, u := range units {
+			queue = append(queue, pendingUnit{
+				path:  path,
+				idx:   i,
+				total: len(units),
+				text:  u,
+			})
 		}
-		if len(text) > maxEmbedInputBytes {
-			text = text[:maxEmbedInputBytes]
-		}
-		queue = append(queue, pending{path: path, text: text})
 	}
 
 	if len(queue) == 0 {
@@ -398,13 +444,8 @@ func runVectorBuild(ctx context.Context, embedder Embedder, idx *vector.Index, m
 			mode = "rebuild"
 		}
 		logger.Info("vector "+mode+": nothing to do",
-			slog.Int("eligible", res.Eligible),
-			slog.Int("skipped", res.Skipped))
+			slog.Int("eligible", res.Eligible))
 		return res, nil
-	}
-
-	if batchSize <= 0 {
-		batchSize = 100
 	}
 
 	mode := "reconcile"
@@ -412,78 +453,228 @@ func runVectorBuild(ctx context.Context, embedder Embedder, idx *vector.Index, m
 		mode = "rebuild"
 	}
 	logger.Info("vector "+mode+" pass starting",
-		slog.Int("count", len(queue)),
+		slog.Int("paragraphs", len(queue)),
 		slog.Int("batch_size", batchSize))
 
-	for i := 0; i < len(queue); i += batchSize {
-		end := i + batchSize
-		if end > len(queue) {
-			end = len(queue)
-		}
-		batch := queue[i:end]
-
-		texts := make([]string, len(batch))
-		for j, p := range batch {
-			texts[j] = p.text
-		}
-
-		batchCtx, cancel := context.WithTimeout(ctx, vectorBatchTimeout)
-		vecs, err := embedder.Embed(batchCtx, texts)
-		cancel()
-		if err != nil {
-			res.Duration = time.Since(start)
-			return res, fmt.Errorf("embed batch starting at %d: %w", i, err)
-		}
-		if len(vecs) != len(batch) {
-			res.Duration = time.Since(start)
-			return res, fmt.Errorf("embed batch starting at %d: got %d vecs for %d inputs", i, len(vecs), len(batch))
-		}
-		for j, p := range batch {
-			if err := idx.Upsert(p.path, vecs[j]); err != nil {
-				logger.Warn("vector "+mode+": upsert failed; continuing",
-					slog.String("path", p.path),
-					slog.String("err", err.Error()))
-				continue
-			}
-			res.Embedded++
-		}
-
-		select {
-		case <-ctx.Done():
-			res.Duration = time.Since(start)
-			logger.Info("vector "+mode+": canceled mid-pass",
-				slog.Int("embedded", res.Embedded),
-				slog.Int("total", len(queue)))
-			return res, ctx.Err()
-		default:
-		}
+	texts := make([]string, len(queue))
+	for i, u := range queue {
+		texts[i] = u.text
 	}
 
+	vecs, skipped, embErr := embedWithAdaptiveBatching(ctx, embedder, texts, batchSize, logger)
+	res.UnitsSkipped = skipped
+
+	// Upsert whatever did embed, even if there was a fatal error
+	// (e.g. ctx cancellation) — partial progress is preserved.
+	filesSeen := map[string]bool{}
+	for i, v := range vecs {
+		if v == nil {
+			continue
+		}
+		u := queue[i]
+		key := unitKey(u.path, u.idx, u.total)
+		if uerr := idx.Upsert(key, v); uerr != nil {
+			logger.Warn("vector "+mode+": upsert failed; continuing",
+				slog.String("key", key),
+				slog.String("err", uerr.Error()))
+			continue
+		}
+		filesSeen[u.path] = true
+		res.UnitsEmbedded++
+	}
+	res.FilesEmbedded = len(filesSeen)
 	res.Duration = time.Since(start)
+
+	if embErr != nil {
+		logger.Warn("vector "+mode+": ended with error",
+			slog.String("err", embErr.Error()),
+			slog.Int("files", res.FilesEmbedded),
+			slog.Int("paragraphs", res.UnitsEmbedded),
+			slog.Int("skipped", res.UnitsSkipped))
+		return res, embErr
+	}
+
 	logger.Info("vector "+mode+" complete",
-		slog.Int("embedded", res.Embedded),
-		slog.Int("eligible", res.Eligible),
-		slog.Int("skipped", res.Skipped),
+		slog.Int("files", res.FilesEmbedded),
+		slog.Int("paragraphs", res.UnitsEmbedded),
+		slog.Int("skipped", res.UnitsSkipped),
 		slog.Duration("duration", res.Duration))
 	return res, nil
 }
 
-// memorySearchDescription returns the LLM-facing description for the
-// memory_search tool. The description varies based on whether
-// semantic search is wired up so the LLM's mental model matches the
-// tool's actual output shape.
-func (te *Executor) memorySearchDescription() string {
-	if te.vectorEnabled() {
-		return "Search across all memory files. Returns TWO labeled result sections per query: " +
-			"'Lexical results (BM25)' for keyword matches, and 'Semantic results' for meaning-based matches " +
-			"via embedding similarity. Each section has up to 5 results with file path, score, and content. " +
-			"The two sections often surface different files — pick whichever is more relevant for your query, " +
-			"or read both. Use lexical when you remember specific words; use semantic when you remember " +
-			"the topic but not the wording. Long results are clipped with a hint pointing back at memory_read " +
-			"so you can load the full file. Optionally filter by file modification date (applies to both sections)."
+// embedWithAdaptiveBatching embeds a slice of texts via the embedder,
+// dynamically halving the batch size on failure and growing it back
+// after a streak of successes. Failures at batch size 1 cause that
+// individual text to be skipped (corresponding output slot stays nil)
+// and the loop continues with the next.
+//
+// Returns:
+//   - vecs: one vector per input text in input order; nil for any
+//     text that was skipped (failed even at batch size 1).
+//   - skipped: count of nil entries in vecs.
+//   - err: non-nil only if ctx is canceled mid-pass; recoverable
+//     batch failures are absorbed and never surface as err.
+//
+// configuredBatchSize is treated as the upper bound; the runtime
+// batch size starts at min(configuredBatchSize, len(texts)) and only
+// grows back toward configuredBatchSize after enough successes.
+func embedWithAdaptiveBatching(ctx context.Context, embedder Embedder, texts []string, configuredBatchSize int, logger *slog.Logger) ([][]float32, int, error) {
+	if len(texts) == 0 {
+		return nil, 0, nil
 	}
-	return "Search across all memory files by keyword relevance (BM25). Returns up to 5 results, each with: " +
-		"file path, relevance score, and content. Long results are clipped with a hint pointing back at " +
-		"memory_read so you can load the full file. Use this to find memories by topic when you don't know " +
-		"the exact file path. Optionally filter by file modification date."
+	if configuredBatchSize <= 0 {
+		configuredBatchSize = 100
+	}
+
+	out := make([][]float32, len(texts))
+	batchSize := configuredBatchSize
+	if batchSize > len(texts) {
+		batchSize = len(texts)
+	}
+
+	var (
+		skipped   int
+		successes int
+		i         int
+	)
+
+	for i < len(texts) {
+		// Honor outer cancellation between batches.
+		if err := ctx.Err(); err != nil {
+			return out, skipped, err
+		}
+
+		end := i + batchSize
+		if end > len(texts) {
+			end = len(texts)
+		}
+		batch := texts[i:end]
+
+		bctx, cancel := context.WithTimeout(ctx, vectorBatchTimeout)
+		result, err := embedder.Embed(bctx, batch)
+		cancel()
+
+		// Treat "wrong count" as a soft failure — same recovery path
+		// as a real error.
+		if err == nil && len(result) != len(batch) {
+			err = fmt.Errorf("embedder returned %d vectors for %d inputs", len(result), len(batch))
+		}
+
+		if err == nil {
+			copy(out[i:end], result)
+			i = end
+			successes++
+			if successes >= batchGrowSuccesses && batchSize < configuredBatchSize {
+				newSize := batchSize * 2
+				if newSize > configuredBatchSize {
+					newSize = configuredBatchSize
+				}
+				logger.Debug("embed batch growing after success streak",
+					slog.Int("from", batchSize),
+					slog.Int("to", newSize))
+				batchSize = newSize
+				successes = 0
+			}
+			continue
+		}
+
+		// If the outer ctx is the cause, surface it; we can't recover.
+		if cerr := ctx.Err(); cerr != nil {
+			return out, skipped, cerr
+		}
+
+		successes = 0
+
+		if batchSize == 1 {
+			// Single-input failure: this paragraph is the problem.
+			// Skip it and continue — the rest of the pass should
+			// still succeed.
+			logger.Warn("embed: skipping paragraph after single-input failure",
+				slog.Int("input_index", i),
+				slog.Int("input_bytes", len(texts[i])),
+				slog.String("err", err.Error()))
+			out[i] = nil
+			skipped++
+			i++
+			continue
+		}
+
+		// Batch failure with size > 1: halve and retry the same
+		// range. Don't advance i.
+		newSize := batchSize / 2
+		if newSize < 1 {
+			newSize = 1
+		}
+		logger.Warn("embed batch failed; halving batch size",
+			slog.Int("from", batchSize),
+			slog.Int("to", newSize),
+			slog.Int("range_start", i),
+			slog.String("err", err.Error()))
+		batchSize = newSize
+	}
+
+	return out, skipped, nil
+}
+
+// chunkIdxFromUnitKey returns the numeric chunk index encoded in a
+// unit key (e.g. 3 for "notes/foo.md#3"), or -1 if the key has no
+// chunk suffix.
+func chunkIdxFromUnitKey(key string) int {
+	if i := strings.LastIndexByte(key, '#'); i > 0 {
+		suffix := key[i+1:]
+		if suffix != "" && allDigits(suffix) {
+			n, err := strconv.Atoi(suffix)
+			if err == nil {
+				return n
+			}
+		}
+	}
+	return -1
+}
+
+// fileLevelHits collapses the raw per-paragraph search results down
+// to one entry per file, keeping each file's highest-scoring chunk.
+// Used by memory_search to present file-granular results to the LLM.
+//
+// rawHits should already be sorted by descending score; the iteration
+// preserves the first (i.e. best) hit per path. The returned slice is
+// truncated to limit and sorted by descending score.
+func fileLevelHits(rawHits []vector.Result, limit int) []vector.Result {
+	if limit <= 0 || len(rawHits) == 0 {
+		return nil
+	}
+	// Caller may pass in unsorted; sort defensively. Stable so equal
+	// scores keep the index-traversal order chosen by Search.
+	sort.SliceStable(rawHits, func(i, j int) bool { return rawHits[i].Score > rawHits[j].Score })
+
+	type fileHit struct {
+		key   string  // original key (with #N if chunked)
+		path  string  // file path (no #N)
+		score float32 // best score across this file's chunks
+	}
+	seen := map[string]int{} // path -> index in out
+	out := make([]fileHit, 0, limit)
+	for _, h := range rawHits {
+		p := pathFromUnitKey(h.Path)
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		out = append(out, fileHit{key: h.Path, path: p, score: h.Score})
+		seen[p] = len(out) - 1
+		if len(out) >= limit {
+			break
+		}
+	}
+
+	// Convert back to []vector.Result so callers don't need to know
+	// about fileHit. Path is the bare file path (post-dedup), Score
+	// is the best chunk's score. The chunked-key is recoverable via
+	// chunkIdxFromUnitKey if we keep it — emit it via Path so callers
+	// can re-derive the chunk index. Two-stage: keep both via a side
+	// channel.
+	results := make([]vector.Result, len(out))
+	for i, h := range out {
+		results[i] = vector.Result{Path: h.key, Score: h.score}
+	}
+	return results
 }

--- a/internal/tools/vector_test.go
+++ b/internal/tools/vector_test.go
@@ -1,0 +1,257 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/matjam/faultline/internal/search/vector"
+)
+
+// fakeEmbedder is a deterministic Embedder for tests. It records
+// every batch it sees and can be configured to fail for batches
+// larger than maxBatchSize, mimicking a server with a physical
+// batch limit (e.g. llama.cpp's --batch-size).
+type fakeEmbedder struct {
+	mu         sync.Mutex
+	calls      []int // batch sizes seen, in order
+	maxBatch   int   // > 0: error when batch size exceeds this
+	failSingle bool  // true: also fail batches of size 1 unconditionally
+	failOnText string
+	dim        int
+	model      string
+}
+
+func (f *fakeEmbedder) Dim() int      { return f.dim }
+func (f *fakeEmbedder) Model() string { return f.model }
+
+func (f *fakeEmbedder) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+	f.mu.Lock()
+	f.calls = append(f.calls, len(texts))
+	f.mu.Unlock()
+
+	if f.maxBatch > 0 && len(texts) > f.maxBatch {
+		return nil, errors.New("batch too large")
+	}
+	if f.failSingle && len(texts) == 1 {
+		return nil, errors.New("single failure")
+	}
+	if f.failOnText != "" {
+		for _, t := range texts {
+			if t == f.failOnText {
+				return nil, errors.New("specific text failure")
+			}
+		}
+	}
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		// Deterministic non-zero vector: first dim slot is text length.
+		v := make([]float32, f.dim)
+		v[0] = float32(len(t)) + 1
+		_ = i
+		_ = t
+		out[i] = v
+	}
+	return out, nil
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestEmbedAdaptive_SinglePassNoFailures(t *testing.T) {
+	f := &fakeEmbedder{dim: 4, model: "m"}
+	texts := []string{"a", "b", "c", "d"}
+
+	vecs, skipped, err := embedWithAdaptiveBatching(context.Background(), f, texts, 100, discardLogger())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if skipped != 0 {
+		t.Errorf("skipped: want 0 got %d", skipped)
+	}
+	if len(vecs) != 4 {
+		t.Fatalf("len: %d", len(vecs))
+	}
+	if len(f.calls) != 1 || f.calls[0] != 4 {
+		t.Errorf("expected one call of 4, got %v", f.calls)
+	}
+}
+
+func TestEmbedAdaptive_HalvesOnFailure(t *testing.T) {
+	// Server accepts max 2 per batch. Configured at 8.
+	f := &fakeEmbedder{dim: 4, model: "m", maxBatch: 2}
+	texts := make([]string, 8)
+	for i := range texts {
+		texts[i] = "t"
+	}
+
+	vecs, skipped, err := embedWithAdaptiveBatching(context.Background(), f, texts, 8, discardLogger())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if skipped != 0 {
+		t.Errorf("nothing should be skipped; got %d", skipped)
+	}
+	for i, v := range vecs {
+		if v == nil {
+			t.Errorf("vec[%d] is nil", i)
+		}
+	}
+	// First call: 8 (fails). Halve: 4 (fails). Halve: 2 (succeeds, stays).
+	// Then 2,2,2 = 4 successes total. Wait — we have 8 inputs.
+	// Sequence: 8 (fail), 4 (fail), 2 (succ, i=0..2), 2 (succ, i=2..4),
+	//          2 (succ, i=4..6), 2 (succ, i=6..8). After 5 successes
+	//          we'd try doubling but we already hit the end.
+	// So calls = [8, 4, 2, 2, 2, 2].
+	if len(f.calls) < 4 {
+		t.Errorf("expected at least 4 calls (failures plus successes), got %v", f.calls)
+	}
+	if f.calls[0] != 8 || f.calls[1] != 4 {
+		t.Errorf("first two calls should be original size then halved: %v", f.calls)
+	}
+}
+
+func TestEmbedAdaptive_GrowsBackAfterSuccesses(t *testing.T) {
+	// maxBatch=4, configured=8: first call fails (8), halves to 4 (success).
+	// Five more 4-batches succeed -> grow back toward 8.
+	f := &fakeEmbedder{dim: 4, model: "m", maxBatch: 4}
+	texts := make([]string, 64)
+	for i := range texts {
+		texts[i] = "t"
+	}
+
+	_, skipped, err := embedWithAdaptiveBatching(context.Background(), f, texts, 8, discardLogger())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if skipped != 0 {
+		t.Errorf("nothing should skip; got %d", skipped)
+	}
+	// Look for a call of 8 (or attempt thereof) somewhere after the
+	// initial 8 -> 4 demotion. With maxBatch=4 every grow-back attempt
+	// of 8 will also fail — verify we see *attempts* at growing.
+	saw8After := 0
+	for i := 1; i < len(f.calls); i++ {
+		if f.calls[i] == 8 {
+			saw8After++
+		}
+	}
+	if saw8After == 0 {
+		t.Errorf("expected at least one grow-back attempt at size 8; calls=%v", f.calls)
+	}
+}
+
+func TestEmbedAdaptive_SkipsSingleInputFailure(t *testing.T) {
+	// "bad" always fails; everything else succeeds.
+	f := &fakeEmbedder{dim: 4, model: "m", failOnText: "bad", maxBatch: 0}
+	// Configure maxBatch = 1 so the batcher reaches single-input mode.
+	f.maxBatch = 1
+	texts := []string{"good1", "bad", "good2"}
+
+	vecs, skipped, err := embedWithAdaptiveBatching(context.Background(), f, texts, 4, discardLogger())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if skipped != 1 {
+		t.Errorf("expected 1 skip, got %d", skipped)
+	}
+	if vecs[0] == nil || vecs[2] == nil {
+		t.Errorf("good inputs should be embedded: vec[0]=%v vec[2]=%v", vecs[0], vecs[2])
+	}
+	if vecs[1] != nil {
+		t.Errorf("bad input should be skipped (vec[1] nil), got %v", vecs[1])
+	}
+}
+
+func TestEmbedAdaptive_RespectsContextCancellation(t *testing.T) {
+	f := &fakeEmbedder{dim: 4, model: "m"}
+	texts := make([]string, 10)
+	for i := range texts {
+		texts[i] = "t"
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel
+
+	_, _, err := embedWithAdaptiveBatching(ctx, f, texts, 5, discardLogger())
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestEmbedAdaptive_EmptyInput(t *testing.T) {
+	f := &fakeEmbedder{dim: 4, model: "m"}
+	vecs, skipped, err := embedWithAdaptiveBatching(context.Background(), f, nil, 100, discardLogger())
+	if err != nil || skipped != 0 || vecs != nil {
+		t.Errorf("empty input: vecs=%v skipped=%d err=%v", vecs, skipped, err)
+	}
+	if len(f.calls) != 0 {
+		t.Errorf("empty input should not call embedder; got %v", f.calls)
+	}
+}
+
+func TestFileLevelHits_DedupesByPath(t *testing.T) {
+	raw := []vector.Result{
+		{Path: "a.md#0", Score: 0.9},
+		{Path: "a.md#3", Score: 0.85}, // same file, lower score — drop
+		{Path: "b.md", Score: 0.8},    // different file
+		{Path: "c.md#1", Score: 0.7},
+		{Path: "b.md#5", Score: 0.6}, // duplicate of b.md
+	}
+	got := fileLevelHits(raw, 5)
+	if len(got) != 3 {
+		t.Fatalf("want 3 distinct files, got %d: %+v", len(got), got)
+	}
+	// Order should be by best score: a.md (0.9), b.md (0.8), c.md (0.7)
+	want := []string{"a.md#0", "b.md", "c.md#1"}
+	for i, w := range want {
+		if got[i].Path != w {
+			t.Errorf("got[%d].Path = %q, want %q", i, got[i].Path, w)
+		}
+	}
+}
+
+func TestFileLevelHits_RespectsLimit(t *testing.T) {
+	raw := []vector.Result{
+		{Path: "a", Score: 0.9},
+		{Path: "b", Score: 0.8},
+		{Path: "c", Score: 0.7},
+		{Path: "d", Score: 0.6},
+	}
+	got := fileLevelHits(raw, 2)
+	if len(got) != 2 {
+		t.Errorf("want 2 (limit), got %d", len(got))
+	}
+}
+
+func TestFileLevelHits_Empty(t *testing.T) {
+	if got := fileLevelHits(nil, 5); got != nil {
+		t.Errorf("nil input: got %v", got)
+	}
+	if got := fileLevelHits([]vector.Result{{Path: "x"}}, 0); got != nil {
+		t.Errorf("limit 0: got %v", got)
+	}
+}
+
+func TestChunkIdxFromUnitKey(t *testing.T) {
+	cases := []struct {
+		key  string
+		want int
+	}{
+		{"foo.md", -1},
+		{"foo.md#0", 0},
+		{"foo.md#42", 42},
+		{"a/b/c.md#7", 7},
+		{"foo.md#abc", -1},
+		{"foo.md#", -1},
+	}
+	for _, c := range cases {
+		if got := chunkIdxFromUnitKey(c.key); got != c.want {
+			t.Errorf("chunkIdxFromUnitKey(%q) = %d, want %d", c.key, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Replaces the whole-file embedding model with paragraph-aligned chunks and adds an adaptive batch embedder that recovers from server-side limits without aborting the whole indexing pass.

## Why

A v1.2.0 reconcile against a llama.cpp embedding server with a 512-token physical batch limit failed on the first batch (1148-token input rejected) and bailed out entirely, leaving the index empty. Even after fixing the server config, our 30 KB whole-file cap was sized for OpenAI's 8192-token context — wrong for any tighter-context model. Skipping oversized files would also be the wrong default; long sessions and research notes are exactly what semantic search is most useful for.

This PR: chunk every file by paragraph, batch adaptively, never abort the whole pass on one bad input.

## Splitter

`internal/tools/chunk.go`. Every file is split on blank-line runs into paragraph units. Each unit is embedded as its own vector. The only safety cap is `maxParagraphBytes = 3000`: a single paragraph exceeding this gets byte-cut into sequential pieces (rare — single-line files, code blocks). Markdown indentation on the first paragraph is preserved. CRLF normalised; runs of blank lines collapse to one separator.

Unit keys: bare `path` for single-paragraph files (legacy shape, back-compat with v1.2.0 indexes), `path#0`/`path#1`/... for multi-paragraph. The `#` separator is unambiguous because the memory path validator restricts segments to `[a-z0-9.-]`.

## Adaptive batching

`embedWithAdaptiveBatching`:
- Starts at the configured `batch_size` (default 100)
- On batch failure: halves and retries the same range
- At batch size 1: logs + skips that single text + continues
- After 5 consecutive successful batches, doubles back up toward the configured ceiling
- Honors outer `ctx` cancellation between batches

The reconcile/rebuild pass feeds every paragraph from every eligible file into one batcher invocation, so batches amortize across files instead of being torn down between them.

`VectorBuildResult` now exposes `FilesEmbedded`, `UnitsEmbedded`, `UnitsSkipped`, `Eligible`. `rebuild_indexes` surfaces these so the LLM can report e.g. *"247 files / 1,832 paragraphs embedded; skipped 3 paragraphs the embedder rejected at batch size 1"*.

## Index API

Three new chunk-aware methods on `*vector.Index`:
- `HasChunks(path)`: bare-path OR any `path#N`. Used by reconcile to identify files already represented.
- `RemoveChunks(path)`: bare + every `path#N` with all-digit suffix. Pre-step on per-mutation reindex (so a file shrunk from 5 to 2 chunks doesn't leave 3 stale entries).
- `RenameChunks(old, new)`: bulk rename for `memory_move`.

The all-digit suffix check prevents accidental matches against sibling paths that share a prefix (`foo` vs `foobar`). `RemovePrefix` (directory-level deletes) naturally catches chunked entries because chunk keys carry the directory prefix.

## `memory_search` changes

Vector search now oversamples the limit by 10x at the index level (limit 5 → ask for 50 chunk hits), then `fileLevelHits` collapses to one entry per file keeping each file's best-scoring chunk. The snippet shown is **the matched paragraph itself**, not the whole file, so the LLM gets the relevant section directly. Result label includes \`[paragraph N/total]\` so the agent knows which section matched.

Date-filter hardening: filter callbacks now strip `#N` before consulting `fs.Stat`, so date-bounded semantic search works with chunked entries.

## Per-mutation reindex

`memory_write` / `edit` / `append` / `insert` / `restore` now:
1. Split content into paragraphs.
2. Embed all paragraphs in one adaptive-batcher call.
3. `RemoveChunks(path)` **after** successful embed (so a failed reindex doesn't leave the index in a worse state than before).
4. Upsert each paragraph at its unit key.

`memory_delete` → `RemoveChunks`. `memory_move` → `RenameChunks` (no re-embedding; file content unchanged). Empty / whitespace-only files clear any prior entries.

## Backward compatibility

v1.2.0-built indexes have bare-path entries. v1.3.0 loads them as-is and the new code coexists: search returns both flat and chunked hits, `fileLevelHits` dedupes both. On the next per-mutation reindex (or a `rebuild_indexes` call), each file's old bare-path entry gets cleared via `RemoveChunks` before its paragraph units are upserted. No on-disk format change.

## Tests

- `internal/tools/chunk_test.go`: empty input, single/multiple paragraphs, adjacent blank lines, blank lines with whitespace, CRLF, leading/trailing whitespace, oversized-paragraph byte-cut, indentation preservation, unit-key encoding, path/idx extraction.
- `internal/search/vector/vector_test.go`: `RemoveChunks` (with sibling rejection and non-digit suffix preservation), `RenameChunks` (with sibling rejection).
- `internal/tools/vector_test.go`: adaptive batcher single-pass, halve-on-failure, grow-back-after-successes, skip-single-input-failure, context cancellation, empty input. `fileLevelHits` dedup and limit. `chunkIdxFromUnitKey` edge cases.

## Docs

README, AGENTS.md (search/vector + tools/vector descriptions, dispatch tree), `system.md` prompt all updated to describe paragraph-level semantic search behavior.

## Verified

- `go build ./...` clean
- `go test ./...` all green
- `golangci-lint run ./...` 0 issues