### PR TITLE
fix: shutdown handling and reconcile observability

### DIFF
--- a/cmd/faultline/main.go
+++ b/cmd/faultline/main.go
@@ -232,7 +232,10 @@ func main() {
 	toolExec := tools.New(memory, index, tg, sb, email, kb, updater, embedder, vIndex,
 		cfg.Embeddings.BatchSize, logger,
 		cfg.Agent.MaxTokens, cfg.Limits, cfg.Agent.MaxSleep.Duration())
-	defer toolExec.Close()
+	// NOTE: do not defer toolExec.Close() here. The agent owns the tool
+	// executor's lifecycle via the Tools port; agent.Close() (deferred
+	// below) calls tools.Close() exactly once. A second defer here was
+	// previously closing webCache.stop twice and panicking on shutdown.
 
 	state := jsonfile.NewPersister(cfg.Agent.StateFile, logger)
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -205,6 +205,28 @@ func (a *Agent) Run(ctx context.Context, shutdownCh <-chan struct{}) error {
 
 	toolDefs := a.tools.ToolDefs()
 
+	// Derive a context for tool execution that cancels on either parent
+	// ctx done OR graceful-shutdown signal. The single bridge goroutine
+	// below translates a shutdownCh close into a cancellation on toolCtx.
+	//
+	// LLM Chat calls keep using parent ctx so a generation in flight when
+	// shutdown is requested can finish naturally (cutting it off discards
+	// model reasoning and wastes tokens). Long-running tool calls -- in
+	// particular sleep, but also web_fetch, sandbox runs, embeddings --
+	// must yield to graceful shutdown so the save phase reaches quickly.
+	//
+	// gracefulSave below derives its own saveCtx from parent ctx + a 2 min
+	// timeout, so that path is unaffected by toolCtx.
+	toolCtx, cancelToolCtx := context.WithCancel(ctx)
+	defer cancelToolCtx()
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-shutdownCh:
+			cancelToolCtx()
+		}
+	}()
+
 	// Track the message log length and idle streak at the moment of the
 	// last successful save. We only re-save when something has actually
 	// changed since then, so an agent sitting on `select` waiting for
@@ -239,7 +261,7 @@ func (a *Agent) Run(ctx context.Context, shutdownCh <-chan struct{}) error {
 		if tokenEst > a.cfg.Agent.CompactionThreshold {
 			a.logger.Warn("context at compaction threshold, compacting",
 				"tokens_est", tokenEst, "threshold", a.cfg.Agent.CompactionThreshold)
-			messages, prompts, err = a.compactContext(ctx, messages, toolDefs, prompts)
+			messages, prompts, err = a.compactContext(ctx, toolCtx, messages, toolDefs, prompts)
 			if err != nil {
 				return err
 			}
@@ -251,7 +273,7 @@ func (a *Agent) Run(ctx context.Context, shutdownCh <-chan struct{}) error {
 		if tokenEst > int(float64(a.cfg.Agent.MaxTokens)*0.95) {
 			a.logger.Warn("context at hard limit, forcing compaction",
 				"tokens_est", tokenEst, "max", a.cfg.Agent.MaxTokens)
-			messages, prompts, err = a.compactContext(ctx, messages, toolDefs, prompts)
+			messages, prompts, err = a.compactContext(ctx, toolCtx, messages, toolDefs, prompts)
 			if err != nil {
 				return err
 			}
@@ -266,7 +288,7 @@ func (a *Agent) Run(ctx context.Context, shutdownCh <-chan struct{}) error {
 		if idleStreak >= idleForceCompactionThreshold {
 			a.logger.Warn("idle loop detected, forcing compaction",
 				"idle_streak", idleStreak, "tokens_est", tokenEst)
-			messages, prompts, err = a.compactContext(ctx, messages, toolDefs, prompts)
+			messages, prompts, err = a.compactContext(ctx, toolCtx, messages, toolDefs, prompts)
 			if err != nil {
 				return err
 			}
@@ -360,10 +382,13 @@ func (a *Agent) Run(ctx context.Context, shutdownCh <-chan struct{}) error {
 			idleStreak = 0
 
 		case len(msg.ToolCalls) > 0:
-			// Normal tool execution path.
+			// Normal tool execution path. Uses toolCtx (cancels on
+			// graceful shutdown) so long-running tools like sleep
+			// yield to a pending shutdown without waiting for ctx
+			// cancellation (which only happens on the second SIGINT).
 			a.tools.SetContextInfo(a.countMessageTokens(messages))
 			for _, tc := range msg.ToolCalls {
-				result := a.tools.Execute(ctx, tc)
+				result := a.tools.Execute(toolCtx, tc)
 				messages = append(messages, toolMessage(tc.ID, result))
 			}
 			idleStreak = 0
@@ -489,7 +514,12 @@ func (a *Agent) initializeContext() ([]llm.Message, map[string]string, int, erro
 // made to its own prompts during compaction take effect on the next turn.
 // The compaction prompt itself was already rendered before this loop began,
 // so edits to prompts/compaction.md only take effect on the *next* compaction.
-func (a *Agent) compactContext(ctx context.Context, messages []llm.Message, toolDefs []llm.Tool, prompts map[string]string) ([]llm.Message, map[string]string, error) {
+//
+// ctx is the parent context (used for the LLM Chat calls). toolCtx is the
+// tool-execution context derived in Run; it cancels on either ctx done or
+// the graceful-shutdown signal so any tools issued during compaction also
+// honor a shutdown that arrives mid-compaction.
+func (a *Agent) compactContext(ctx context.Context, toolCtx context.Context, messages []llm.Message, toolDefs []llm.Tool, prompts map[string]string) ([]llm.Message, map[string]string, error) {
 	a.logger.Info("starting context compaction")
 
 	// Inject compaction prompt
@@ -532,7 +562,7 @@ func (a *Agent) compactContext(ctx context.Context, messages []llm.Message, tool
 			a.tools.SetContextInfo(a.countMessageTokens(messages))
 
 			for _, tc := range msg.ToolCalls {
-				result := a.tools.Execute(ctx, tc)
+				result := a.tools.Execute(toolCtx, tc)
 				messages = append(messages, toolMessage(tc.ID, result))
 			}
 		} else {

--- a/internal/agent/ports.go
+++ b/internal/agent/ports.go
@@ -61,6 +61,11 @@ type Tokenizer interface {
 // against. Implemented by *tools.Executor. ToolDefs is fixed for the
 // life of the process; Execute runs one tool call and returns the
 // result body that will be wrapped in a tool-role chat message.
+//
+// The agent owns the tool executor's lifecycle: Close is invoked from
+// Agent.Close, so the composition root must not separately defer a
+// close on the same instance. Implementations should still make Close
+// idempotent as a defensive measure.
 type Tools interface {
 	ToolDefs() []llm.Tool
 	Execute(ctx context.Context, call llm.ToolCall) string

--- a/internal/tools/executor.go
+++ b/internal/tools/executor.go
@@ -78,10 +78,11 @@ type webCacheEntry struct {
 
 // webCache is a TTL cache for web_fetch results with proactive eviction.
 type webCache struct {
-	mu      sync.Mutex
-	entries map[string]webCacheEntry
-	ttl     time.Duration
-	stop    chan struct{}
+	mu        sync.Mutex
+	entries   map[string]webCacheEntry
+	ttl       time.Duration
+	stop      chan struct{}
+	closeOnce sync.Once
 }
 
 func newWebCache(ttl time.Duration) *webCache {
@@ -94,9 +95,15 @@ func newWebCache(ttl time.Duration) *webCache {
 	return c
 }
 
-// Close stops the background eviction goroutine.
+// Close stops the background eviction goroutine. Idempotent: safe to
+// call more than once. The Tools port doc declares Close as the
+// agent's responsibility, but a defensive sync.Once guards against any
+// future caller (or doubled-up defer in the composition root) closing
+// the channel twice and panicking.
 func (c *webCache) Close() {
-	close(c.stop)
+	c.closeOnce.Do(func() {
+		close(c.stop)
+	})
 }
 
 // evictLoop periodically removes expired entries.

--- a/internal/tools/vector.go
+++ b/internal/tools/vector.go
@@ -52,6 +52,20 @@ const vectorBatchTimeout = 60 * time.Second
 // single failure on the freshly-doubled size demotes us again.
 const batchGrowSuccesses = 5
 
+// progressLogInterval is the minimum wall-clock gap between two
+// progress log lines emitted from the adaptive batcher. Bounds the
+// log rate on small-batch slogs (e.g. after a halve event when each
+// batch is just a few seconds).
+const progressLogInterval = 30 * time.Second
+
+// progressLogPercentStep is the minimum percent advance that triggers
+// an early progress log even if progressLogInterval has not yet
+// elapsed. Together they give: at least one line every 30s on a slow
+// pass, and at most 10 lines on a fast pass that finishes in under a
+// minute. Quiet on small reconciles (a handful of paragraphs won't
+// cross either threshold).
+const progressLogPercentStep = 10
+
 // vectorEnabled reports whether semantic indexing is wired up. Both
 // the embedder and the index must be non-nil; either being nil is
 // the "feature disabled" path and all helper methods become no-ops.
@@ -538,6 +552,15 @@ func embedWithAdaptiveBatching(ctx context.Context, embedder Embedder, texts []s
 		i         int
 	)
 
+	// Progress reporting state. lastLogTime starts at the entry to the
+	// batcher so the first progress line shows up at most
+	// progressLogInterval after start (rather than progressLogInterval
+	// after the first successful batch). lastLogPercent is the last
+	// reported percent rounded down to the nearest progressLogPercentStep.
+	startTime := time.Now()
+	lastLogTime := startTime
+	lastLogPercent := 0
+
 	for i < len(texts) {
 		// Honor outer cancellation between batches.
 		if err := ctx.Err(); err != nil {
@@ -574,6 +597,37 @@ func embedWithAdaptiveBatching(ctx context.Context, embedder Embedder, texts []s
 					slog.Int("to", newSize))
 				batchSize = newSize
 				successes = 0
+			}
+
+			// Periodic progress log. Throttled so a small reconcile
+			// stays quiet but a long pass (e.g. model swap rebuilding
+			// thousands of paragraphs) gets a heartbeat the operator
+			// can see. Triggers when either the percent advance crosses
+			// the next progressLogPercentStep bucket OR the wall-clock
+			// gap exceeds progressLogInterval. Final summary is logged
+			// by the caller (runVectorBuild) so we don't double up at
+			// 100%.
+			if i < len(texts) {
+				percent := i * 100 / len(texts)
+				now := time.Now()
+				bucket := percent - (percent % progressLogPercentStep)
+				if bucket > lastLogPercent || now.Sub(lastLogTime) >= progressLogInterval {
+					elapsed := now.Sub(startTime).Round(time.Second)
+					var rate float64
+					if elapsed > 0 {
+						rate = float64(i) / elapsed.Seconds()
+					}
+					logger.Info("embed: progress",
+						slog.Int("done", i),
+						slog.Int("total", len(texts)),
+						slog.Int("percent", percent),
+						slog.Float64("rate_par_per_s", rate),
+						slog.Duration("elapsed", elapsed),
+						slog.Int("batch_size", batchSize),
+						slog.Int("skipped", skipped))
+					lastLogTime = now
+					lastLogPercent = bucket
+				}
 			}
 			continue
 		}


### PR DESCRIPTION
## Summary

Three independent fixes triggered by a real production crash on `kraken` (logs in the operator's report):

1. **`fix:`** — `webCache` panicked on shutdown with `close of closed channel`. `Executor.Close()` was being called twice (once via `defer toolExec.Close()` in `main.go`, once via `agent.Close()` → `tools.Close()` through the port). The agent owns the executor's lifecycle via the `Tools` port — drop the duplicate defer in `main.go`, add a `sync.Once` guard in `webCache.Close` as a defensive belt, and document the ownership rule on the port.

2. **`fix:`** — `sleep` (and any other long-running tool) ignored the first-SIGINT graceful shutdown for up to its full duration. The two-phase shutdown closes `shutdownCh` on the first signal but only cancels `ctx` on the second; tools that selected on `ctx.Done()` slept right through the polite save window. A real run observed `sleep` stalling for ~6 minutes after a successful self-update applied. `agent.Run` now derives a `toolCtx` from the parent ctx that also cancels when `shutdownCh` closes (via a single bridge goroutine), and `tools.Execute` receives `toolCtx` in both the normal-loop and compaction paths. LLM `Chat` calls keep using the parent ctx because cutting generations off mid-thought is wasteful; `gracefulSave` already uses its own `saveCtx` with a 2 min budget and is unaffected.

3. **`feat:`** — startup reconcile that re-embeds thousands of paragraphs (after a model swap, typically) was silent for minutes between start and end. `embedWithAdaptiveBatching` now emits a periodic INFO progress line whenever either a 10% advance bucket has been crossed OR 30 s have elapsed since the last log. Quiet on small reconciles, visible on the case that actually matters.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — all packages pass
- `golangci-lint run ./...` — 0 issues

## Notes for review

- Commits are split one-per-fix so each can be reverted independently.
- No new tests added: fix #1 is a defer/lifecycle change covered by build, fix #2 is exercised by the existing run loop, fix #3 is log-only with no behavior change. Happy to add seam-level tests for the agent loop if desired (the ports make it straightforward).
- `feat:` for #3 will land as a minor bump via release-please. The two `fix:` commits land as a patch bump. No `feat!:` — wire and protocol surface unchanged.