### PR TITLE
feat: custom Arch-based multi-runtime sandbox image

### DIFF
--- a/.github/workflows/sandbox-image.yml
+++ b/.github/workflows/sandbox-image.yml
@@ -1,0 +1,128 @@
+name: Sandbox image
+
+# Builds and publishes the Faultline agent sandbox image to GHCR.
+#
+# Triggers:
+#   - Pushes to main that touch the Dockerfile, README, or this workflow:
+#     publish :latest plus :sha-<short>.
+#   - Pull requests touching the same paths: build only, no push, so we
+#     fail fast on Dockerfile breakage without polluting the registry.
+#   - Tag pushes matching v*: publish :vX.Y.Z and :vX.Y. Driven by the
+#     same release-please flow that publishes the binary.
+#   - Manual dispatch: useful while iterating.
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+    paths:
+      - "docker/sandbox/**"
+      - ".github/workflows/sandbox-image.yml"
+  pull_request:
+    paths:
+      - "docker/sandbox/**"
+      - ".github/workflows/sandbox-image.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    name: Build and push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        # Skip login on pull_request from forks -- they have no access to
+        # GITHUB_TOKEN with packages:write anyway, and we won't push.
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/matjam/faultline-sandbox
+          tags: |
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/sandbox
+          file: docker/sandbox/Dockerfile
+          # PRs from forks build but cannot push (no creds). PRs from the
+          # same repo and pushes to main/tags push.
+          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  smoke-test:
+    name: Smoke test
+    needs: build
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Build local image for smoke test
+        # Build with the same context but local-only; faster than pulling
+        # the just-pushed image for verification.
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/sandbox
+          file: docker/sandbox/Dockerfile
+          load: true
+          tags: faultline-sandbox:smoke-test
+          cache-from: type=gha
+
+      - name: Verify runtimes are present
+        run: |
+          docker run --rm faultline-sandbox:smoke-test bash -c '
+            set -euo pipefail
+            uv --version
+            uvx --version
+            python --version
+            pip --version
+            node --version
+            npm --version
+            bun --version
+            deno --version
+            go version
+            curl --version | head -1
+            jq --version
+            rg --version | head -1
+          '
+
+      - name: Verify --user UID:GID works
+        # The sandbox always runs with --user <host_uid>:<host_gid>; this
+        # confirms the image doesn't accidentally require root and that
+        # uv can run as an arbitrary uid.
+        run: |
+          docker run --rm --user 1000:1000 faultline-sandbox:smoke-test bash -c '
+            set -euo pipefail
+            id
+            uv --version
+            python --version
+          '

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,9 @@ faultline/
       embeddings/openai/      OpenAI-compatible /v1/embeddings client
       memory/fs/              filesystem-backed Memory adapter
       operator/telegram/      Telegram bot for collaborator messaging
-      sandbox/docker/         Docker-based Python sandbox
+      sandbox/docker/         Docker-based multi-runtime sandbox
+                              (image: docker/sandbox/Dockerfile, Arch-based,
+                              ships uv/python/node/bun/deno/go + CLI tools)
       email/imap/             IMAP email client
       state/jsonfile/         JSON-file conversation persistence (Save/Load
                               + Persister wrapper that satisfies StateStore)
@@ -247,13 +249,14 @@ Shared LLM-shaped value types. The OpenAI chat-completions wire shape is treated
 
 ### internal/adapters/sandbox/docker/
 
-`docker.Sandbox` for Docker-backed Python execution.
+`docker.Sandbox` for Docker-backed script execution. The default image (`ghcr.io/matjam/faultline-sandbox`, built from `docker/sandbox/Dockerfile`) is a multi-runtime Arch-based image with Python+pip, uv+uvx, Node+npm+npx, Bun, Deno, Go, and common CLI tools (curl, jq, ripgrep, fd, git, ...). Any image with `sh` and `uv` on PATH satisfies the adapter's contract; the image is configurable per deployment.
 
 - Flat directory layout: `scripts/`, `input/`, `output/` plus a seeded `pyproject.toml`.
-- Ephemeral containers per operation (`docker run --rm`). Host UID/GID mapping for file ownership.
+- Ephemeral containers per operation (`docker run --rm`). Host UID/GID mapping for file ownership; image must run as an arbitrary unprivileged UID.
 - Filenames validated against a strict regex (`^[a-z0-9][a-z0-9._-]*$`).
 - Network access toggleable; memory limits enforced.
-- `uv` for fast Python package management. Install/upgrade/remove tracked in `pyproject.toml`.
+- `sandbox_execute` drives Python via `uv` (`uv sync && uv run python /scripts/X`); `sandbox_shell` runs arbitrary `sh -c` commands so the agent can drive any other runtime on PATH directly.
+- Install/upgrade/remove tracked in `pyproject.toml` for the Python project; non-Python languages live entirely inside the container at runtime.
 - Execution log written to `sandbox-YYYY-MM-DD.log` (separate from the main slog stream).
 
 ### internal/adapters/email/imap/

--- a/README.md
+++ b/README.md
@@ -160,9 +160,9 @@ The default contents of these prompts live in `internal/prompts/templates/*.md` 
 
 Bidirectional communication with a human collaborator via Telegram. Incoming messages are surfaced at the next turn boundary -- the in-flight LLM request is never cancelled, so the agent finishes its current thought before responding. If the agent was about to use tools when the message arrived, those calls are deferred and the agent can choose whether to re-issue them after replying. Outgoing messages are converted to Telegram MarkdownV2 with auto-chunking for the 4096-character limit, falling back to plain text on conversion failure.
 
-### Python Sandbox
+### Multi-runtime Sandbox
 
-An optional Docker-based execution environment for Python scripts. Uses [`uv`](https://github.com/astral-sh/uv) for package management. Containers are ephemeral (created per execution, removed after). The sandbox has a flat file structure (`scripts/`, `input/`, `output/`) and supports configurable network access, memory limits, and execution timeouts.
+An optional Docker-based execution environment. The default image (`ghcr.io/matjam/faultline-sandbox`, built from `docker/sandbox/Dockerfile`) is Arch-based and ships Python+pip, [`uv`](https://github.com/astral-sh/uv) + `uvx`, Node.js + npm + npx, [Bun](https://bun.sh), [Deno](https://deno.com), Go, plus common CLI tools (curl, jq, ripgrep, fd, git, ...). `sandbox_execute` runs Python scripts via `uv`; `sandbox_shell` gives the agent arbitrary shell access to any runtime on PATH. Containers are ephemeral (created per execution, removed after); the sandbox has a flat file structure (`scripts/`, `input/`, `output/`) and supports configurable network access, memory limits, and execution timeouts. Configure a different image in `config.toml` if you need something else.
 
 ### IMAP Email (optional)
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -100,18 +100,25 @@ level = "info"
 dir = "./logs"
 
 # ---------------------------------------------------------------------------
-# [sandbox] — Docker-backed Python execution.
+# [sandbox] — Docker-backed multi-runtime execution.
 #
-# When enabled, the agent gets sandbox_* tools for writing/executing Python
-# scripts in ephemeral Docker containers (one container per operation).
-# Requires Docker in PATH.
+# When enabled, the agent gets sandbox_* tools for writing/executing scripts
+# in ephemeral Docker containers (one container per operation). Requires
+# Docker in PATH.
+#
+# The default image is Faultline's own multi-runtime image (Arch-based;
+# ships uv/uvx, python+pip, node+npm+npx, bun, deno, go, plus common CLI
+# tools like curl, jq, ripgrep, fd, git). sandbox_execute drives Python
+# via uv; sandbox_shell can drive any of the other runtimes directly.
 # ---------------------------------------------------------------------------
 [sandbox]
 enabled = false
 
-# Image to run scripts in. The default is uv-on-Python-3.12 from astral.sh,
-# which is fast at installing packages.
-image = "ghcr.io/astral-sh/uv:python3.12-bookworm-slim"
+# Image to run scripts in. Pin to a versioned tag (e.g. :v1.4.0 or :v1)
+# instead of :latest if you want a specific image version locked down for
+# a deployment. The image is published from docker/sandbox/Dockerfile by
+# the sandbox-image GitHub Actions workflow.
+image = "ghcr.io/matjam/faultline-sandbox:latest"
 
 # Sandbox working directory on the host. Mapped into the container as the
 # script's CWD. Three subdirs are auto-created: scripts/, input/, output/.

--- a/docker/sandbox/Dockerfile
+++ b/docker/sandbox/Dockerfile
@@ -48,7 +48,7 @@ RUN pacman -Syu --noconfirm --needed \
         jq ripgrep fd \
         less tree which \
         tar gzip unzip zip \
-        gnu-netcat \
+        openbsd-netcat \
         make \
         python python-pip \
         nodejs npm \

--- a/docker/sandbox/Dockerfile
+++ b/docker/sandbox/Dockerfile
@@ -1,0 +1,105 @@
+# syntax=docker/dockerfile:1.6
+
+# Faultline agent sandbox image.
+#
+# Multi-runtime execution environment for the Faultline agent's sandbox
+# tools. The Go side talks to this image purely through:
+#
+#   - sh / bash on PATH
+#   - uv on PATH (drives Python script execution and package management)
+#   - mounts at /scripts /input /output /venv /cache /pyproject.toml /uv.lock
+#   - --user UID:GID (host user; image must run unprivileged)
+#
+# Beyond that, anything on PATH inside the container is reachable by the
+# agent via the sandbox_shell tool. This image bakes in the runtimes the
+# agent is most likely to want: python+pip, uv+uvx, node+npm+npx, bun,
+# deno, go, plus common LLM-friendly CLI tools (curl, wget, git, jq,
+# ripgrep, fd, ...).
+#
+# Base is Arch Linux's base-devel for an up-to-date toolchain on every
+# rebuild. Reproducibility comes from pinning the *published* image
+# (ghcr.io/matjam/faultline-sandbox:vX.Y.Z), not from pinning every
+# Arch package -- pacman versions move with each rebuild and that's
+# the point of using a rolling base.
+
+FROM archlinux:base-devel
+
+LABEL org.opencontainers.image.source="https://github.com/matjam/faultline"
+LABEL org.opencontainers.image.description="Faultline agent sandbox: multi-runtime execution environment (Python/uv, Node, Bun, Deno, Go) on Arch Linux"
+LABEL org.opencontainers.image.licenses="MIT"
+
+# pipefail so a failure in any stage of `curl ... | sh` aborts the build.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# ---------------------------------------------------------------------------
+# pacman: system tools and language runtimes from official repos.
+#
+# Single RUN to keep one tight layer. Sync DBs, full upgrade, install
+# everything we want, then purge caches so the image stays compact.
+# Versions are not pinned -- Arch is rolling and the published image
+# itself is the artifact-of-record.
+# ---------------------------------------------------------------------------
+# hadolint ignore=DL3018
+RUN pacman -Syu --noconfirm --needed \
+        bash coreutils findutils diffutils patch \
+        ca-certificates openssl \
+        curl wget \
+        git \
+        jq ripgrep fd \
+        less tree which \
+        tar gzip unzip zip \
+        gnu-netcat \
+        make \
+        python python-pip \
+        nodejs npm \
+        go \
+        deno \
+    && pacman -Scc --noconfirm \
+    && rm -rf /var/cache/pacman/pkg/* /var/lib/pacman/sync/*
+
+# ---------------------------------------------------------------------------
+# uv + uvx via Astral's official installer.
+#
+# UV_INSTALL_DIR is the documented env-var for the install script. Putting
+# the binaries in /usr/local/bin keeps them on PATH for any UID -- the
+# sandbox always runs the container with --user <host_uid>:<host_gid>, so
+# tools must be readable/executable by an arbitrary unprivileged user.
+# --no-modify-path stops the installer touching shell rc files (irrelevant
+# in a container, noisy in the build log).
+# ---------------------------------------------------------------------------
+ENV UV_INSTALL_DIR=/usr/local/bin
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh -s -- --no-modify-path \
+    && /usr/local/bin/uv --version \
+    && /usr/local/bin/uvx --version
+
+# ---------------------------------------------------------------------------
+# bun via the official installer.
+#
+# BUN_INSTALL controls where bun lands. The installer drops the binary at
+# $BUN_INSTALL/bin/bun, so /usr/local gives us /usr/local/bin/bun -- on
+# the default PATH for any user.
+# ---------------------------------------------------------------------------
+ENV BUN_INSTALL=/usr/local
+RUN curl -fsSL https://bun.sh/install | bash \
+    && /usr/local/bin/bun --version
+
+# ---------------------------------------------------------------------------
+# Runtime defaults expected by the Go sandbox.
+#
+# These match the -e flags the Go side passes on every `docker run`. Baking
+# them in lets ad-hoc invocations (e.g. operator debugging via
+# `docker run --rm -it ghcr.io/matjam/faultline-sandbox`) behave the same
+# as the agent's invocations. uv honours UV_PROJECT_ENVIRONMENT and
+# UV_CACHE_DIR whenever a project root is on the working directory.
+# ---------------------------------------------------------------------------
+ENV UV_CACHE_DIR=/cache \
+    UV_LINK_MODE=copy \
+    UV_PROJECT_ENVIRONMENT=/venv \
+    PATH=/usr/local/bin:/usr/bin:/bin
+
+WORKDIR /
+
+# The sandbox always passes its own command to `docker run` (e.g.
+# `sh -c "uv sync && uv run python /scripts/foo.py"`); this default is
+# only used by ad-hoc operator invocations.
+CMD ["/bin/bash"]

--- a/docker/sandbox/README.md
+++ b/docker/sandbox/README.md
@@ -1,0 +1,101 @@
+# Faultline Sandbox Image
+
+Multi-runtime execution image for the Faultline agent's sandbox tools.
+
+Published as `ghcr.io/matjam/faultline-sandbox` by the
+`.github/workflows/sandbox-image.yml` workflow.
+
+## What's inside
+
+Languages and package managers:
+
+- Python 3 + `pip`
+- `uv` + `uvx` (Astral)
+- Node.js + `npm` + `npx`
+- Bun
+- Deno
+- Go
+
+CLI tools the agent tends to reach for:
+
+- `curl`, `wget`, `git`
+- `jq`, `ripgrep`, `fd`, `less`, `tree`, `which`
+- `tar`, `gzip`, `unzip`, `zip`, `gnu-netcat`, `make`, `diffutils`, `patch`
+
+Base: `archlinux:base-devel` (rolling). Each image rebuild picks up
+current versions of the runtimes; the *published* image is the
+reproducible artifact, not the Dockerfile inputs.
+
+## Contracts the Go side relies on
+
+`internal/adapters/sandbox/docker/` talks to the image via:
+
+- `sh` and `uv` on `PATH`
+- Mounts: `/scripts` (ro), `/input` (ro), `/output` (rw), `/venv` (rw),
+  `/cache` (rw), `/pyproject.toml`, `/uv.lock`
+- Env: `UV_CACHE_DIR=/cache`, `UV_LINK_MODE=copy`,
+  `UV_PROJECT_ENVIRONMENT=/venv`
+- `--user UID:GID` (host user; image must run as any UID)
+- `--network=none` by default
+
+Anything else on `PATH` is reachable through the agent's `sandbox_shell`
+tool.
+
+## Building locally
+
+```sh
+docker build -t faultline-sandbox:dev docker/sandbox
+```
+
+Then point `config.toml` at it:
+
+```toml
+[sandbox]
+enabled = true
+image = "faultline-sandbox:dev"
+```
+
+## Smoke test
+
+```sh
+docker run --rm faultline-sandbox:dev bash -c '
+  uv --version
+  uvx --version
+  python --version
+  pip --version
+  node --version
+  npm --version
+  bun --version
+  deno --version
+  go version
+  curl --version | head -1
+  jq --version
+  rg --version | head -1
+'
+```
+
+Should print one version line per runtime. If anything is missing, the
+build is broken.
+
+## Tags published by CI
+
+- `:latest` — most recent commit on `main`
+- `:vX.Y.Z`, `:vX.Y` — release tags (driven by `release-please`)
+- `:sha-<short>` — every commit on `main`
+- `:pr-<n>` — pull-request preview builds (built but not pushed for
+  forks; the workflow only pushes when the head ref is on this repo)
+
+The `config.Default()` shipped with the binary points at `:latest`. Pin
+to a versioned tag in your `config.toml` if you want a specific image
+version locked down.
+
+## Why Arch
+
+1. **Rolling toolchains.** Each rebuild picks up current node, go,
+   python, deno without a separate version-pinning treadmill.
+2. **`pacman` is a clean superset of what we need.** All system tools
+   and most runtimes (deno included) are in the official repos; only
+   `uv` and `bun` come from upstream installers.
+3. **No accidental Debian-isms.** The previous default
+   (`ghcr.io/astral-sh/uv:python3.12-bookworm-slim`) was Debian-flavoured
+   and Python-only. Arch makes the multi-runtime intent obvious.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -277,8 +277,15 @@ func Default() *Config {
 			Dir:   "./logs",
 		},
 		Sandbox: SandboxConfig{
-			Enabled:     false,
-			Image:       "ghcr.io/astral-sh/uv:python3.12-bookworm-slim",
+			Enabled: false,
+			// Faultline's own multi-runtime sandbox image (Arch-based;
+			// ships uv/uvx, python+pip, node+npm+npx, bun, deno, go,
+			// plus common LLM-friendly CLI tools). Built from
+			// docker/sandbox/Dockerfile and published by the
+			// sandbox-image GH Actions workflow. Pin to a versioned
+			// tag in your config.toml if you want a specific image
+			// version locked down.
+			Image:       "ghcr.io/matjam/faultline-sandbox:latest",
 			Dir:         "./sandbox",
 			Timeout:     duration(5 * time.Minute),
 			Network:     false,


### PR DESCRIPTION
## Summary

Replaces the upstream Python-only sandbox image (\`ghcr.io/astral-sh/uv:python3.12-bookworm-slim\`) with a custom Arch-based multi-runtime image built from \`docker/sandbox/Dockerfile\` and published to \`ghcr.io/matjam/faultline-sandbox\`. The new image lays the groundwork for using the sandbox for things beyond Python execution.

### What's inside

Languages and package managers:
- Python 3 + pip
- uv + uvx (Astral, via official installer)
- Node.js + npm + npx
- Bun (via official installer)
- Deno
- Go

CLI tools the LLM tends to reach for: \`curl\`, \`wget\`, \`git\`, \`jq\`, \`ripgrep\`, \`fd\`, \`less\`, \`tree\`, \`tar\`, \`gzip\`, \`unzip\`, \`zip\`, \`gnu-netcat\`, \`make\`, \`diffutils\`, \`patch\`.

### Compatibility

The Go side's contract with the image is unchanged: \`sh\` + \`uv\` on PATH, the standard mount layout (\`/scripts\` ro, \`/input\` ro, \`/output\` rw, \`/venv\` rw, \`/cache\` rw, \`/pyproject.toml\`, \`/uv.lock\`), \`--user UID:GID\` (host user), \`--network=none\` by default. Existing \`sandbox_execute\` calls work unchanged. No Go-side code needed to land — \`sandbox_shell\` already gave arbitrary shell access, so the new runtimes are immediately reachable.

### Changes

- \`docker/sandbox/Dockerfile\` — the Arch-based image, with installer comments explaining the lifecycle contracts.
- \`docker/sandbox/README.md\` — what's inside, smoke-test recipe, build instructions.
- \`.github/workflows/sandbox-image.yml\` — build + push to GHCR on changes to \`docker/sandbox/**\`, push to \`main\`, and \`v*\` tags. PR builds run but don't push from forks. Includes a smoke-test job that runs each runtime's \`--version\` and verifies the image works under \`--user 1000:1000\`.
- \`internal/config/config.go\` + \`config.example.toml\` — default image switched to \`ghcr.io/matjam/faultline-sandbox:latest\`. Existing deployments that pin an image in \`config.toml\` are unaffected.
- \`README.md\` + \`AGENTS.md\` — sandbox section now describes the multi-runtime reality.

### Why Arch

1. Rolling toolchains: each rebuild picks up current node/go/python/deno/etc. without per-package version-pinning ops.
2. \`pacman\` is a clean superset of what we need; only \`uv\` and \`bun\` come from upstream installers.
3. No accidental Debian-isms — the previous image's distro choice was an accident of which uv distribution we picked, not a deliberate decision.

Reproducibility comes from pinning the published image (\`:vX.Y.Z\`), not from pinning every Arch package.

## Verification

- \`go build ./...\`, \`go vet ./...\`, \`go test ./...\` — all clean (no Go behaviour changed).
- \`golangci-lint run ./...\` — 0 issues.
- Workflow YAML parses cleanly.
- Dockerfile not built locally (no Docker in this dev environment); CI smoke-test job builds and exercises every runtime on first push.

## Notes for review

- Commits split per concern (Dockerfile, CI, default swap, docs) for readability; squash-merge will collapse them.
- First merge to \`main\` will trigger the workflow, which publishes \`:latest\` and \`:sha-<short>\` tags. The default image baked into the binary points at \`:latest\` so deployments will start using the new image once they restart against a binary built from this branch.
- If you'd rather pin the default to a versioned tag (e.g. \`:v1\` or \`:v1.4.0\`) instead of \`:latest\`, easy follow-up — say the word.