### PR TITLE
feat: Agent Skills support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,9 @@ faultline/
       sandbox/docker/         Docker-based multi-runtime sandbox
                               (image: docker/sandbox/Dockerfile, Arch-based,
                               ships uv/python/node/bun/deno/go + CLI tools)
+      skills/fs/              filesystem-backed Agent Skills catalog
+                              (https://agentskills.io); reads
+                              <root>/<name>/SKILL.md
       email/imap/             IMAP email client
       state/jsonfile/         JSON-file conversation persistence (Save/Load
                               + Persister wrapper that satisfies StateStore)
@@ -91,6 +94,12 @@ cmd/faultline/main.go
         |                            embeddings configured: dual sections)
         |     +-> send_message     (operator port: telegram.Bot)
         |     +-> sandbox_*        (docker.Sandbox)
+        |     +-> skill_activate   (skills/fs.Store; loads SKILL.md body)
+        |     +-> skill_read       (skills/fs.Store; reads bundled resource)
+        |     +-> skill_execute    (docker.Sandbox.ExecuteIsolated with
+        |                            /skill ro + per-call /work rw + /cache)
+        |     +-> skill_work_read  (reads files from a previous skill_execute's
+        |                            /work directory by call_id)
         |     +-> email_fetch      (short-lived imap.Client per call)
         |     +-> context_status   (token usage + kobold.Client.Perf if detected)
         |     +-> get_time         (current timestamp)
@@ -136,6 +145,7 @@ The hexagon. Pure domain logic with no I/O outside what the ports allow.
   | `Tokenizer` | `*kobold.Client` | nil-allowed; agent falls back to heuristic. Includes `Perf()` for context_status diagnostics; returns `*kobold.PerfInfo` (intentional small leak documented in port comment). |
   | `Tools` | `*tools.Executor` | ToolDefs, Execute, SetContextInfo, Close. |
   | `StateStore` | `*jsonfile.Persister` | Save/Load conversation log; binds path + logger at construction. |
+  | `Skills` | `*skillsfs.Store` | nil-allowed; List/Reload for the tier-1 catalog injection in `BuildCycleContext`. Tools layer drives the rest. |
 
 ### internal/config/
 
@@ -258,6 +268,19 @@ Shared LLM-shaped value types. The OpenAI chat-completions wire shape is treated
 - `sandbox_execute` drives Python via `uv` (`uv sync && uv run python /scripts/X`); `sandbox_shell` runs arbitrary `sh -c` commands so the agent can drive any other runtime on PATH directly.
 - Install/upgrade/remove tracked in `pyproject.toml` for the Python project; non-Python languages live entirely inside the container at runtime.
 - Execution log written to `sandbox-YYYY-MM-DD.log` (separate from the main slog stream).
+- `ExecuteIsolated(ctx, command, mounts, network, cwd, env)` is the building block for skill execution: a fresh `docker run --rm` with only the supplied bind-mounts (no `/scripts`, `/input`, `/output`, `/venv`, `/pyproject.toml`), respecting the same `--user UID:GID`, memory, and timeout settings as `Execute`/`ShellExec`. The skill_* tools use this with `/skill` (ro), `/cache` (rw), and a per-call `/work` (rw).
+- `SkillWorkRoot()` and `ResetSkillWork()` manage the per-call scratch root at `<sandbox-dir>/skill-work/`. The composition root calls `ResetSkillWork` at startup so stale `work_id`s from a previous session can't resolve.
+
+### internal/adapters/skills/fs/
+
+`fs.Store` is the filesystem-backed Skills adapter; satisfies the agent's `Skills` port plus extra methods used by the tools layer (`Get`, `Read`, `Resources`).
+
+- Discovery walks `<root>/<name>/SKILL.md` at depth 2; non-skill subdirectories (no SKILL.md) and dotfile dirs (`.git`, etc.) are ignored.
+- Frontmatter parser uses `gopkg.in/yaml.v3` with a one-shot lenient retry that quotes unquoted-colon values (the spec's most common authoring mistake). Strict parse fails with no retry success surface as warnings; the skill is dropped.
+- Lenient validation: name mismatch with directory → use directory name (with diagnostic); over-length name/description/compatibility → diagnostic, still loaded; missing description → hard skip.
+- `Resources(name)` enumerates files under conventional `scripts/`, `references/`, `assets/` subdirs (excluding dotfiles), capped at `MaxResourceListing` (50) entries. Used by `skill_activate` to surface bundled resources without eagerly reading them.
+- `Read(name, relPath)` reads a single resource file; the relative path is rejected if it's absolute or if `filepath.Rel` resolves outside the skill directory.
+- `Reload()` is best-effort: per-skill parse errors log and drop the offending skill but never fail the whole catalog. The agent calls `Reload` on every context rebuild so operator-dropped skills become visible without a restart.
 
 ### internal/adapters/email/imap/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,9 @@ cmd/faultline/main.go
         |                            /skill ro + per-call /work rw + /cache)
         |     +-> skill_work_read  (reads files from a previous skill_execute's
         |                            /work directory by call_id)
+        |     +-> skill_install    (optional; fetches tarball/git URL into
+        |                            skills root, validates SKILL.md, reloads
+        |                            catalog. Gated on [skills] install_enabled)
         |     +-> email_fetch      (short-lived imap.Client per call)
         |     +-> context_status   (token usage + kobold.Client.Perf if detected)
         |     +-> get_time         (current timestamp)

--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ An optional Docker-based execution environment. The default image (`ghcr.io/matj
 
 When `[email]` is configured, the agent gets an `email_fetch` tool that opens a short-lived IMAP connection per call. Useful for letting the agent pick up things its operator emails to a dedicated inbox.
 
+### Agent Skills (optional)
+
+Faultline supports the [Agent Skills](https://agentskills.io) open standard. When `[skills]` is enabled, Faultline scans `<dir>/<skill-name>/SKILL.md` files at startup and on every context rebuild, injects each skill's name + description into the system prompt's "Available Skills" section, and advertises four `skill_*` tools (activate, read, execute, work_read). Skills are operator-supplied folders that bundle specialized instructions plus optional `scripts/`, `references/`, and `assets/` subdirectories. Each `skill_execute` call runs in an isolated Docker container with **only** the named skill's directory mounted at `/skill` (read-only) plus a fresh per-call `/work` scratch directory — skills cannot see the agent's memory, the regular sandbox, or any other skill's data. The sandbox feature must be enabled separately for `skill_execute` to function.
+
 ## Tools
 
 | Category | Tools |
@@ -177,6 +181,7 @@ When `[email]` is configured, the agent gets an `email_fetch` tool that opens a 
 | **System** | `context_status`, `get_time`, `sleep`, `send_message`, `get_version`, `rebuild_indexes` |
 | **Self-update** (when enabled) | `update_check`, `update_apply` |
 | **Sandbox** (when enabled) | `sandbox_write`, `sandbox_read`, `sandbox_edit`, `sandbox_append`, `sandbox_insert`, `sandbox_delete`, `sandbox_rename`, `sandbox_list`, `sandbox_execute`, `sandbox_shell`, `sandbox_install_package`, `sandbox_upgrade_package`, `sandbox_remove_package`, `sandbox_list_packages` |
+| **Skills** (when enabled, ≥1 skill) | `skill_activate`, `skill_read`, `skill_execute`, `skill_work_read` |
 | **Email** (when configured) | `email_fetch` |
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ When `[email]` is configured, the agent gets an `email_fetch` tool that opens a 
 
 Faultline supports the [Agent Skills](https://agentskills.io) open standard. When `[skills]` is enabled, Faultline scans `<dir>/<skill-name>/SKILL.md` files at startup and on every context rebuild, injects each skill's name + description into the system prompt's "Available Skills" section, and advertises four `skill_*` tools (activate, read, execute, work_read). Skills are operator-supplied folders that bundle specialized instructions plus optional `scripts/`, `references/`, and `assets/` subdirectories. Each `skill_execute` call runs in an isolated Docker container with **only** the named skill's directory mounted at `/skill` (read-only) plus a fresh per-call `/work` scratch directory — skills cannot see the agent's memory, the regular sandbox, or any other skill's data. The sandbox feature must be enabled separately for `skill_execute` to function.
 
+When `[skills] install_enabled = true` (off by default), the agent can also install new skills autonomously via `skill_install`, which fetches a tarball URL or git repository into the skills directory after validating that it contains a parseable `SKILL.md`. The catalog reloads on every context rebuild plus immediately after a successful install, so a freshly-installed skill is visible without a restart.
+
 ## Tools
 
 | Category | Tools |
@@ -182,6 +184,7 @@ Faultline supports the [Agent Skills](https://agentskills.io) open standard. Whe
 | **Self-update** (when enabled) | `update_check`, `update_apply` |
 | **Sandbox** (when enabled) | `sandbox_write`, `sandbox_read`, `sandbox_edit`, `sandbox_append`, `sandbox_insert`, `sandbox_delete`, `sandbox_rename`, `sandbox_list`, `sandbox_execute`, `sandbox_shell`, `sandbox_install_package`, `sandbox_upgrade_package`, `sandbox_remove_package`, `sandbox_list_packages` |
 | **Skills** (when enabled, ≥1 skill) | `skill_activate`, `skill_read`, `skill_execute`, `skill_work_read` |
+| **Skills install** (when `install_enabled`) | `skill_install` |
 | **Email** (when configured) | `email_fetch` |
 
 ## Architecture

--- a/cmd/faultline/main.go
+++ b/cmd/faultline/main.go
@@ -258,7 +258,7 @@ func main() {
 	}
 
 	toolExec := tools.New(memory, index, tg, sb, email, kb, updater, embedder, vIndex,
-		skillStore,
+		skillStore, cfg.Skills.InstallEnabled,
 		cfg.Embeddings.BatchSize, logger,
 		cfg.Agent.MaxTokens, cfg.Limits, cfg.Agent.MaxSleep.Duration())
 	// NOTE: do not defer toolExec.Close() here. The agent owns the tool

--- a/cmd/faultline/main.go
+++ b/cmd/faultline/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/matjam/faultline/internal/adapters/memory/fs"
 	"github.com/matjam/faultline/internal/adapters/operator/telegram"
 	"github.com/matjam/faultline/internal/adapters/sandbox/docker"
+	skillsfs "github.com/matjam/faultline/internal/adapters/skills/fs"
 	"github.com/matjam/faultline/internal/adapters/state/jsonfile"
 	"github.com/matjam/faultline/internal/agent"
 	"github.com/matjam/faultline/internal/config"
@@ -229,7 +230,35 @@ func main() {
 		defer flushVectorIndex(vIndex, vectorPath, logger)
 	}
 
+	// Skills (Agent Skills support, https://agentskills.io). Optional;
+	// when configured but the root directory doesn't exist, the catalog
+	// stays empty and Reload picks up skills the operator adds later.
+	var skillStore *skillsfs.Store
+	if cfg.Skills.Active() {
+		skillStore, err = skillsfs.New(cfg.Skills.Dir, logger)
+		if err != nil {
+			logger.Error("init skills store", "error", err, "dir", cfg.Skills.Dir)
+			os.Exit(1)
+		}
+		logger.Info("skills enabled", "dir", skillStore.Root())
+
+		// Wipe the per-call /work scratch root from the previous
+		// session so stale work_ids issued before a restart can't
+		// resolve. The Sandbox is already constructed at this point
+		// when sandbox is enabled; if it's not, skill_execute will
+		// surface a useful error at call time.
+		if sb != nil {
+			if err := sb.ResetSkillWork(); err != nil {
+				logger.Warn("could not reset skill /work root; stale call_ids may resolve",
+					"error", err)
+			}
+		}
+	} else {
+		logger.Info("skills not configured, skill_* tools disabled")
+	}
+
 	toolExec := tools.New(memory, index, tg, sb, email, kb, updater, embedder, vIndex,
+		skillStore,
 		cfg.Embeddings.BatchSize, logger,
 		cfg.Agent.MaxTokens, cfg.Limits, cfg.Agent.MaxSleep.Duration())
 	// NOTE: do not defer toolExec.Close() here. The agent owns the tool
@@ -241,6 +270,15 @@ func main() {
 
 	// --- Agent ---------------------------------------------------------
 
+	// Translate the concrete *skillsfs.Store into the agent.Skills
+	// interface. agent.Skills is nil-allowed; the conversion via a
+	// nil typed pointer would create a non-nil interface, which is
+	// the wrong behavior here -- so guard the conversion explicitly.
+	var skillsPort agent.Skills
+	if skillStore != nil {
+		skillsPort = skillStore
+	}
+
 	a := agent.New(cfg, agent.Deps{
 		Chat:      chat,
 		Memory:    memory,
@@ -249,6 +287,7 @@ func main() {
 		Tokenizer: tokenizer,
 		Tools:     toolExec,
 		State:     state,
+		Skills:    skillsPort,
 	}, logger)
 	defer a.Close()
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -299,3 +299,17 @@ enabled = false
 # <dir>/pdf-processing/SKILL.md. A missing directory is not an error -- the
 # catalog stays empty until the operator drops skills in.
 dir = "./skills"
+
+# Allow the agent to install new skills autonomously via the
+# skill_install tool. When false (the default), skill_install is not
+# advertised at all and the operator must drop skills into Dir manually.
+# When true, the agent can fetch skills from tarball URLs (.tar.gz, .tgz,
+# .tar, .zip) or git repositories (.git URLs, git@ URLs, git+https://, or
+# plain GitHub repo URLs) into Dir. The download is extracted to a temp
+# directory, validated (must contain a SKILL.md that parses cleanly),
+# then moved into the skills root. Existing skills are NOT overwritten.
+# Caps: 50 MiB max download, 5 min total timeout, path-traversal guards
+# on archive entries. Even with this on, the agent's reach is bounded by
+# the standard sandbox feature -- skill_execute still runs every script
+# in an isolated container with only the skill's own directory mounted.
+install_enabled = false

--- a/config.example.toml
+++ b/config.example.toml
@@ -270,3 +270,32 @@ timeout = "30s"
 # and ignore this. OpenAI accepts up to 2048 inputs per call but smaller
 # batches keep individual failures localized.
 batch_size = 100
+
+# ---------------------------------------------------------------------------
+# [skills] — Agent Skills support (https://agentskills.io).
+#
+# When enabled, Faultline scans <dir>/<skill-name>/SKILL.md at startup and
+# on every context rebuild, injects each skill's name + description into
+# the system prompt's "Available Skills" section, and advertises four
+# tools to the LLM: skill_activate (load full instructions), skill_read
+# (read a bundled resource file), skill_execute (run a command in an
+# isolated container with only the skill's directory mounted), and
+# skill_work_read (fetch files the skill produced in its per-call /work
+# scratch dir).
+#
+# Skills are operator-supplied and implicitly trusted: anything dropped
+# into Dir is fair game for the agent. Skill execution always runs
+# through the [sandbox] feature, which must be enabled separately for
+# skill_execute to function. Each skill_execute call mounts only its
+# own skill directory at /skill (read-only), the regular sandbox /cache
+# at /cache (read-write, for shared package caches), and a fresh per-
+# call /work directory at /work (read-write, wiped on agent restart).
+# Skills cannot see the agent's memory or other skills' directories.
+# ---------------------------------------------------------------------------
+[skills]
+enabled = false
+
+# Root directory under which each skill lives in its own subfolder, e.g.
+# <dir>/pdf-processing/SKILL.md. A missing directory is not an error -- the
+# catalog stays empty until the operator drops skills in.
+dir = "./skills"

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,9 @@ require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/Mad-Pixels/goldmark-tgmd v0.0.10
 	github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1
+	golang.org/x/mod v0.35.0
 	golang.org/x/net v0.53.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -35,7 +37,6 @@ require (
 	github.com/sqs/go-xoauth2 v0.0.0-20120917012134-0911dad68e56 // indirect
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
 	github.com/yuin/goldmark v1.6.0 // indirect
-	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -69,5 +69,7 @@ golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=
 golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/adapters/sandbox/docker/docker.go
+++ b/internal/adapters/sandbox/docker/docker.go
@@ -576,6 +576,123 @@ func (s *Sandbox) dockerRun(ctx context.Context, needsNetwork bool, command ...s
 }
 
 // ---------------------------------------------------------------------------
+// Isolated execution (used by skill_execute)
+// ---------------------------------------------------------------------------
+
+// Mount describes one bind-mount for ExecuteIsolated. ContainerPath is
+// where the mount appears inside the container; HostPath is the
+// pre-existing host directory or file. ReadOnly = true adds the ":ro"
+// suffix in the docker run argument.
+type Mount struct {
+	HostPath      string
+	ContainerPath string
+	ReadOnly      bool
+}
+
+// ExecuteIsolated runs `sh -c <command>` inside a fresh container with
+// only the supplied mounts -- no /scripts, /input, /output, /venv, or
+// pyproject.toml from the regular sandbox. Used by the skill_execute
+// tool to give each skill a tightly-scoped filesystem view.
+//
+// `cwd` becomes the container's working directory. `network`
+// independently of the sandbox-wide setting controls whether the
+// container can reach the network (skills sometimes legitimately need
+// it; the caller decides). `env` is applied as additional -e flags
+// after the image's baked-in ENV, so callers can override
+// UV_PROJECT_ENVIRONMENT etc. for the skill.
+//
+// `--user UID:GID` and the global timeout/memory limit are still
+// applied, matching the regular sandbox's security posture.
+func (s *Sandbox) ExecuteIsolated(ctx context.Context, command string, mounts []Mount, network bool, cwd string, env map[string]string) (string, error) {
+	if command == "" {
+		return "", fmt.Errorf("command is required")
+	}
+	if cwd == "" {
+		cwd = "/"
+	}
+
+	containerName := "faultline-skill-" + randomID()
+	args := []string{
+		"run", "--rm",
+		"--name", containerName,
+		"-w", cwd,
+		"--memory", s.memoryLimit,
+		"--user", fmt.Sprintf("%d:%d", s.uid, s.gid),
+	}
+	for _, m := range mounts {
+		spec := m.HostPath + ":" + m.ContainerPath
+		if m.ReadOnly {
+			spec += ":ro"
+		} else {
+			spec += ":rw"
+		}
+		args = append(args, "-v", spec)
+	}
+	for k, v := range env {
+		args = append(args, "-e", k+"="+v)
+	}
+	if !network {
+		args = append(args, "--network=none")
+	}
+	args = append(args, s.image, "sh", "-c", command)
+
+	runCtx, cancel := context.WithTimeout(ctx, s.timeout)
+	defer cancel()
+
+	s.logger.Debug("docker run (isolated)", "container", containerName, "cwd", cwd, "mounts", len(mounts), "network", network)
+	cmd := exec.CommandContext(runCtx, "docker", args...)
+
+	output, err := cmd.CombinedOutput()
+	if runCtx.Err() == context.DeadlineExceeded {
+		s.logger.Warn("isolated sandbox timeout, killing container", "container", containerName)
+		killCmd := exec.Command("docker", "kill", containerName)
+		_ = killCmd.Run()
+		return string(output), fmt.Errorf("execution timed out after %s", s.timeout)
+	}
+	if err != nil {
+		return string(output), fmt.Errorf("docker run failed: %w\nOutput: %s", err, string(output))
+	}
+	return string(output), nil
+}
+
+// Dir returns the absolute host path of the sandbox working
+// directory. Used by callers (e.g. the skill_execute tool) that need
+// to construct sibling paths under the sandbox root.
+func (s *Sandbox) Dir() string {
+	return s.dir
+}
+
+// SkillWorkRoot returns the host directory where per-call /work
+// scratch dirs live. Created lazily; callers should mkdir -p before
+// the first use. The agent loop wipes this on startup to prevent
+// accumulating cruft across restarts.
+func (s *Sandbox) SkillWorkRoot() string {
+	return filepath.Join(s.dir, "skill-work")
+}
+
+// ResetSkillWork wipes and re-creates the skill-work root. Call this
+// at startup so a stale call_id from a previous session can't
+// accidentally resolve. Best-effort: filesystem errors are returned
+// but Faultline can run with skills disabled if this fails.
+func (s *Sandbox) ResetSkillWork() error {
+	root := s.SkillWorkRoot()
+	if err := os.RemoveAll(root); err != nil {
+		return fmt.Errorf("clear skill-work: %w", err)
+	}
+	if err := os.MkdirAll(root, 0755); err != nil {
+		return fmt.Errorf("recreate skill-work: %w", err)
+	}
+	return nil
+}
+
+// Truncate exposes the executor's truncation helper to the tools
+// layer so skill_execute can apply the same output cap as
+// sandbox_execute / sandbox_shell.
+func (s *Sandbox) Truncate(output, suggestion string) string {
+	return s.truncateOutput(output, suggestion)
+}
+
+// ---------------------------------------------------------------------------
 // Script execution
 // ---------------------------------------------------------------------------
 

--- a/internal/adapters/skills/fs/fs.go
+++ b/internal/adapters/skills/fs/fs.go
@@ -200,6 +200,18 @@ func loadSkill(raw []byte, dir, mdPath, dirName string) (*skills.Skill, error) {
 	return sk, nil
 }
 
+// LoadSkillForValidation parses a SKILL.md as if it were being added
+// to the catalog and returns the populated Skill. Exposed for the
+// install-time pre-flight check in the tools layer so a malformed
+// skill is rejected before being moved into the live skills root.
+//
+// The same rules apply as during normal Reload(): missing frontmatter
+// or description is a hard error; lenient issues land in
+// skill.Diagnostics rather than failing the load.
+func LoadSkillForValidation(raw []byte, dir, mdPath, dirName string) (*skills.Skill, error) {
+	return loadSkill(raw, dir, mdPath, dirName)
+}
+
 // List returns all skills in the catalog, ordered by name. The
 // returned slice is a copy of the underlying records; mutating it does
 // not affect the store.

--- a/internal/adapters/skills/fs/fs.go
+++ b/internal/adapters/skills/fs/fs.go
@@ -1,0 +1,344 @@
+package fs
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/matjam/faultline/internal/skills"
+)
+
+// ErrNotFound is returned by Get/Read when the requested skill does
+// not exist in the catalog.
+var ErrNotFound = errors.New("skill not found")
+
+// ErrPathEscape is returned by Read when the requested resource path
+// resolves outside the skill's directory (path traversal attempt).
+var ErrPathEscape = errors.New("resource path escapes skill directory")
+
+// resourceDirs are the optional subdirectories the spec defines.
+// Anything outside these is hidden from the bundled-resources listing
+// at activation time, but still readable via Read for skills with
+// non-conventional layouts.
+var resourceDirs = []string{"scripts", "references", "assets"}
+
+// MaxResourceListing caps how many resources are surfaced in a single
+// activation result. A pathologically large skill won't blow up the
+// activation message; the caller appends a "[truncated]" note when
+// this kicks in.
+const MaxResourceListing = 50
+
+// Store is the filesystem-backed implementation of the agent's Skills
+// port. It owns an in-memory catalog rebuilt by Reload (called at
+// startup and on context rebuild). All methods are safe for concurrent
+// use; the agent's Reload-from-rebuild path serializes naturally with
+// the loop, but tools may call List/Get/Read mid-turn.
+type Store struct {
+	root   string
+	logger *slog.Logger
+
+	mu      sync.RWMutex
+	catalog map[string]*skills.Skill
+	order   []string // sorted skill names for deterministic List output
+}
+
+// New constructs a Store rooted at dir. Reload is called once
+// synchronously so the catalog is populated before the constructor
+// returns. A missing root directory is not a fatal error -- the
+// catalog stays empty and the operator can drop skills in later, with
+// a Reload at the next context rebuild picking them up.
+func New(dir string, logger *slog.Logger) (*Store, error) {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve skills root: %w", err)
+	}
+	s := &Store{
+		root:   abs,
+		logger: logger,
+	}
+	if err := s.Reload(); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// Root returns the absolute path of the skills root directory.
+func (s *Store) Root() string {
+	return s.root
+}
+
+// Reload rescans the skills root directory and rebuilds the in-memory
+// catalog. Called at startup and again on every context rebuild so
+// operator-dropped skills appear without a process restart.
+//
+// Reload is best-effort: per-skill parse errors are logged and the
+// problem skill is dropped from the catalog, but the operation as a
+// whole only fails on filesystem-level issues (e.g. unreadable root).
+// A missing root is treated as "no skills" rather than an error.
+func (s *Store) Reload() error {
+	info, err := os.Stat(s.root)
+	if errors.Is(err, os.ErrNotExist) {
+		// No skills root yet -- equivalent to an empty catalog. Operator
+		// can mkdir it later; next Reload will pick up its contents.
+		s.mu.Lock()
+		s.catalog = nil
+		s.order = nil
+		s.mu.Unlock()
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("stat skills root: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("skills root %q is not a directory", s.root)
+	}
+
+	entries, err := os.ReadDir(s.root)
+	if err != nil {
+		return fmt.Errorf("read skills root: %w", err)
+	}
+
+	catalog := make(map[string]*skills.Skill)
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		// Skip dotfiles and the conventional "exclude" patterns. A
+		// .git directory at the skills root happens when the operator
+		// keeps their skills under git.
+		if strings.HasPrefix(name, ".") {
+			continue
+		}
+		dir := filepath.Join(s.root, name)
+		mdPath := filepath.Join(dir, "SKILL.md")
+		raw, err := os.ReadFile(mdPath)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				// Subdir with no SKILL.md isn't a skill; ignore quietly.
+				continue
+			}
+			s.logger.Warn("skills: SKILL.md unreadable; skipping",
+				slog.String("name", name),
+				slog.String("err", err.Error()))
+			continue
+		}
+
+		sk, err := loadSkill(raw, dir, mdPath, name)
+		if err != nil {
+			s.logger.Warn("skills: skipping malformed skill",
+				slog.String("name", name),
+				slog.String("err", err.Error()))
+			continue
+		}
+
+		// Per the spec: warn on collisions but be deterministic. Within
+		// a single root we shouldn't hit collisions because directory
+		// names must be unique on the filesystem; this is here in case
+		// loadSkill ever rewrites the name (currently it doesn't).
+		if existing, exists := catalog[sk.Name]; exists {
+			s.logger.Warn("skills: name collision; keeping first found",
+				slog.String("name", sk.Name),
+				slog.String("kept", existing.Dir),
+				slog.String("dropped", sk.Dir))
+			continue
+		}
+		catalog[sk.Name] = sk
+
+		for _, d := range sk.Diagnostics {
+			s.logger.Warn("skills: diagnostic during load",
+				slog.String("name", sk.Name),
+				slog.String("msg", d))
+		}
+	}
+
+	order := make([]string, 0, len(catalog))
+	for name := range catalog {
+		order = append(order, name)
+	}
+	sort.Strings(order)
+
+	s.mu.Lock()
+	s.catalog = catalog
+	s.order = order
+	s.mu.Unlock()
+
+	s.logger.Info("skills: catalog loaded",
+		slog.Int("count", len(catalog)),
+		slog.String("root", s.root))
+	return nil
+}
+
+// loadSkill parses a single SKILL.md and returns a populated Skill.
+// Returns an error only when the skill must be skipped entirely
+// (no frontmatter, unparseable YAML, or missing description). Lenient
+// issues (name mismatch, over-length description, etc.) are recorded
+// in skill.Diagnostics and the skill is still returned.
+func loadSkill(raw []byte, dir, mdPath, dirName string) (*skills.Skill, error) {
+	fm, body, ok := splitFrontmatter(raw)
+	if !ok {
+		return nil, errors.New("missing YAML frontmatter")
+	}
+	parsed, err := parseFrontmatter(fm)
+	if err != nil {
+		return nil, err
+	}
+
+	sk := &skills.Skill{
+		Body:        body,
+		Dir:         dir,
+		SkillMDPath: mdPath,
+	}
+	if err := applyFrontmatter(sk, parsed, dirName); err != nil {
+		return nil, err
+	}
+	return sk, nil
+}
+
+// List returns all skills in the catalog, ordered by name. The
+// returned slice is a copy of the underlying records; mutating it does
+// not affect the store.
+func (s *Store) List() []skills.Skill {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]skills.Skill, 0, len(s.order))
+	for _, name := range s.order {
+		out = append(out, *s.catalog[name])
+	}
+	return out
+}
+
+// Get returns the skill with the given name. Returns ErrNotFound if
+// the skill is not in the catalog.
+func (s *Store) Get(name string) (skills.Skill, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sk, ok := s.catalog[name]
+	if !ok {
+		return skills.Skill{}, fmt.Errorf("%w: %q", ErrNotFound, name)
+	}
+	return *sk, nil
+}
+
+// Read returns the contents of a resource file inside the named
+// skill's directory. relPath is interpreted relative to the skill
+// directory and validated to ensure it does not escape via "..". Any
+// path that resolves outside the skill directory returns
+// ErrPathEscape.
+func (s *Store) Read(name, relPath string) (string, error) {
+	sk, err := s.Get(name)
+	if err != nil {
+		return "", err
+	}
+	target, err := resolveResource(sk.Dir, relPath)
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		return "", fmt.Errorf("read %s/%s: %w", name, relPath, err)
+	}
+	return string(data), nil
+}
+
+// resolveResource joins skillDir + relPath, then verifies the result
+// is still under skillDir. Symlinks are not specially handled -- if a
+// skill directory contains a symlink that points outside its dir,
+// reads through that symlink will succeed at the OS level. This is
+// considered the operator's responsibility (skills are trusted; they
+// were dropped into the skills root by the operator).
+func resolveResource(skillDir, relPath string) (string, error) {
+	if relPath == "" {
+		return "", fmt.Errorf("relative path is required")
+	}
+	if filepath.IsAbs(relPath) {
+		return "", fmt.Errorf("%w: absolute paths not allowed", ErrPathEscape)
+	}
+	clean := filepath.Clean(filepath.Join(skillDir, relPath))
+	rel, err := filepath.Rel(skillDir, clean)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("%w: %q", ErrPathEscape, relPath)
+	}
+	return clean, nil
+}
+
+// Resource is one entry in the bundled-resources listing returned by
+// Resources. Path is the skill-relative path; Size is the file size
+// in bytes for files (0 for directories). IsDir distinguishes the two
+// so the agent knows whether a path is something it can read directly.
+type Resource struct {
+	Path  string
+	Size  int64
+	IsDir bool
+}
+
+// Resources walks the conventional resource subdirectories
+// (scripts/, references/, assets/) of the named skill and returns a
+// flat listing of every file underneath them. Hidden files (dotfiles)
+// are skipped. The listing is capped at MaxResourceListing entries;
+// when the cap is hit, Truncated is true so the caller can append a
+// note to the activation message.
+//
+// This is the tier-2 disclosure: when a skill activates, the agent
+// learns what supporting files exist without their content being
+// loaded into context.
+func (s *Store) Resources(name string) (entries []Resource, truncated bool, err error) {
+	sk, err := s.Get(name)
+	if err != nil {
+		return nil, false, err
+	}
+	for _, sub := range resourceDirs {
+		subPath := filepath.Join(sk.Dir, sub)
+		info, statErr := os.Stat(subPath)
+		if statErr != nil || !info.IsDir() {
+			continue
+		}
+		walkErr := filepath.WalkDir(subPath, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			base := d.Name()
+			if strings.HasPrefix(base, ".") && path != subPath {
+				if d.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if path == subPath {
+				return nil // skip the resource-dir root itself
+			}
+			rel, relErr := filepath.Rel(sk.Dir, path)
+			if relErr != nil {
+				return relErr
+			}
+			rel = filepath.ToSlash(rel)
+			if d.IsDir() {
+				entries = append(entries, Resource{Path: rel, IsDir: true})
+				return nil
+			}
+			fi, fiErr := d.Info()
+			if fiErr != nil {
+				return fiErr
+			}
+			entries = append(entries, Resource{Path: rel, Size: fi.Size()})
+			if len(entries) >= MaxResourceListing {
+				truncated = true
+				return filepath.SkipAll
+			}
+			return nil
+		})
+		if walkErr != nil {
+			return entries, truncated, fmt.Errorf("walk %s: %w", sub, walkErr)
+		}
+		if truncated {
+			break
+		}
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Path < entries[j].Path })
+	return entries, truncated, nil
+}

--- a/internal/adapters/skills/fs/fs_test.go
+++ b/internal/adapters/skills/fs/fs_test.go
@@ -1,0 +1,197 @@
+package fs
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// silentLogger returns a slog.Logger that discards everything. Used in
+// tests so per-skill diagnostic logs don't pollute test output.
+func silentLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// writeSkill creates a skill directory under root with the given
+// SKILL.md contents.
+func writeSkill(t *testing.T, root, name, skillMD string) string {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(skillMD), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestStore_DiscoversSkills(t *testing.T) {
+	root := t.TempDir()
+	writeSkill(t, root, "pdf-processing", "---\nname: pdf-processing\ndescription: Handle PDFs.\n---\n\nBody here.\n")
+	writeSkill(t, root, "data-analysis", "---\nname: data-analysis\ndescription: Analyze datasets.\n---\n")
+
+	s, err := New(root, silentLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	skills := s.List()
+	if len(skills) != 2 {
+		t.Fatalf("got %d skills, want 2", len(skills))
+	}
+	if skills[0].Name != "data-analysis" || skills[1].Name != "pdf-processing" {
+		t.Errorf("skills not sorted by name: %v", []string{skills[0].Name, skills[1].Name})
+	}
+}
+
+func TestStore_SkipsMalformedSkills(t *testing.T) {
+	root := t.TempDir()
+	writeSkill(t, root, "good", "---\nname: good\ndescription: Works.\n---\nbody\n")
+	writeSkill(t, root, "no-desc", "---\nname: no-desc\n---\nbody\n")
+	writeSkill(t, root, "no-fence", "no frontmatter at all\n")
+	// dir without SKILL.md
+	if err := os.MkdirAll(filepath.Join(root, "empty"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// dotfile dir
+	if err := os.MkdirAll(filepath.Join(root, ".hidden"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := New(root, silentLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	skills := s.List()
+	if len(skills) != 1 || skills[0].Name != "good" {
+		t.Errorf("expected only 'good' to survive, got %v", skills)
+	}
+}
+
+func TestStore_MissingRootIsNotError(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "does-not-exist")
+	s, err := New(root, silentLogger())
+	if err != nil {
+		t.Fatalf("New on missing root: %v", err)
+	}
+	if got := s.List(); len(got) != 0 {
+		t.Errorf("expected empty catalog, got %d skills", len(got))
+	}
+}
+
+func TestStore_NameMismatchUsesDirectoryNameWithDiagnostic(t *testing.T) {
+	root := t.TempDir()
+	writeSkill(t, root, "pdf-processing", "---\nname: something-else\ndescription: PDFs.\n---\n")
+
+	s, err := New(root, silentLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.Get("pdf-processing")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Name != "pdf-processing" {
+		t.Errorf("expected directory name to win, got %q", got.Name)
+	}
+	if len(got.Diagnostics) == 0 {
+		t.Error("expected a diagnostic about name mismatch")
+	}
+}
+
+func TestStore_GetNotFound(t *testing.T) {
+	s, _ := New(t.TempDir(), silentLogger())
+	if _, err := s.Get("nope"); err == nil {
+		t.Error("Get(nope) returned nil error")
+	}
+}
+
+func TestStore_ReadResource(t *testing.T) {
+	root := t.TempDir()
+	dir := writeSkill(t, root, "with-resources", "---\nname: with-resources\ndescription: Has scripts.\n---\n")
+	scriptsDir := filepath.Join(dir, "scripts")
+	_ = os.MkdirAll(scriptsDir, 0755)
+	_ = os.WriteFile(filepath.Join(scriptsDir, "extract.py"), []byte("print('hi')\n"), 0644)
+
+	s, _ := New(root, silentLogger())
+	got, err := s.Read("with-resources", "scripts/extract.py")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got != "print('hi')\n" {
+		t.Errorf("unexpected content: %q", got)
+	}
+}
+
+func TestStore_ReadRejectsPathEscape(t *testing.T) {
+	root := t.TempDir()
+	writeSkill(t, root, "my-skill", "---\nname: my-skill\ndescription: x.\n---\n")
+
+	s, _ := New(root, silentLogger())
+	for _, bad := range []string{
+		"../../etc/passwd",
+		"/etc/passwd",
+		"scripts/../../escape.txt",
+	} {
+		if _, err := s.Read("my-skill", bad); err == nil {
+			t.Errorf("Read(%q) accepted path escape", bad)
+		}
+	}
+}
+
+func TestStore_ResourcesEnumeration(t *testing.T) {
+	root := t.TempDir()
+	dir := writeSkill(t, root, "skill-x", "---\nname: skill-x\ndescription: x.\n---\n")
+	for _, p := range []struct {
+		path    string
+		content string
+	}{
+		{"scripts/run.py", "x"},
+		{"scripts/helper.py", "x"},
+		{"references/README.md", "x"},
+		{"assets/template.txt", "x"},
+		{"scripts/.hidden.py", "x"}, // dotfile, should be excluded
+		{"random.txt", "x"},         // outside conventional dirs, should be excluded
+	} {
+		full := filepath.Join(dir, p.path)
+		_ = os.MkdirAll(filepath.Dir(full), 0755)
+		_ = os.WriteFile(full, []byte(p.content), 0644)
+	}
+
+	s, _ := New(root, silentLogger())
+	res, truncated, err := s.Resources("skill-x")
+	if err != nil {
+		t.Fatalf("Resources: %v", err)
+	}
+	if truncated {
+		t.Error("did not expect truncation for 4 entries")
+	}
+	want := []string{"assets/template.txt", "references/README.md", "scripts/helper.py", "scripts/run.py"}
+	if len(res) != len(want) {
+		t.Fatalf("got %d entries, want %d (%v)", len(res), len(want), res)
+	}
+	for i, w := range want {
+		if res[i].Path != w {
+			t.Errorf("entry %d: got %q want %q", i, res[i].Path, w)
+		}
+	}
+}
+
+func TestStore_Reload_PicksUpNewSkills(t *testing.T) {
+	root := t.TempDir()
+	writeSkill(t, root, "first", "---\nname: first\ndescription: x.\n---\n")
+	s, _ := New(root, silentLogger())
+	if got := s.List(); len(got) != 1 {
+		t.Fatalf("initial: got %d", len(got))
+	}
+
+	writeSkill(t, root, "second", "---\nname: second\ndescription: y.\n---\n")
+	if err := s.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if got := s.List(); len(got) != 2 {
+		t.Errorf("after reload: got %d", len(got))
+	}
+}

--- a/internal/adapters/skills/fs/parser.go
+++ b/internal/adapters/skills/fs/parser.go
@@ -1,0 +1,234 @@
+// Package fs is the filesystem-backed adapter for the Skills port.
+// Skills are stored as <root>/<skill-name>/SKILL.md plus optional
+// scripts/, references/, and assets/ subdirectories.
+package fs
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/matjam/faultline/internal/skills"
+)
+
+// frontmatterDelim is the YAML frontmatter fence used by SKILL.md.
+var frontmatterDelim = []byte("---")
+
+// rawFrontmatter is the structural shape we extract from SKILL.md
+// before normalising into a domain skills.Skill. Everything is
+// deliberately permissive (string or map) so we don't reject otherwise
+// valid skills on minor type quirks.
+type rawFrontmatter struct {
+	Name          string                 `yaml:"name"`
+	Description   string                 `yaml:"description"`
+	License       string                 `yaml:"license"`
+	Compatibility string                 `yaml:"compatibility"`
+	Metadata      map[string]interface{} `yaml:"metadata"`
+	AllowedTools  string                 `yaml:"allowed-tools"`
+}
+
+// splitFrontmatter pulls the YAML frontmatter and body apart. Returns:
+//
+//   - frontmatter bytes: everything between the opening "---" line and
+//     the matching closing "---" line, exclusive.
+//   - body string: everything after the closing "---", trimmed.
+//
+// Returns ok=false when no frontmatter is present (the file doesn't
+// start with "---" on its own line). The caller treats that as a hard
+// error: a SKILL.md without frontmatter has no name or description and
+// can't be loaded.
+func splitFrontmatter(content []byte) (frontmatter []byte, body string, ok bool) {
+	// Normalise CRLF to LF so the line scanner works regardless of how
+	// the file was authored. SKILL.md authored on Windows is common.
+	content = bytes.ReplaceAll(content, []byte("\r\n"), []byte("\n"))
+
+	// Strip a leading UTF-8 BOM if present -- some editors prepend one,
+	// and a BOM in front of the opening "---" would prevent a match.
+	content = bytes.TrimPrefix(content, []byte("\xef\xbb\xbf"))
+
+	lines := bytes.SplitN(content, []byte("\n"), 2)
+	if len(lines) < 2 || !bytes.Equal(bytes.TrimSpace(lines[0]), frontmatterDelim) {
+		return nil, "", false
+	}
+
+	rest := lines[1]
+	closeIdx := indexLine(rest, frontmatterDelim)
+	if closeIdx < 0 {
+		return nil, "", false
+	}
+
+	frontmatter = rest[:closeIdx]
+	body = strings.TrimSpace(string(rest[closeIdx+len(frontmatterDelim):]))
+	// Strip a leading newline left over from the closing fence.
+	body = strings.TrimLeft(body, "\n")
+	return frontmatter, body, true
+}
+
+// indexLine returns the byte offset of the first line in `data` that
+// equals (after trim) `target`, or -1 if not found. Includes the
+// trailing newline before the matched line so the caller can slice the
+// frontmatter cleanly.
+func indexLine(data, target []byte) int {
+	pos := 0
+	for pos < len(data) {
+		nl := bytes.IndexByte(data[pos:], '\n')
+		var line []byte
+		var lineEnd int
+		if nl < 0 {
+			line = data[pos:]
+			lineEnd = len(data)
+		} else {
+			line = data[pos : pos+nl]
+			lineEnd = pos + nl
+		}
+		if bytes.Equal(bytes.TrimSpace(line), target) {
+			return pos
+		}
+		if nl < 0 {
+			return -1
+		}
+		pos = lineEnd + 1
+	}
+	return -1
+}
+
+// parseFrontmatter parses a YAML frontmatter block into rawFrontmatter.
+// Applies a one-shot lenient retry: if the first parse fails on the
+// common "unquoted colon in value" mistake the spec calls out, retry
+// with values quoted.
+func parseFrontmatter(frontmatter []byte) (rawFrontmatter, error) {
+	var raw rawFrontmatter
+	if err := yaml.Unmarshal(frontmatter, &raw); err == nil {
+		return raw, nil
+	} else {
+		// Try the lenient retry. If it still fails, surface the original
+		// error -- the operator gets the more diagnostic message.
+		retried, retryErr := lenientRetry(frontmatter)
+		if retryErr == nil {
+			if err2 := yaml.Unmarshal(retried, &raw); err2 == nil {
+				return raw, nil
+			}
+		}
+		return raw, fmt.Errorf("yaml parse: %w", err)
+	}
+}
+
+// lenientRetry rewrites the frontmatter to quote any value containing
+// an unescaped colon-then-space sequence in a `key: value` line. This
+// covers the common authoring mistake the agentskills spec calls out:
+//
+//	description: Use this skill when: the user asks about PDFs
+//
+// where the second `:` confuses the YAML parser. We only quote when
+// the value is otherwise unquoted (no leading "/' and not starting
+// with a YAML control char) and we leave already-valid lines alone.
+//
+// This is a heuristic, not a full YAML rewriter. It's deliberately
+// limited to the single most common compatibility issue.
+func lenientRetry(frontmatter []byte) ([]byte, error) {
+	lines := bytes.Split(frontmatter, []byte("\n"))
+	for i, line := range lines {
+		// Only consider top-level scalar `key: value` lines (not
+		// indented keys, not list items, not blank, not comments).
+		trim := bytes.TrimSpace(line)
+		if len(trim) == 0 || trim[0] == '#' || trim[0] == '-' {
+			continue
+		}
+		if line[0] == ' ' || line[0] == '\t' {
+			// indented -- part of a map; skip
+			continue
+		}
+		colon := bytes.Index(line, []byte(": "))
+		if colon < 0 {
+			continue
+		}
+		key := bytes.TrimSpace(line[:colon])
+		value := bytes.TrimSpace(line[colon+2:])
+		if len(value) == 0 {
+			continue
+		}
+		// Already quoted or block-scalar -> leave alone.
+		first := value[0]
+		if first == '"' || first == '\'' || first == '|' || first == '>' || first == '[' || first == '{' {
+			continue
+		}
+		// If the value contains another `:` followed by space, quoting it
+		// is the fix. (A trailing `:` is fine in plain YAML; only `: ` mid-
+		// value confuses the parser.)
+		if bytes.Contains(value, []byte(": ")) {
+			// Escape any embedded double quote and wrap.
+			escaped := bytes.ReplaceAll(value, []byte(`"`), []byte(`\"`))
+			rebuilt := append([]byte{}, key...)
+			rebuilt = append(rebuilt, []byte(": \"")...)
+			rebuilt = append(rebuilt, escaped...)
+			rebuilt = append(rebuilt, '"')
+			lines[i] = rebuilt
+		}
+	}
+	return bytes.Join(lines, []byte("\n")), nil
+}
+
+// stringMap normalises a yaml.v3 untyped-map value into the
+// map[string]string Skill.Metadata wants. yaml.v3 returns interface{}
+// for arbitrary values; we stringify each one with fmt.Sprintf. Nested
+// maps/slices are flattened to their Go default formatting -- the
+// skill author's responsibility to keep metadata simple.
+func stringMap(in map[string]interface{}) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = fmt.Sprintf("%v", v)
+	}
+	return out
+}
+
+// applyFrontmatter populates a Skill from a parsed rawFrontmatter
+// block. dirName is the parent directory's basename, used to detect
+// name mismatches under lenient validation.
+//
+// Returns nil if the skill is loadable (potentially with diagnostics);
+// returns an error only when the skill must be skipped entirely
+// (description missing).
+func applyFrontmatter(s *skills.Skill, raw rawFrontmatter, dirName string) error {
+	// Name: the spec says it must match the directory. Lenient: if the
+	// frontmatter name is missing, fall back to the directory name; if
+	// it disagrees, prefer the directory name so the catalog key stays
+	// stable, and record a diagnostic.
+	name := raw.Name
+	if name == "" {
+		name = dirName
+		s.Diagnostics = append(s.Diagnostics, "frontmatter has no `name` field; using directory name")
+	} else if name != dirName {
+		s.Diagnostics = append(s.Diagnostics, fmt.Sprintf("frontmatter name %q does not match directory %q; using directory name", name, dirName))
+		name = dirName
+	}
+	if err := skills.ValidateName(name); err != nil {
+		s.Diagnostics = append(s.Diagnostics, "name is not spec-clean: "+err.Error())
+	}
+	s.Name = name
+
+	// Description: hard error if missing or empty -- nothing to put in
+	// the catalog. Over-length is a warning.
+	desc := strings.TrimSpace(raw.Description)
+	if desc == "" {
+		return fmt.Errorf("description is missing or empty")
+	}
+	if err := skills.ValidateDescription(desc); err != nil {
+		s.Diagnostics = append(s.Diagnostics, err.Error())
+	}
+	s.Description = desc
+
+	s.License = strings.TrimSpace(raw.License)
+	s.Compatibility = strings.TrimSpace(raw.Compatibility)
+	if s.Compatibility != "" && len(s.Compatibility) > skills.MaxCompatLen {
+		s.Diagnostics = append(s.Diagnostics, fmt.Sprintf("compatibility exceeds %d characters", skills.MaxCompatLen))
+	}
+	s.AllowedTools = strings.TrimSpace(raw.AllowedTools)
+	s.Metadata = stringMap(raw.Metadata)
+
+	return nil
+}

--- a/internal/adapters/skills/fs/parser_test.go
+++ b/internal/adapters/skills/fs/parser_test.go
@@ -1,0 +1,88 @@
+package fs
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSplitFrontmatter_Basic(t *testing.T) {
+	input := []byte("---\nname: foo\ndescription: bar\n---\n\n# Body\n\nHello.\n")
+	fm, body, ok := splitFrontmatter(input)
+	if !ok {
+		t.Fatal("splitFrontmatter returned ok=false")
+	}
+	if !strings.Contains(string(fm), "name: foo") {
+		t.Errorf("frontmatter missing name: got %q", fm)
+	}
+	if !strings.HasPrefix(body, "# Body") {
+		t.Errorf("body unexpected: got %q", body)
+	}
+}
+
+func TestSplitFrontmatter_CRLF(t *testing.T) {
+	input := []byte("---\r\nname: foo\r\ndescription: bar\r\n---\r\nbody\r\n")
+	_, body, ok := splitFrontmatter(input)
+	if !ok {
+		t.Fatal("splitFrontmatter returned ok=false on CRLF input")
+	}
+	if !strings.HasPrefix(body, "body") {
+		t.Errorf("body unexpected: got %q", body)
+	}
+}
+
+func TestSplitFrontmatter_BOM(t *testing.T) {
+	input := []byte("\xef\xbb\xbf---\nname: foo\ndescription: bar\n---\nbody\n")
+	_, _, ok := splitFrontmatter(input)
+	if !ok {
+		t.Fatal("splitFrontmatter returned ok=false on BOM input")
+	}
+}
+
+func TestSplitFrontmatter_NoFrontmatter(t *testing.T) {
+	input := []byte("# Just markdown\n\nNo frontmatter here.\n")
+	_, _, ok := splitFrontmatter(input)
+	if ok {
+		t.Error("splitFrontmatter returned ok=true for missing frontmatter")
+	}
+}
+
+func TestSplitFrontmatter_UnclosedFence(t *testing.T) {
+	input := []byte("---\nname: foo\ndescription: bar\nthis never closes\n")
+	_, _, ok := splitFrontmatter(input)
+	if ok {
+		t.Error("splitFrontmatter returned ok=true for unclosed frontmatter")
+	}
+}
+
+func TestParseFrontmatter_Strict(t *testing.T) {
+	input := []byte("name: foo\ndescription: bar baz\nlicense: MIT\n")
+	raw, err := parseFrontmatter(input)
+	if err != nil {
+		t.Fatalf("parseFrontmatter: %v", err)
+	}
+	if raw.Name != "foo" || raw.Description != "bar baz" || raw.License != "MIT" {
+		t.Errorf("unexpected raw: %+v", raw)
+	}
+}
+
+func TestParseFrontmatter_LenientRetry_UnquotedColonInValue(t *testing.T) {
+	// The spec calls out this exact authoring mistake. Strict YAML
+	// parse fails because "Use this skill when:" looks like a nested
+	// key-value pair. Our lenient retry quotes it.
+	input := []byte("name: pdf\ndescription: Use this skill when: the user asks about PDFs\n")
+	raw, err := parseFrontmatter(input)
+	if err != nil {
+		t.Fatalf("parseFrontmatter: %v", err)
+	}
+	if !strings.HasPrefix(raw.Description, "Use this skill when:") {
+		t.Errorf("description not preserved through lenient retry: %q", raw.Description)
+	}
+}
+
+func TestParseFrontmatter_TotallyBroken(t *testing.T) {
+	// Unbalanced brackets should fail even with lenient retry.
+	input := []byte("name: [foo\n  description: bar\n")
+	if _, err := parseFrontmatter(input); err == nil {
+		t.Error("parseFrontmatter accepted unparseable YAML")
+	}
+}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -18,6 +18,7 @@ import (
 	"github.com/matjam/faultline/internal/llm"
 	prompt "github.com/matjam/faultline/internal/prompts"
 	"github.com/matjam/faultline/internal/search/bm25"
+	skillsdomain "github.com/matjam/faultline/internal/skills"
 )
 
 // Agent is the autonomous agent that runs in a continuous loop.
@@ -30,6 +31,7 @@ type Agent struct {
 	tokenizer Tokenizer // nil when no real tokenizer is detected
 	tools     Tools
 	state     StateStore
+	skills    Skills // nil when skills support is disabled
 	logger    *slog.Logger
 }
 
@@ -44,11 +46,12 @@ type Deps struct {
 	Tokenizer Tokenizer // optional
 	Tools     Tools
 	State     StateStore
+	Skills    Skills // optional
 }
 
 // New constructs an Agent. Any nil-allowed dependency (Operator,
-// Tokenizer) may be left as a nil interface; the agent handles those
-// cases internally with heuristic fallbacks.
+// Tokenizer, Skills) may be left as a nil interface; the agent handles
+// those cases internally with heuristic fallbacks or empty catalogs.
 func New(cfg *config.Config, deps Deps, logger *slog.Logger) *Agent {
 	return &Agent{
 		cfg:       cfg,
@@ -59,8 +62,25 @@ func New(cfg *config.Config, deps Deps, logger *slog.Logger) *Agent {
 		tokenizer: deps.Tokenizer,
 		tools:     deps.Tools,
 		state:     deps.State,
+		skills:    deps.Skills,
 		logger:    logger,
 	}
+}
+
+// gatherSkillCatalog returns the current skill catalog for system-prompt
+// injection. Returns nil when skills support is disabled. Reload errors
+// are logged but never fatal -- a transient filesystem hiccup
+// shouldn't kill the agent loop, and the previous catalog stays in
+// place until the next attempt.
+func (a *Agent) gatherSkillCatalog() []skillsdomain.Skill {
+	if a.skills == nil {
+		return nil
+	}
+	if err := a.skills.Reload(); err != nil {
+		a.logger.Warn("skills: reload failed; using previous catalog",
+			"error", err)
+	}
+	return a.skills.List()
 }
 
 // Close releases the resources owned by the agent. Adapters whose
@@ -454,12 +474,13 @@ func (a *Agent) initializeContext() ([]llm.Message, map[string]string, int, erro
 		return nil, nil, 0, fmt.Errorf("load prompts: %w", err)
 	}
 
-	// Build a fresh system message from current prompts + recent memories.
-	// This is used both for fresh starts and for replacing the (stale)
-	// system message in a restored state file.
+	// Build a fresh system message from current prompts + recent memories
+	// + current skill catalog. This is used both for fresh starts and
+	// for replacing the (stale) system message in a restored state file.
 	memories := a.gatherContextMemories()
+	skillCatalog := a.gatherSkillCatalog()
 	now := time.Now()
-	fullSystemPrompt := prompt.BuildCycleContext(prompts["system"], memories, now, a.cfg.Limits.RecentMemoryChars)
+	fullSystemPrompt := prompt.BuildCycleContext(prompts["system"], memories, skillCatalog, now, a.cfg.Limits.RecentMemoryChars)
 	systemMsg := llm.Message{
 		Role:    llm.RoleSystem,
 		Content: fullSystemPrompt,
@@ -590,10 +611,12 @@ func (a *Agent) rebuildContext(summary string) ([]llm.Message, map[string]string
 		return nil, nil, fmt.Errorf("load prompts: %w", err)
 	}
 
-	// Load fresh memories
+	// Load fresh memories and refresh the skill catalog so any skills
+	// the operator has dropped in since the last cycle become visible.
 	memories := a.gatherContextMemories()
+	skillCatalog := a.gatherSkillCatalog()
 	now := time.Now()
-	fullSystemPrompt := prompt.BuildCycleContext(prompts["system"], memories, now, a.cfg.Limits.RecentMemoryChars)
+	fullSystemPrompt := prompt.BuildCycleContext(prompts["system"], memories, skillCatalog, now, a.cfg.Limits.RecentMemoryChars)
 
 	messages := []llm.Message{
 		{Role: llm.RoleSystem, Content: fullSystemPrompt},

--- a/internal/agent/ports.go
+++ b/internal/agent/ports.go
@@ -6,6 +6,7 @@ import (
 	"github.com/matjam/faultline/internal/adapters/llm/kobold"
 	"github.com/matjam/faultline/internal/llm"
 	"github.com/matjam/faultline/internal/search/bm25"
+	"github.com/matjam/faultline/internal/skills"
 )
 
 // ChatModel is the LLM port. The agent does not care which backend
@@ -79,4 +80,18 @@ type Tools interface {
 type StateStore interface {
 	Save(messages []llm.Message, idleStreak int) error
 	Load() ([]llm.Message, int, error)
+}
+
+// Skills is the catalog port for Agent Skills support
+// (https://agentskills.io). The agent uses List() to inject the
+// tier-1 catalog into the system prompt and Reload() on context
+// rebuild so operator-dropped skills become visible without a
+// restart. Get/Read are not used by the agent loop directly; the
+// tools layer drives skill activation and resource reads.
+//
+// May be nil when skills support is disabled or the configured root
+// directory is unset.
+type Skills interface {
+	List() []skills.Skill
+	Reload() error
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,12 @@ type Config struct {
 	// alongside BM25 in memory_search and memory mutations re-embed
 	// the affected file synchronously.
 	Embeddings EmbeddingsConfig `toml:"embeddings"`
+
+	// Skills is optional; when Enabled, the agent scans the configured
+	// directory for Agent Skills (https://agentskills.io) at startup
+	// and on every context rebuild, injects a tier-1 catalog into the
+	// system prompt, and advertises skill_* tools.
+	Skills SkillsConfig `toml:"skills"`
 }
 
 // APIConfig holds LLM API connection settings.
@@ -227,6 +233,35 @@ func (e EmbeddingsConfig) Active() bool {
 	return e.Enabled && e.URL != "" && e.Model != ""
 }
 
+// SkillsConfig holds Agent Skills settings. When Enabled, Faultline
+// scans the Dir directory for skill folders (each containing a
+// SKILL.md), injects their name + description into the system prompt
+// at startup and on context rebuild, and advertises skill_activate,
+// skill_read, skill_execute, and skill_work_read tools to the LLM.
+//
+// Skills are operator-supplied and implicitly trusted: anything the
+// operator drops into Dir is fair game for the agent to load and
+// execute. Skill execution always runs through the Docker sandbox
+// with a per-call /work scratch directory; the sandbox feature must
+// be enabled separately for skill_execute to function.
+type SkillsConfig struct {
+	// Enabled toggles skill discovery and the skill_* tools.
+	Enabled bool `toml:"enabled"`
+
+	// Dir is the root directory under which each skill lives in its
+	// own subfolder, e.g. <Dir>/<skill-name>/SKILL.md. Defaults to
+	// "./skills". Created lazily by the operator; a missing directory
+	// is not an error -- the catalog stays empty until skills appear.
+	Dir string `toml:"dir"`
+}
+
+// Active reports whether skills support is wired up. Mirrors the
+// pattern used by EmbeddingsConfig.Active so callers don't have to
+// check both Enabled and the minimum required fields.
+func (s SkillsConfig) Active() bool {
+	return s.Enabled && s.Dir != ""
+}
+
 // EmailConfig holds optional IMAP email connection settings.
 type EmailConfig struct {
 	Host     string `toml:"host"`
@@ -311,6 +346,10 @@ func Default() *Config {
 			Model:     "text-embedding-3-small",
 			Timeout:   duration(30 * time.Second),
 			BatchSize: 100,
+		},
+		Skills: SkillsConfig{
+			Enabled: false,
+			Dir:     "./skills",
 		},
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -253,6 +253,14 @@ type SkillsConfig struct {
 	// "./skills". Created lazily by the operator; a missing directory
 	// is not an error -- the catalog stays empty until skills appear.
 	Dir string `toml:"dir"`
+
+	// InstallEnabled gates the skill_install tool. When false (the
+	// default), the agent cannot install skills autonomously and the
+	// tool is not advertised at all. When true, the agent can fetch
+	// skills from tarball URLs or git repositories into Dir; this
+	// gives the agent significant filesystem and network capability,
+	// so opt in deliberately.
+	InstallEnabled bool `toml:"install_enabled"`
 }
 
 // Active reports whether skills support is wired up. Mirrors the

--- a/internal/prompts/cycle_test.go
+++ b/internal/prompts/cycle_test.go
@@ -6,11 +6,12 @@ import (
 	"time"
 
 	"github.com/matjam/faultline/internal/search/bm25"
+	"github.com/matjam/faultline/internal/skills"
 )
 
 func TestBuildCycleContext_NoMemories(t *testing.T) {
 	now := time.Date(2026, 4, 27, 10, 30, 0, 0, time.UTC)
-	got := BuildCycleContext("SYSTEM PROMPT", nil, now, 2000)
+	got := BuildCycleContext("SYSTEM PROMPT", nil, nil, now, 2000)
 
 	if !strings.Contains(got, "SYSTEM PROMPT") {
 		t.Error("output missing system prompt")
@@ -21,6 +22,9 @@ func TestBuildCycleContext_NoMemories(t *testing.T) {
 	if strings.Contains(got, "Recent Memories") {
 		t.Error("output should not have Recent Memories section when no memories provided")
 	}
+	if strings.Contains(got, "Available Skills") {
+		t.Error("output should not have Available Skills section when no skills provided")
+	}
 }
 
 func TestBuildCycleContext_WithMemories(t *testing.T) {
@@ -29,7 +33,7 @@ func TestBuildCycleContext_WithMemories(t *testing.T) {
 		{Path: "alpha.md", Content: "alpha content"},
 		{Path: "beta.md", Content: "beta content"},
 	}
-	got := BuildCycleContext("SYS", mems, now, 2000)
+	got := BuildCycleContext("SYS", mems, nil, now, 2000)
 
 	if !strings.Contains(got, "Recent Memories") {
 		t.Error("missing Recent Memories header")
@@ -48,7 +52,7 @@ func TestBuildCycleContext_WithMemories(t *testing.T) {
 func TestBuildCycleContext_TruncatesLongMemory(t *testing.T) {
 	long := strings.Repeat("x", 3000)
 	mems := []bm25.Result{{Path: "long.md", Content: long}}
-	got := BuildCycleContext("SYS", mems, time.Now(), 2000)
+	got := BuildCycleContext("SYS", mems, nil, time.Now(), 2000)
 
 	if !strings.Contains(got, "[truncated") {
 		t.Error("expected truncation marker for long memory")
@@ -70,12 +74,48 @@ func TestBuildCycleContext_TruncatesLongMemory(t *testing.T) {
 func TestBuildCycleContext_NoLimitKeepsFullContent(t *testing.T) {
 	long := strings.Repeat("x", 3000)
 	mems := []bm25.Result{{Path: "long.md", Content: long}}
-	got := BuildCycleContext("SYS", mems, time.Now(), 0)
+	got := BuildCycleContext("SYS", mems, nil, time.Now(), 0)
 
 	if strings.Contains(got, "[truncated") {
 		t.Error("did not expect truncation marker when limit is disabled")
 	}
 	if strings.Count(got, "x") < 3000 {
 		t.Errorf("expected full 3000 x's when limit disabled; got %d", strings.Count(got, "x"))
+	}
+}
+
+func TestBuildCycleContext_WithSkills(t *testing.T) {
+	cat := []skills.Skill{
+		{Name: "pdf-processing", Description: "Handle PDFs."},
+		{Name: "data-analysis", Description: "Analyze datasets."},
+	}
+	got := BuildCycleContext("SYS", nil, cat, time.Now(), 2000)
+
+	if !strings.Contains(got, "## Available Skills") {
+		t.Error("missing Available Skills header")
+	}
+	if !strings.Contains(got, "**pdf-processing**: Handle PDFs.") {
+		t.Errorf("missing pdf-processing entry; got %q", got)
+	}
+	if !strings.Contains(got, "**data-analysis**: Analyze datasets.") {
+		t.Error("missing data-analysis entry")
+	}
+	if !strings.Contains(got, "skill_activate") {
+		t.Error("missing skill_activate instruction")
+	}
+}
+
+func TestBuildCycleContext_SkillsAndMemoriesTogether(t *testing.T) {
+	cat := []skills.Skill{{Name: "x", Description: "x."}}
+	mems := []bm25.Result{{Path: "m.md", Content: "memory body"}}
+	got := BuildCycleContext("SYS", mems, cat, time.Now(), 2000)
+
+	skillsIdx := strings.Index(got, "## Available Skills")
+	memIdx := strings.Index(got, "## Recent Memories")
+	if skillsIdx < 0 || memIdx < 0 {
+		t.Fatalf("missing one or both sections: skillsIdx=%d memIdx=%d", skillsIdx, memIdx)
+	}
+	if skillsIdx > memIdx {
+		t.Error("skills section should appear before memories")
 	}
 }

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/matjam/faultline/internal/search/bm25"
+	"github.com/matjam/faultline/internal/skills"
 )
 
 // Embedded default prompt contents, compiled into the binary from templates/.
@@ -164,16 +165,29 @@ func Render(template string, now time.Time) string {
 	return result
 }
 
-// BuildCycleContext assembles the full system message with recent memories.
-// memoryCharLimit caps the per-entry content size; when exceeded, a
-// retrieval hint is appended pointing the agent at memory_read so it can
-// load the rest of the file. A non-positive limit disables the cap.
-func BuildCycleContext(systemPrompt string, memories []bm25.Result, now time.Time, memoryCharLimit int) string {
+// BuildCycleContext assembles the full system message with recent
+// memories and (optionally) the skill catalog. Both sections are
+// omitted entirely when their input slice is empty -- no empty
+// headers in the rendered prompt.
+//
+// memoryCharLimit caps the per-entry memory excerpt size; when
+// exceeded, a retrieval hint is appended pointing the agent at
+// memory_read. A non-positive limit disables the cap.
+//
+// skillCatalog, when non-empty, is rendered as an "## Available
+// Skills" section with a brief instruction telling the agent to call
+// skill_activate when a task matches a skill's description. Each
+// entry costs ~50-100 tokens, matching the spec's tier-1 disclosure.
+func BuildCycleContext(systemPrompt string, memories []bm25.Result, skillCatalog []skills.Skill, now time.Time, memoryCharLimit int) string {
 	var sb strings.Builder
 
 	sb.WriteString(systemPrompt)
 	sb.WriteString("\n\n---\n\n")
 	fmt.Fprintf(&sb, "**Current Time**: %s\n\n", now.Format(time.RFC1123))
+
+	if len(skillCatalog) > 0 {
+		writeSkillCatalog(&sb, skillCatalog)
+	}
 
 	if len(memories) > 0 {
 		sb.WriteString("## Recent Memories\n\n")
@@ -195,6 +209,24 @@ func BuildCycleContext(systemPrompt string, memories []bm25.Result, now time.Tim
 	}
 
 	return sb.String()
+}
+
+// writeSkillCatalog renders the tier-1 skill disclosure section:
+// behavioral instructions plus a bulleted name/description list.
+// Format follows the agentskills.io implementation guide: the catalog
+// itself is small (~100 tok per skill), full instructions only load
+// when the model calls skill_activate.
+func writeSkillCatalog(sb *strings.Builder, catalog []skills.Skill) {
+	sb.WriteString("## Available Skills\n\n")
+	sb.WriteString("The following skills provide specialized instructions for specific tasks. ")
+	sb.WriteString("When a task matches a skill's description, call the `skill_activate` tool ")
+	sb.WriteString("with the skill's name to load its full instructions. ")
+	sb.WriteString("Skills can also expose bundled scripts and references that are loaded ")
+	sb.WriteString("on demand via `skill_read`, and execute scripts in an isolated sandbox via `skill_execute`.\n\n")
+	for _, s := range catalog {
+		fmt.Fprintf(sb, "- **%s**: %s\n", s.Name, s.Description)
+	}
+	sb.WriteString("\n")
 }
 
 // lineCountFor returns the number of newline-delimited lines in s. A

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -1,0 +1,124 @@
+// Package skills holds the domain types for Agent Skills support
+// (https://agentskills.io). A skill is a directory containing a SKILL.md
+// file with YAML frontmatter (required: name, description; optional:
+// license, compatibility, metadata, allowed-tools) and a markdown body
+// of free-form instructions.
+//
+// This package owns the domain types and validation rules. Filesystem
+// discovery, frontmatter parsing, and resource enumeration live in the
+// adapter (internal/adapters/skills/fs).
+package skills
+
+import "fmt"
+
+// Skill is the domain representation of one Agent Skill, parsed from a
+// SKILL.md file. Description and Body are required for the skill to be
+// usable; the rest of the fields are optional metadata.
+type Skill struct {
+	// Name is the skill identifier. Must match the parent directory.
+	// Lenient validation: warnings are recorded in Diagnostics but the
+	// skill is still loaded.
+	Name string
+
+	// Description is the catalog blurb the agent sees at startup.
+	// Mandatory: skills with no description are skipped at discovery.
+	Description string
+
+	// Optional metadata fields from the spec.
+	License       string
+	Compatibility string
+	Metadata      map[string]string
+	AllowedTools  string // experimental per the spec; preserved but not enforced
+
+	// Body is the markdown content following the closing frontmatter
+	// delimiter, trimmed. This is what skill_activate returns.
+	Body string
+
+	// Dir is the absolute path to the skill's directory (the parent of
+	// SKILL.md). Used to resolve relative resource paths.
+	Dir string
+
+	// SkillMDPath is the absolute path to the skill's SKILL.md.
+	SkillMDPath string
+
+	// Diagnostics is a list of human-readable warnings raised during
+	// parsing. Populated when the skill is loaded leniently (e.g.
+	// name doesn't match directory, name has invalid characters but
+	// the skill is otherwise usable). Empty for clean loads.
+	Diagnostics []string
+}
+
+// Catalog is a small projection of a Skill suitable for the system
+// prompt's tier-1 disclosure. Just name + description.
+type Catalog struct {
+	Name        string
+	Description string
+}
+
+// Catalog returns the tier-1 projection of this skill.
+func (s Skill) ToCatalog() Catalog {
+	return Catalog{Name: s.Name, Description: s.Description}
+}
+
+// MaxNameLen, MaxDescriptionLen, and MaxCompatLen are the spec's caps.
+// Names exceeding MaxNameLen and descriptions exceeding MaxDescriptionLen
+// are flagged as errors; the lenient loader may downgrade them to
+// diagnostics. Compatibility's cap is informational.
+const (
+	MaxNameLen        = 64
+	MaxDescriptionLen = 1024
+	MaxCompatLen      = 500
+)
+
+// ValidateName checks the spec rules for the name field:
+//   - non-empty, ≤ MaxNameLen
+//   - only lowercase ASCII letters, digits, and hyphens
+//   - hyphens never appear at the start or end
+//   - no two consecutive hyphens
+//
+// Returns nil for spec-clean names. Callers using lenient validation
+// should treat a non-nil error as a warning and load the skill anyway,
+// recording the message in Skill.Diagnostics.
+//
+// Implemented procedurally rather than as a regex because Go's RE2
+// engine doesn't support the lookahead a one-line pattern would want
+// for the consecutive-hyphen rule.
+func ValidateName(name string) error {
+	if name == "" {
+		return fmt.Errorf("name is empty")
+	}
+	if len(name) > MaxNameLen {
+		return fmt.Errorf("name %q exceeds %d characters", name, MaxNameLen)
+	}
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= '0' && c <= '9':
+			// allowed
+		case c == '-':
+			if i == 0 || i == len(name)-1 {
+				return fmt.Errorf("name %q: hyphens not allowed at start or end", name)
+			}
+			if name[i-1] == '-' {
+				return fmt.Errorf("name %q: consecutive hyphens not allowed", name)
+			}
+		default:
+			return fmt.Errorf("name %q: only lowercase letters, digits, and hyphens allowed (got %q at index %d)", name, c, i)
+		}
+	}
+	return nil
+}
+
+// ValidateDescription enforces the spec rule that description must be
+// non-empty and not exceed MaxDescriptionLen. Empty is a hard error
+// (the catalog needs the description); over-length is also returned as
+// an error so the caller can decide whether to warn or skip.
+func ValidateDescription(desc string) error {
+	switch {
+	case desc == "":
+		return fmt.Errorf("description is empty")
+	case len(desc) > MaxDescriptionLen:
+		return fmt.Errorf("description exceeds %d characters", MaxDescriptionLen)
+	}
+	return nil
+}

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -1,0 +1,52 @@
+package skills
+
+import "testing"
+
+func TestValidateName(t *testing.T) {
+	cases := []struct {
+		name string
+		ok   bool
+	}{
+		{"pdf-processing", true},
+		{"data-analysis", true},
+		{"a", true},
+		{"abc123", true},
+		{"a-1", true},
+
+		{"", false},
+		{"PDF-Processing", false}, // uppercase
+		{"-pdf", false},           // leading hyphen
+		{"pdf-", false},           // trailing hyphen
+		{"pdf--processing", false},
+		{"pdf processing", false}, // space
+		{"pdf_processing", false}, // underscore
+		// 65 characters
+		{"abcdefghij-abcdefghij-abcdefghij-abcdefghij-abcdefghij-abcdefghij1", false},
+	}
+	for _, c := range cases {
+		err := ValidateName(c.name)
+		if c.ok && err != nil {
+			t.Errorf("ValidateName(%q) = %v, want nil", c.name, err)
+		}
+		if !c.ok && err == nil {
+			t.Errorf("ValidateName(%q) = nil, want error", c.name)
+		}
+	}
+}
+
+func TestValidateDescription(t *testing.T) {
+	if err := ValidateDescription(""); err == nil {
+		t.Error("ValidateDescription(empty) = nil, want error")
+	}
+	if err := ValidateDescription("a useful description"); err != nil {
+		t.Errorf("ValidateDescription(short) = %v, want nil", err)
+	}
+
+	long := make([]byte, MaxDescriptionLen+1)
+	for i := range long {
+		long[i] = 'a'
+	}
+	if err := ValidateDescription(string(long)); err == nil {
+		t.Error("ValidateDescription(over-long) = nil, want error")
+	}
+}

--- a/internal/tools/executor.go
+++ b/internal/tools/executor.go
@@ -978,24 +978,26 @@ func indexKey(path string) string {
 
 // Executor handles executing tool calls.
 type Executor struct {
-	memory         *fs.Store
-	index          *bm25.Index
-	telegram       *telegram.Bot
-	sandbox        *docker.Sandbox
-	email          *config.EmailConfig
-	kobold         *kobold.Client  // optional; nil means no perf info in context_status
-	updater        *update.Updater // optional; always non-nil but Enabled() may be false
-	embedder       Embedder        // optional; nil means semantic search disabled
-	vIndex         *vector.Index   // optional; nil means semantic search disabled
-	skills         *skillsfs.Store // optional; nil means skills support disabled
-	embedBatchSize int             // batch size for bulk embed calls (rebuild_indexes); 0 -> default
-	logger         *slog.Logger
-	http           *http.Client
-	cache          *webCache
-	maxTokens      int
-	currentTokens  int
-	limits         config.LimitsConfig
-	maxSleep       time.Duration // upper bound for the `sleep` tool
+	memory              *fs.Store
+	index               *bm25.Index
+	telegram            *telegram.Bot
+	sandbox             *docker.Sandbox
+	email               *config.EmailConfig
+	kobold              *kobold.Client  // optional; nil means no perf info in context_status
+	updater             *update.Updater // optional; always non-nil but Enabled() may be false
+	embedder            Embedder        // optional; nil means semantic search disabled
+	vIndex              *vector.Index   // optional; nil means semantic search disabled
+	skills              *skillsfs.Store // optional; nil means skills support disabled
+	skillInstallEnabled bool            // when false, skill_install is not advertised or executable
+	skillsRoot          string          // absolute path to the skills root; empty when skills disabled
+	embedBatchSize      int             // batch size for bulk embed calls (rebuild_indexes); 0 -> default
+	logger              *slog.Logger
+	http                *http.Client
+	cache               *webCache
+	maxTokens           int
+	currentTokens       int
+	limits              config.LimitsConfig
+	maxSleep            time.Duration // upper bound for the `sleep` tool
 }
 
 // New creates a new tool executor. kb, embedder, vIndex, and skills may
@@ -1004,27 +1006,38 @@ type Executor struct {
 //
 // embedBatchSize is the batch size used by the rebuild_indexes tool;
 // values <= 0 fall back to a sensible default inside the build helper.
-func New(memory *fs.Store, index *bm25.Index, tg *telegram.Bot, sb *docker.Sandbox, email *config.EmailConfig, kb *kobold.Client, updater *update.Updater, embedder Embedder, vIndex *vector.Index, skills *skillsfs.Store, embedBatchSize int, logger *slog.Logger, maxTokens int, limits config.LimitsConfig, maxSleep time.Duration) *Executor {
+//
+// skillInstallEnabled gates the skill_install tool. When skills is nil
+// it has no effect; when both skills and skillInstallEnabled are set
+// the tool is advertised and the agent can fetch skills from tarball
+// URLs or git repositories.
+func New(memory *fs.Store, index *bm25.Index, tg *telegram.Bot, sb *docker.Sandbox, email *config.EmailConfig, kb *kobold.Client, updater *update.Updater, embedder Embedder, vIndex *vector.Index, skills *skillsfs.Store, skillInstallEnabled bool, embedBatchSize int, logger *slog.Logger, maxTokens int, limits config.LimitsConfig, maxSleep time.Duration) *Executor {
 	if sb != nil {
 		sb.SetOutputLimit(limits.SandboxOutputChars)
 	}
+	skillsRoot := ""
+	if skills != nil {
+		skillsRoot = skills.Root()
+	}
 	return &Executor{
-		memory:         memory,
-		index:          index,
-		telegram:       tg,
-		sandbox:        sb,
-		email:          email,
-		kobold:         kb,
-		updater:        updater,
-		embedder:       embedder,
-		vIndex:         vIndex,
-		skills:         skills,
-		embedBatchSize: embedBatchSize,
-		logger:         logger,
-		maxTokens:      maxTokens,
-		limits:         limits,
-		maxSleep:       maxSleep,
-		cache:          newWebCache(60 * time.Second),
+		memory:              memory,
+		index:               index,
+		telegram:            tg,
+		sandbox:             sb,
+		email:               email,
+		kobold:              kb,
+		updater:             updater,
+		embedder:            embedder,
+		vIndex:              vIndex,
+		skills:              skills,
+		skillInstallEnabled: skillInstallEnabled,
+		skillsRoot:          skillsRoot,
+		embedBatchSize:      embedBatchSize,
+		logger:              logger,
+		maxTokens:           maxTokens,
+		limits:              limits,
+		maxSleep:            maxSleep,
+		cache:               newWebCache(60 * time.Second),
 		http: &http.Client{
 			Timeout: 30 * time.Second,
 			Transport: &http.Transport{
@@ -1163,6 +1176,8 @@ func (te *Executor) Execute(ctx context.Context, call llm.ToolCall) string {
 		return te.skillExecute(ctx, args)
 	case "skill_work_read":
 		return te.skillWorkRead(args)
+	case "skill_install":
+		return te.skillInstall(ctx, args)
 	default:
 		return fmt.Sprintf("Unknown tool: %s", name)
 	}

--- a/internal/tools/executor.go
+++ b/internal/tools/executor.go
@@ -26,6 +26,7 @@ import (
 	"github.com/matjam/faultline/internal/adapters/memory/fs"
 	"github.com/matjam/faultline/internal/adapters/operator/telegram"
 	"github.com/matjam/faultline/internal/adapters/sandbox/docker"
+	skillsfs "github.com/matjam/faultline/internal/adapters/skills/fs"
 	"github.com/matjam/faultline/internal/config"
 	"github.com/matjam/faultline/internal/llm"
 	"github.com/matjam/faultline/internal/search/bm25"
@@ -953,6 +954,13 @@ func (te *Executor) ToolDefs() []llm.Tool {
 		)
 	}
 
+	// Skills (Agent Skills support, https://agentskills.io). Tools are
+	// only advertised when the catalog has at least one entry; an empty
+	// skill_* tool surface confuses the model per the spec.
+	if defs := te.skillToolDefs(); len(defs) > 0 {
+		tools = append(tools, defs...)
+	}
+
 	return tools
 }
 
@@ -979,6 +987,7 @@ type Executor struct {
 	updater        *update.Updater // optional; always non-nil but Enabled() may be false
 	embedder       Embedder        // optional; nil means semantic search disabled
 	vIndex         *vector.Index   // optional; nil means semantic search disabled
+	skills         *skillsfs.Store // optional; nil means skills support disabled
 	embedBatchSize int             // batch size for bulk embed calls (rebuild_indexes); 0 -> default
 	logger         *slog.Logger
 	http           *http.Client
@@ -989,13 +998,13 @@ type Executor struct {
 	maxSleep       time.Duration // upper bound for the `sleep` tool
 }
 
-// New creates a new tool executor. kb, embedder, and vIndex may be nil.
-// embedder and vIndex must be both nil (feature off) or both non-nil
-// (feature on); main.go is responsible for that pairing.
+// New creates a new tool executor. kb, embedder, vIndex, and skills may
+// be nil. embedder and vIndex must be both nil (feature off) or both
+// non-nil (feature on); main.go is responsible for that pairing.
 //
 // embedBatchSize is the batch size used by the rebuild_indexes tool;
 // values <= 0 fall back to a sensible default inside the build helper.
-func New(memory *fs.Store, index *bm25.Index, tg *telegram.Bot, sb *docker.Sandbox, email *config.EmailConfig, kb *kobold.Client, updater *update.Updater, embedder Embedder, vIndex *vector.Index, embedBatchSize int, logger *slog.Logger, maxTokens int, limits config.LimitsConfig, maxSleep time.Duration) *Executor {
+func New(memory *fs.Store, index *bm25.Index, tg *telegram.Bot, sb *docker.Sandbox, email *config.EmailConfig, kb *kobold.Client, updater *update.Updater, embedder Embedder, vIndex *vector.Index, skills *skillsfs.Store, embedBatchSize int, logger *slog.Logger, maxTokens int, limits config.LimitsConfig, maxSleep time.Duration) *Executor {
 	if sb != nil {
 		sb.SetOutputLimit(limits.SandboxOutputChars)
 	}
@@ -1009,6 +1018,7 @@ func New(memory *fs.Store, index *bm25.Index, tg *telegram.Bot, sb *docker.Sandb
 		updater:        updater,
 		embedder:       embedder,
 		vIndex:         vIndex,
+		skills:         skills,
 		embedBatchSize: embedBatchSize,
 		logger:         logger,
 		maxTokens:      maxTokens,
@@ -1144,6 +1154,15 @@ func (te *Executor) Execute(ctx context.Context, call llm.ToolCall) string {
 		return te.sandboxListPackages()
 	case "sandbox_shell":
 		return te.sandboxShell(ctx, args)
+	// Skill tools (https://agentskills.io)
+	case "skill_activate":
+		return te.skillActivate(args)
+	case "skill_read":
+		return te.skillRead(args)
+	case "skill_execute":
+		return te.skillExecute(ctx, args)
+	case "skill_work_read":
+		return te.skillWorkRead(args)
 	default:
 		return fmt.Sprintf("Unknown tool: %s", name)
 	}

--- a/internal/tools/skill_install.go
+++ b/internal/tools/skill_install.go
@@ -1,0 +1,627 @@
+package tools
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	skillsfs "github.com/matjam/faultline/internal/adapters/skills/fs"
+	"github.com/matjam/faultline/internal/llm"
+	"github.com/matjam/faultline/internal/skills"
+)
+
+// Install caps. The agent should never need to fetch a skill larger
+// than a few MB; capping the download protects against a buggy or
+// malicious URL pointing at a multi-gigabyte payload.
+const (
+	skillInstallMaxBytes  = 50 * 1024 * 1024 // 50 MiB
+	skillInstallTimeout   = 5 * time.Minute  // covers slow git clones over poor links
+	skillInstallUserAgent = "faultline-skill-install/1"
+)
+
+// Recognized tarball/zip extensions. Order matters: longest suffixes
+// first so .tar.gz isn't mis-detected as .gz.
+var archiveExtensions = []struct {
+	suffix string
+	kind   string
+}{
+	{".tar.gz", "tarball"},
+	{".tgz", "tarball"},
+	{".tar", "tarball"},
+	{".zip", "zip"},
+}
+
+// skillInstallToolDef returns the tool definition advertised when
+// install_enabled is on. Kept separate from skillToolDefs so the
+// default path (install disabled) doesn't accidentally surface the
+// tool through a code-path mistake.
+func (te *Executor) skillInstallToolDef() llm.Tool {
+	return llm.Tool{
+		Type: llm.ToolTypeFunction,
+		Function: &llm.FunctionDef{
+			Name: "skill_install",
+			Description: "Install a new Agent Skill from a remote source into the configured skills directory. " +
+				"Sources: a tarball URL (.tar.gz, .tgz, .tar, .zip), a git URL (ends in .git, starts with git@, or git+https://), or a plain GitHub repo URL. " +
+				"The download is extracted to a temp directory, validated (must contain a SKILL.md), then moved into the skills root. " +
+				"Existing skills are NOT overwritten -- delete first if you want to update. The catalog is reloaded automatically so the skill is immediately available via skill_activate.",
+			Parameters: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"source": map[string]interface{}{
+						"type":        "string",
+						"description": "URL to fetch. Examples: 'https://example.com/skills/pdf.tar.gz', 'https://github.com/owner/repo.git', 'https://github.com/owner/repo'.",
+					},
+					"name": map[string]interface{}{
+						"type":        "string",
+						"description": "Override the destination directory name (must match the SKILL.md frontmatter's name field). When omitted, inferred from the source URL.",
+					},
+					"subpath": map[string]interface{}{
+						"type":        "string",
+						"description": "When the SKILL.md is not at the root of the archive/repo (e.g. a monorepo containing many skills), the path within the extracted tree to the skill directory. Examples: 'skills/pdf-processing'.",
+					},
+					"kind": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional explicit source kind. Useful when auto-detection would pick the wrong path. One of: 'tarball', 'zip', 'git'.",
+						"enum":        []string{"tarball", "zip", "git"},
+					},
+				},
+				"required": []string{"source"},
+			},
+		},
+	}
+}
+
+// skillInstall is the tool handler for skill_install. Returns a
+// human-readable result string for the LLM.
+func (te *Executor) skillInstall(ctx context.Context, argsJSON string) string {
+	if te.skills == nil {
+		return "Error: skills support is not enabled."
+	}
+	if !te.skillInstallEnabled {
+		return "Error: skill_install is disabled. Enable [skills] install_enabled in config to use this tool."
+	}
+	if te.skillsRoot == "" {
+		return "Error: skills root is not configured."
+	}
+
+	var p struct {
+		Source  string `json:"source"`
+		Name    string `json:"name"`
+		Subpath string `json:"subpath"`
+		Kind    string `json:"kind"`
+	}
+	if err := json.Unmarshal([]byte(argsJSON), &p); err != nil {
+		return fmt.Sprintf("Error parsing arguments: %s", err)
+	}
+	p.Source = strings.TrimSpace(p.Source)
+	p.Name = strings.TrimSpace(p.Name)
+	p.Subpath = strings.TrimSpace(p.Subpath)
+	p.Kind = strings.TrimSpace(p.Kind)
+
+	if p.Source == "" {
+		return "Error: 'source' is required."
+	}
+
+	kind, normalisedSource, err := detectSourceKind(p.Source, p.Kind)
+	if err != nil {
+		return fmt.Sprintf("Error: %s", err)
+	}
+
+	// Decide on the destination name now (before the network call) so
+	// we can reject obvious "already exists" / "invalid name" cases
+	// without burning a download.
+	desiredName := p.Name
+	if desiredName == "" {
+		desiredName = inferSkillName(normalisedSource, p.Subpath)
+	}
+	if err := skills.ValidateName(desiredName); err != nil {
+		return fmt.Sprintf("Error: derived name %q is invalid: %s. Pass an explicit `name` parameter that matches the spec (lowercase letters/digits/hyphens, no leading/trailing/consecutive hyphens).", desiredName, err)
+	}
+	dest := filepath.Join(te.skillsRoot, desiredName)
+	if _, err := os.Stat(dest); err == nil {
+		return fmt.Sprintf("Error: a skill named %q already exists at %s. Delete it manually first if you want to reinstall.", desiredName, dest)
+	}
+
+	// Bounded context for the whole fetch+extract+validate dance.
+	installCtx, cancel := context.WithTimeout(ctx, skillInstallTimeout)
+	defer cancel()
+
+	// Stage in a temp directory under the skills root so move-into-
+	// place is a same-filesystem rename (atomic on most filesystems).
+	tempDir, err := os.MkdirTemp(te.skillsRoot, ".install-*")
+	if err != nil {
+		return fmt.Sprintf("Error creating temp dir: %s", err)
+	}
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.RemoveAll(tempDir)
+		}
+	}()
+
+	te.logger.Info("skill_install: starting",
+		slog.String("source", normalisedSource),
+		slog.String("kind", kind),
+		slog.String("name", desiredName))
+
+	switch kind {
+	case "tarball":
+		err = downloadAndExtractTar(installCtx, te.http, normalisedSource, tempDir)
+	case "zip":
+		err = downloadAndExtractZip(installCtx, te.http, normalisedSource, tempDir)
+	case "git":
+		err = gitClone(installCtx, normalisedSource, tempDir, te.logger)
+	default:
+		err = fmt.Errorf("unsupported source kind: %s", kind)
+	}
+	if err != nil {
+		return fmt.Sprintf("Error fetching skill: %s", err)
+	}
+
+	// Resolve the actual skill directory inside what we extracted.
+	// Many tarballs wrap their contents in a single top-level
+	// directory (the GitHub archive convention), and operators may
+	// also point at a subpath within a monorepo via the `subpath`
+	// argument.
+	skillRoot, err := resolveSkillRoot(tempDir, p.Subpath)
+	if err != nil {
+		return fmt.Sprintf("Error: %s", err)
+	}
+
+	// Validate before moving. We parse the SKILL.md the same way the
+	// runtime catalog does so a skill that won't load is rejected
+	// here rather than silently sitting broken in the skills root.
+	mdPath := filepath.Join(skillRoot, "SKILL.md")
+	mdBytes, err := os.ReadFile(mdPath)
+	if err != nil {
+		return fmt.Sprintf("Error: SKILL.md not found at %s. If the SKILL.md is in a subdirectory, pass it via the `subpath` parameter.", relPathOrSelf(tempDir, mdPath))
+	}
+	parsed, err := skillsfs.LoadSkillForValidation(mdBytes, skillRoot, mdPath, desiredName)
+	if err != nil {
+		return fmt.Sprintf("Error: SKILL.md is malformed: %s", err)
+	}
+	if parsed.Name != desiredName {
+		// LoadSkillForValidation uses dirName as the canonical name
+		// when frontmatter disagrees, so this branch only fires when
+		// the operator passed a name that disagrees with what the
+		// frontmatter specifies. Surface it clearly.
+		return fmt.Sprintf("Error: SKILL.md frontmatter name %q does not match destination directory name %q. Pass --name=%q (or rename the destination) to install with the spec-mandated matching name.", parsed.Name, desiredName, parsed.Name)
+	}
+
+	// All-clear: move skillRoot into place. If skillRoot is the temp
+	// dir itself, rename it; otherwise rename the subdir into place
+	// and clean up the temp dir.
+	if skillRoot == tempDir {
+		if err := os.Rename(tempDir, dest); err != nil {
+			return fmt.Sprintf("Error moving skill into place: %s", err)
+		}
+		cleanup = false
+	} else {
+		if err := os.Rename(skillRoot, dest); err != nil {
+			return fmt.Sprintf("Error moving skill into place: %s", err)
+		}
+		// Best-effort temp-dir cleanup; the rest of the archive
+		// contents are not the agent's problem.
+	}
+
+	if err := te.skills.Reload(); err != nil {
+		te.logger.Warn("skill_install: catalog reload failed; will pick up at next rebuild",
+			slog.String("err", err.Error()))
+	}
+
+	resourceCount, _ := countResources(dest)
+	te.logger.Info("skill_install: ok",
+		slog.String("name", desiredName),
+		slog.String("dest", dest))
+	return fmt.Sprintf(
+		"Installed skill %q into %s (%d bundled resource files). It is now available via skill_activate.",
+		desiredName, dest, resourceCount)
+}
+
+// detectSourceKind inspects the source URL and the optional explicit
+// kind override and returns the kind to use plus a normalised source
+// URL. Recognized kinds: "tarball", "zip", "git". A plain GitHub
+// repo URL is normalised to the .git form so it can be cloned.
+func detectSourceKind(source, override string) (string, string, error) {
+	switch override {
+	case "tarball", "zip", "git":
+		return override, source, nil
+	case "":
+		// auto-detect below
+	default:
+		return "", source, fmt.Errorf("unknown kind %q (expected one of: tarball, zip, git)", override)
+	}
+
+	low := strings.ToLower(source)
+	for _, ext := range archiveExtensions {
+		if strings.Contains(low, ext.suffix+"?") || strings.HasSuffix(low, ext.suffix) {
+			return ext.kind, source, nil
+		}
+	}
+
+	// Git suffix forms.
+	if strings.HasSuffix(low, ".git") || strings.HasPrefix(low, "git@") || strings.HasPrefix(low, "git+") {
+		return "git", strings.TrimPrefix(source, "git+"), nil
+	}
+
+	// Plain GitHub repo URL: https://github.com/owner/repo with no
+	// further path. Normalise to .git so git clone handles it.
+	if u, err := url.Parse(source); err == nil && u.Scheme != "" {
+		host := strings.ToLower(u.Host)
+		if (host == "github.com" || host == "gitlab.com" || host == "codeberg.org") && countSegments(u.Path) == 2 {
+			return "git", strings.TrimRight(source, "/") + ".git", nil
+		}
+	}
+
+	return "", source, fmt.Errorf("could not infer source kind from %q. Pass `kind` (one of: tarball, zip, git) explicitly, or provide a URL ending in .tar.gz/.tgz/.tar/.zip/.git", source)
+}
+
+// countSegments returns the number of non-empty path segments in p.
+// Used to recognize "owner/repo" GitHub-style URLs that don't have
+// further path components like /tree/main/whatever.
+func countSegments(p string) int {
+	n := 0
+	for _, seg := range strings.Split(p, "/") {
+		if seg != "" {
+			n++
+		}
+	}
+	return n
+}
+
+// inferSkillName derives a destination directory name from the source
+// URL when the caller didn't supply one. Strips common archive and
+// git suffixes, lowercases, and applies hyphen-only normalisation so
+// the result has the best shot at matching the spec's name rules.
+func inferSkillName(source, subpath string) string {
+	if subpath != "" {
+		return sanitiseName(path.Base(filepath.ToSlash(subpath)))
+	}
+	u, err := url.Parse(source)
+	if err != nil {
+		return ""
+	}
+	base := path.Base(strings.TrimRight(u.Path, "/"))
+	for _, suffix := range []string{".tar.gz", ".tgz", ".tar", ".zip", ".git"} {
+		if strings.HasSuffix(strings.ToLower(base), suffix) {
+			base = base[:len(base)-len(suffix)]
+			break
+		}
+	}
+	return sanitiseName(base)
+}
+
+// sanitiseName lowercases and replaces invalid characters with
+// hyphens, collapsing runs and trimming leading/trailing hyphens.
+// Best-effort -- the caller still validates against the spec.
+func sanitiseName(in string) string {
+	if in == "" {
+		return ""
+	}
+	var b strings.Builder
+	prevHyphen := false
+	for _, r := range strings.ToLower(in) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			prevHyphen = false
+		case r == '-' || r == '_' || r == ' ' || r == '.':
+			if !prevHyphen && b.Len() > 0 {
+				b.WriteByte('-')
+				prevHyphen = true
+			}
+		}
+	}
+	out := strings.TrimRight(b.String(), "-")
+	return out
+}
+
+// downloadAndExtractTar streams a (possibly gzipped) tar from URL into
+// dst. Caps the total extracted bytes at skillInstallMaxBytes to
+// guard against zip-bomb-style attacks; rejects entries with absolute
+// paths or ".." segments.
+func downloadAndExtractTar(ctx context.Context, client *http.Client, source, dst string) error {
+	body, closeBody, err := openHTTP(ctx, client, source)
+	if err != nil {
+		return err
+	}
+	defer closeBody()
+
+	var reader io.Reader
+	if isGzipped(source) {
+		gz, err := gzip.NewReader(io.LimitReader(body, skillInstallMaxBytes+1))
+		if err != nil {
+			return fmt.Errorf("gunzip: %w", err)
+		}
+		defer gz.Close()
+		reader = gz
+	} else {
+		reader = io.LimitReader(body, skillInstallMaxBytes+1)
+	}
+
+	tr := tar.NewReader(reader)
+	var totalBytes int64
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("tar read: %w", err)
+		}
+		target, err := safeJoin(dst, hdr.Name)
+		if err != nil {
+			return err
+		}
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, fileMode(hdr.Mode))
+			if err != nil {
+				return err
+			}
+			n, err := io.CopyN(out, tr, skillInstallMaxBytes-totalBytes+1)
+			out.Close()
+			if err != nil && !errors.Is(err, io.EOF) {
+				return fmt.Errorf("write %s: %w", target, err)
+			}
+			totalBytes += n
+			if totalBytes > skillInstallMaxBytes {
+				return fmt.Errorf("archive exceeds %d bytes; refusing to extract", skillInstallMaxBytes)
+			}
+		default:
+			// Skip symlinks, devices, etc. -- no legitimate skill
+			// needs them, and they're a sandbox-escape risk.
+			continue
+		}
+	}
+	return nil
+}
+
+// downloadAndExtractZip streams a zip file from URL into dst. Same
+// safety guards as downloadAndExtractTar.
+func downloadAndExtractZip(ctx context.Context, client *http.Client, source, dst string) error {
+	body, closeBody, err := openHTTP(ctx, client, source)
+	if err != nil {
+		return err
+	}
+	defer closeBody()
+
+	// archive/zip needs a ReaderAt; buffer to a temp file rather than
+	// memory so a large-but-legal zip doesn't blow up RSS.
+	tmp, err := os.CreateTemp("", "faultline-zip-*.zip")
+	if err != nil {
+		return fmt.Errorf("buffer zip: %w", err)
+	}
+	defer os.Remove(tmp.Name())
+	defer tmp.Close()
+
+	written, err := io.CopyN(tmp, body, skillInstallMaxBytes+1)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return fmt.Errorf("download zip: %w", err)
+	}
+	if written > skillInstallMaxBytes {
+		return fmt.Errorf("archive exceeds %d bytes; refusing to extract", skillInstallMaxBytes)
+	}
+	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+
+	zr, err := zip.NewReader(tmp, written)
+	if err != nil {
+		return fmt.Errorf("zip read: %w", err)
+	}
+	var totalBytes int64
+	for _, f := range zr.File {
+		target, err := safeJoin(dst, f.Name)
+		if err != nil {
+			return err
+		}
+		if f.FileInfo().IsDir() {
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return fmt.Errorf("open %s in zip: %w", f.Name, err)
+		}
+		out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, fileMode(int64(f.Mode().Perm())))
+		if err != nil {
+			rc.Close()
+			return err
+		}
+		n, copyErr := io.CopyN(out, rc, skillInstallMaxBytes-totalBytes+1)
+		rc.Close()
+		out.Close()
+		if copyErr != nil && !errors.Is(copyErr, io.EOF) {
+			return fmt.Errorf("write %s: %w", target, copyErr)
+		}
+		totalBytes += n
+		if totalBytes > skillInstallMaxBytes {
+			return fmt.Errorf("archive exceeds %d bytes; refusing to extract", skillInstallMaxBytes)
+		}
+	}
+	return nil
+}
+
+// gitClone shells out to the local git binary to do a shallow clone
+// into dst. Requires git on PATH; surfaced as a tool-result error if
+// not present.
+func gitClone(ctx context.Context, source, dst string, logger *slog.Logger) error {
+	if _, err := exec.LookPath("git"); err != nil {
+		return fmt.Errorf("git binary not found in PATH; install git or use a tarball URL instead")
+	}
+	// Empty the temp dir so git clone treats it as a fresh
+	// destination (clone refuses to write into a non-empty dir).
+	if err := os.RemoveAll(dst); err != nil {
+		return err
+	}
+	cmd := exec.CommandContext(ctx, "git", "clone", "--depth", "1", "--single-branch", source, dst)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git clone failed: %w (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+	logger.Debug("skill_install: git clone ok", slog.String("source", source))
+
+	// Strip the .git directory so the extracted tree matches what a
+	// tarball would have given us.
+	_ = os.RemoveAll(filepath.Join(dst, ".git"))
+	return nil
+}
+
+// resolveSkillRoot picks the directory inside `extracted` that
+// actually contains SKILL.md. Three cases:
+//
+//  1. Caller specified `subpath`: trust them and use it.
+//  2. SKILL.md exists at the root: use the root.
+//  3. The extracted tree has exactly one top-level directory and
+//     that directory contains SKILL.md (or the recursive expansion
+//     of case 2 inside it): GitHub archive convention -- unwrap.
+//
+// Anything else returns an error pointing the caller at `subpath`.
+func resolveSkillRoot(extracted, subpath string) (string, error) {
+	if subpath != "" {
+		// Reject path-escape attempts in user-supplied subpath.
+		clean := filepath.Clean(subpath)
+		if filepath.IsAbs(clean) || strings.HasPrefix(clean, "..") {
+			return "", fmt.Errorf("subpath %q escapes the extracted directory", subpath)
+		}
+		candidate := filepath.Join(extracted, clean)
+		if _, err := os.Stat(filepath.Join(candidate, "SKILL.md")); err == nil {
+			return candidate, nil
+		}
+		return "", fmt.Errorf("subpath %q does not contain a SKILL.md", subpath)
+	}
+
+	if _, err := os.Stat(filepath.Join(extracted, "SKILL.md")); err == nil {
+		return extracted, nil
+	}
+
+	// Fall back to single-top-level-dir unwrapping.
+	entries, err := os.ReadDir(extracted)
+	if err != nil {
+		return "", err
+	}
+	var dirs []os.DirEntry
+	for _, e := range entries {
+		if e.IsDir() && !strings.HasPrefix(e.Name(), ".") {
+			dirs = append(dirs, e)
+		}
+	}
+	if len(dirs) == 1 {
+		inner := filepath.Join(extracted, dirs[0].Name())
+		if _, err := os.Stat(filepath.Join(inner, "SKILL.md")); err == nil {
+			return inner, nil
+		}
+	}
+
+	return "", fmt.Errorf("SKILL.md not found at the archive root or inside a single top-level directory; pass `subpath` if the SKILL.md lives deeper")
+}
+
+// openHTTP issues a GET with the install user-agent and a
+// caller-supplied context. Returns the body plus a closer to be
+// deferred; non-2xx responses are surfaced as errors.
+func openHTTP(ctx context.Context, client *http.Client, source string) (io.Reader, func(), error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, source, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("User-Agent", skillInstallUserAgent)
+	req.Header.Set("Accept", "*/*")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("http get: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		_ = resp.Body.Close()
+		return nil, nil, fmt.Errorf("http %s: %s", resp.Status, source)
+	}
+	return resp.Body, func() { _ = resp.Body.Close() }, nil
+}
+
+// isGzipped is a poor-man's content type sniff: tarballs are always
+// served either with a .gz suffix or as a plain .tar. We rely on the
+// URL's apparent extension since most servers don't bother with
+// honest Content-Type for archives.
+func isGzipped(source string) bool {
+	low := strings.ToLower(source)
+	return strings.Contains(low, ".tar.gz") || strings.Contains(low, ".tgz")
+}
+
+// safeJoin resolves a joined path and rejects results that escape
+// the parent directory via ".." or absolute paths. Mirrors the
+// guard the skills adapter applies for resource reads, but for
+// archive extraction.
+func safeJoin(parent, child string) (string, error) {
+	if filepath.IsAbs(child) {
+		return "", fmt.Errorf("archive entry has absolute path: %s", child)
+	}
+	clean := filepath.Clean(filepath.Join(parent, child))
+	rel, err := filepath.Rel(parent, clean)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("archive entry escapes target dir: %s", child)
+	}
+	return clean, nil
+}
+
+// fileMode masks the on-disk permission bits we will accept from an
+// archive. Strips setuid/setgid/sticky and never grants execute to
+// world; the agent's writable filesystem doesn't need them.
+func fileMode(mode int64) os.FileMode {
+	return os.FileMode(mode) & 0o755
+}
+
+// relPathOrSelf returns p relative to base if it can; otherwise
+// returns p as-is. Used to keep error messages compact.
+func relPathOrSelf(base, p string) string {
+	if rel, err := filepath.Rel(base, p); err == nil {
+		return rel
+	}
+	return p
+}
+
+// countResources is a thin wrapper that returns just the count of
+// non-directory entries in a freshly-installed skill, used in the
+// success message. Errors are swallowed -- the count is informational.
+func countResources(skillDir string) (int, error) {
+	var n int
+	err := filepath.WalkDir(skillDir, func(_ string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			n++
+		}
+		return nil
+	})
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, nil
+	}
+	return n, err
+}

--- a/internal/tools/skill_install_test.go
+++ b/internal/tools/skill_install_test.go
@@ -1,0 +1,265 @@
+package tools
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	skillsfs "github.com/matjam/faultline/internal/adapters/skills/fs"
+	"github.com/matjam/faultline/internal/config"
+)
+
+// silentTestLogger discards all log output so tests don't pollute the run.
+func silentTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestDetectSourceKind(t *testing.T) {
+	cases := []struct {
+		name     string
+		source   string
+		override string
+		wantKind string
+		wantErr  bool
+	}{
+		{"tar.gz", "https://example.com/skill.tar.gz", "", "tarball", false},
+		{"tgz", "https://example.com/skill.tgz", "", "tarball", false},
+		{"plain tar", "https://example.com/skill.tar", "", "tarball", false},
+		{"zip", "https://example.com/skill.zip", "", "zip", false},
+		{".git suffix", "https://github.com/owner/repo.git", "", "git", false},
+		{"git@", "git@github.com:owner/repo.git", "", "git", false},
+		{"git+https", "git+https://github.com/owner/repo.git", "", "git", false},
+		{"plain github repo", "https://github.com/owner/repo", "", "git", false},
+		{"plain github with trailing slash", "https://github.com/owner/repo/", "", "git", false},
+		{"github tree url not normalised", "https://github.com/owner/repo/tree/main", "", "", true},
+
+		{"override tarball", "https://example.com/anything", "tarball", "tarball", false},
+		{"override zip", "https://example.com/anything", "zip", "zip", false},
+		{"override git", "https://example.com/anything", "git", "git", false},
+		{"override unknown", "https://example.com/anything", "what", "", true},
+
+		{"unrecognized", "https://example.com/no-extension", "", "", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			kind, _, err := detectSourceKind(c.source, c.override)
+			if c.wantErr {
+				if err == nil {
+					t.Errorf("expected error for %q, got kind=%q", c.source, kind)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if kind != c.wantKind {
+				t.Errorf("kind=%q want %q", kind, c.wantKind)
+			}
+		})
+	}
+}
+
+func TestInferSkillName(t *testing.T) {
+	cases := []struct {
+		source  string
+		subpath string
+		want    string
+	}{
+		{"https://example.com/skill.tar.gz", "", "skill"},
+		{"https://example.com/pdf-processing.tgz", "", "pdf-processing"},
+		{"https://github.com/owner/repo.git", "", "repo"},
+		{"https://github.com/owner/repo", "", "repo"},
+		{"https://example.com/dir/some_skill.tar.gz", "", "some-skill"},
+		// subpath wins
+		{"https://github.com/owner/monorepo.git", "skills/pdf-processing", "pdf-processing"},
+	}
+	for _, c := range cases {
+		got := inferSkillName(c.source, c.subpath)
+		if got != c.want {
+			t.Errorf("inferSkillName(%q, %q) = %q, want %q", c.source, c.subpath, got, c.want)
+		}
+	}
+}
+
+func TestSanitiseName(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"PDF Processing", "pdf-processing"},
+		{"some_skill", "some-skill"},
+		{"alpha--beta", "alpha-beta"},
+		{"-leading", "leading"},
+		{"trailing-", "trailing"},
+		{"good.name", "good-name"},
+	}
+	for _, c := range cases {
+		got := sanitiseName(c.in)
+		if got != c.want {
+			t.Errorf("sanitiseName(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestSafeJoin(t *testing.T) {
+	parent := "/tmp/parent"
+	good, err := safeJoin(parent, "subdir/file.txt")
+	if err != nil || !strings.HasPrefix(good, parent) {
+		t.Errorf("safeJoin(good) failed: %v %q", err, good)
+	}
+
+	for _, bad := range []string{
+		"../escape.txt",
+		"subdir/../../etc/passwd",
+		"/etc/passwd",
+	} {
+		if _, err := safeJoin(parent, bad); err == nil {
+			t.Errorf("safeJoin(%q) accepted path escape", bad)
+		}
+	}
+}
+
+// buildTarGz constructs a .tar.gz byte slice in memory containing the
+// supplied file map. Used by TestSkillInstall_Tarball below to feed a
+// fake httptest server without any disk I/O.
+func buildTarGz(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for name, content := range files {
+		hdr := &tar.Header{
+			Name:     name,
+			Mode:     0o644,
+			Size:     int64(len(content)),
+			Typeflag: tar.TypeReg,
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// TestSkillInstall_Tarball is the end-to-end happy path: serve a
+// minimal tar.gz over httptest, drive skill_install, expect the skill
+// to land in the configured root and be visible via the catalog.
+func TestSkillInstall_Tarball(t *testing.T) {
+	skillsRoot := t.TempDir()
+
+	// GitHub-archive convention: contents wrapped in a single
+	// top-level directory. resolveSkillRoot should unwrap it.
+	tarData := buildTarGz(t, map[string]string{
+		"my-skill-main/SKILL.md":          "---\nname: my-skill\ndescription: A test skill.\n---\n\nBody.\n",
+		"my-skill-main/scripts/run.py":    "print('ok')\n",
+		"my-skill-main/references/foo.md": "ref\n",
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = w.Write(tarData)
+	}))
+	defer srv.Close()
+
+	// Construct a real Store + Executor against the temp skills root.
+	store, err := skillsfs.New(skillsRoot, silentTestLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	te := New(nil, nil, nil, nil, nil, nil, nil, nil, nil,
+		store, true, // install enabled
+		0, silentTestLogger(),
+		0, config.LimitsConfig{}, 0)
+
+	args := `{"source":"` + srv.URL + `/my-skill.tar.gz","name":"my-skill"}`
+	got := te.skillInstall(context.Background(), args)
+	if !strings.Contains(got, "Installed skill") {
+		t.Fatalf("install failed: %s", got)
+	}
+
+	// The skill should now exist on disk and in the catalog.
+	if _, err := os.Stat(filepath.Join(skillsRoot, "my-skill", "SKILL.md")); err != nil {
+		t.Errorf("SKILL.md not on disk: %v", err)
+	}
+	if _, err := store.Get("my-skill"); err != nil {
+		t.Errorf("skill not in catalog after install: %v", err)
+	}
+}
+
+func TestSkillInstall_RejectsExisting(t *testing.T) {
+	skillsRoot := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(skillsRoot, "duplicate"), 0o755)
+	_ = os.WriteFile(filepath.Join(skillsRoot, "duplicate", "SKILL.md"),
+		[]byte("---\nname: duplicate\ndescription: x.\n---\n"), 0o644)
+
+	store, _ := skillsfs.New(skillsRoot, silentTestLogger())
+	te := New(nil, nil, nil, nil, nil, nil, nil, nil, nil,
+		store, true,
+		0, silentTestLogger(),
+		0, config.LimitsConfig{}, 0)
+
+	args := `{"source":"https://example.com/duplicate.tar.gz","name":"duplicate"}`
+	got := te.skillInstall(context.Background(), args)
+	if !strings.Contains(got, "already exists") {
+		t.Errorf("expected refusal on existing skill, got: %s", got)
+	}
+}
+
+func TestSkillInstall_DisabledByDefault(t *testing.T) {
+	skillsRoot := t.TempDir()
+	store, _ := skillsfs.New(skillsRoot, silentTestLogger())
+	// install_enabled = false
+	te := New(nil, nil, nil, nil, nil, nil, nil, nil, nil,
+		store, false,
+		0, silentTestLogger(),
+		0, config.LimitsConfig{}, 0)
+
+	args := `{"source":"https://example.com/x.tar.gz"}`
+	got := te.skillInstall(context.Background(), args)
+	if !strings.Contains(got, "disabled") {
+		t.Errorf("expected disabled error, got: %s", got)
+	}
+
+	// Tool def should not be advertised.
+	for _, def := range te.skillToolDefs() {
+		if def.Function != nil && def.Function.Name == "skill_install" {
+			t.Errorf("skill_install advertised despite install_enabled=false")
+		}
+	}
+}
+
+func TestSkillInstall_RejectsInvalidName(t *testing.T) {
+	skillsRoot := t.TempDir()
+	store, _ := skillsfs.New(skillsRoot, silentTestLogger())
+	te := New(nil, nil, nil, nil, nil, nil, nil, nil, nil,
+		store, true,
+		0, silentTestLogger(),
+		0, config.LimitsConfig{}, 0)
+
+	// "Bad_Name" sanitizes to "bad-name" via inferSkillName, which is
+	// fine -- we use an explicit name with capitals to force the
+	// validation failure.
+	args := `{"source":"https://example.com/x.tar.gz","name":"BadName"}`
+	got := te.skillInstall(context.Background(), args)
+	if !strings.Contains(got, "invalid") {
+		t.Errorf("expected invalid-name error, got: %s", got)
+	}
+}

--- a/internal/tools/skills.go
+++ b/internal/tools/skills.go
@@ -25,16 +25,30 @@ func (te *Executor) skillsAvailable() bool {
 	return te.skills != nil && len(te.skills.List()) > 0
 }
 
-// skillToolDefs returns the skill_* tool definitions when at least one
-// skill is registered. Returns an empty slice otherwise so the caller
-// can append unconditionally without checking.
+// skillToolDefs returns the skill_* tool definitions when skills are
+// configured. The activate/read/execute/work_read tools require at
+// least one skill to be in the catalog (an empty skill_activate
+// surface confuses the model per the spec). skill_install -- when
+// enabled -- is advertised even with an empty catalog so the agent
+// can bootstrap the first skill.
 //
-// The `name` parameter is constrained to the current set of skill
-// names via an enum, so the model can't hallucinate a non-existent
-// skill -- per the agentskills.io implementation guidance.
+// The `name` parameter on activate/read/execute is constrained to the
+// current set of skill names via an enum, so the model can't
+// hallucinate a non-existent skill -- per the agentskills.io
+// implementation guidance.
 func (te *Executor) skillToolDefs() []llm.Tool {
+	var defs []llm.Tool
+
+	// skill_install can be advertised independently of the catalog
+	// being non-empty, so the agent can install the first skill
+	// from a fresh deployment. Still gated on Skills being
+	// configured at all.
+	if te.skills != nil && te.skillInstallEnabled {
+		defs = append(defs, te.skillInstallToolDef())
+	}
+
 	if !te.skillsAvailable() {
-		return nil
+		return defs
 	}
 
 	names := make([]string, 0)
@@ -49,7 +63,7 @@ func (te *Executor) skillToolDefs() []llm.Tool {
 		"enum":        names,
 	}
 
-	return []llm.Tool{
+	defs = append(defs, []llm.Tool{
 		{
 			Type: llm.ToolTypeFunction,
 			Function: &llm.FunctionDef{
@@ -125,7 +139,8 @@ func (te *Executor) skillToolDefs() []llm.Tool {
 				},
 			},
 		},
-	}
+	}...)
+	return defs
 }
 
 // skillActivate returns the SKILL.md body (frontmatter already

--- a/internal/tools/skills.go
+++ b/internal/tools/skills.go
@@ -1,0 +1,430 @@
+package tools
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/matjam/faultline/internal/adapters/sandbox/docker"
+	skillsfs "github.com/matjam/faultline/internal/adapters/skills/fs"
+	"github.com/matjam/faultline/internal/llm"
+)
+
+// skillsAvailable returns true when the Skills feature is wired up and
+// the catalog currently contains at least one skill. Tier-1 disclosure
+// is conditional on this -- the spec is explicit that an empty
+// <available_skills/> block confuses the model.
+func (te *Executor) skillsAvailable() bool {
+	return te.skills != nil && len(te.skills.List()) > 0
+}
+
+// skillToolDefs returns the skill_* tool definitions when at least one
+// skill is registered. Returns an empty slice otherwise so the caller
+// can append unconditionally without checking.
+//
+// The `name` parameter is constrained to the current set of skill
+// names via an enum, so the model can't hallucinate a non-existent
+// skill -- per the agentskills.io implementation guidance.
+func (te *Executor) skillToolDefs() []llm.Tool {
+	if !te.skillsAvailable() {
+		return nil
+	}
+
+	names := make([]string, 0)
+	for _, s := range te.skills.List() {
+		names = append(names, s.Name)
+	}
+	sort.Strings(names)
+
+	nameSchema := map[string]interface{}{
+		"type":        "string",
+		"description": "The skill's name as listed in the system prompt's Available Skills section.",
+		"enum":        names,
+	}
+
+	return []llm.Tool{
+		{
+			Type: llm.ToolTypeFunction,
+			Function: &llm.FunctionDef{
+				Name:        "skill_activate",
+				Description: "Load the full instructions for a skill listed in the system prompt's Available Skills section. Returns the SKILL.md body (frontmatter stripped) wrapped in <skill_content> tags, plus a list of bundled scripts and references the skill exposes. Call this when a task matches a skill's description; the returned instructions tell you how to perform the task.",
+				Parameters: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"name": nameSchema,
+					},
+					"required": []string{"name"},
+				},
+			},
+		},
+		{
+			Type: llm.ToolTypeFunction,
+			Function: &llm.FunctionDef{
+				Name:        "skill_read",
+				Description: "Read a bundled resource file from a skill's directory (e.g. references/REFERENCE.md, assets/template.txt, or a script's source for inspection). Path is relative to the skill's root and must not escape it. Use this on demand when a skill's instructions reference a supporting file.",
+				Parameters: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"name": nameSchema,
+						"path": map[string]interface{}{
+							"type":        "string",
+							"description": "Resource path relative to the skill directory. Examples: 'scripts/extract.py', 'references/REFERENCE.md', 'assets/template.txt'.",
+						},
+					},
+					"required": []string{"name", "path"},
+				},
+			},
+		},
+		{
+			Type: llm.ToolTypeFunction,
+			Function: &llm.FunctionDef{
+				Name:        "skill_execute",
+				Description: "Run a shell command inside an isolated Docker container with the skill's directory mounted at /skill (read-only) and a fresh per-call /work directory mounted read-write. The skill cannot see the agent's memory, the regular sandbox, or any other skill's directory. Working directory is /skill. Returns combined stdout/stderr plus a manifest of files the command created in /work; fetch any of those with skill_work_read using the returned work_id. Use this to run scripts the skill bundles.",
+				Parameters: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"name": nameSchema,
+						"command": map[string]interface{}{
+							"type":        "string",
+							"description": "Shell command to execute. The skill's SKILL.md tells you how to invoke its scripts. Examples: 'python scripts/extract.py /work/input.pdf', 'bun scripts/run.ts --output /work/result.json', 'go run scripts/main.go'.",
+						},
+						"network": map[string]interface{}{
+							"type":        "boolean",
+							"description": "Allow network access during execution. Defaults to false (network disabled). Some skills genuinely need internet access -- the SKILL.md's compatibility field will say so.",
+						},
+					},
+					"required": []string{"name", "command"},
+				},
+			},
+		},
+		{
+			Type: llm.ToolTypeFunction,
+			Function: &llm.FunctionDef{
+				Name:        "skill_work_read",
+				Description: "Read a file from a /work directory produced by a previous skill_execute call. The work_id is returned in skill_execute's manifest. Use this to fetch files the skill produced as side effects (extracted text, generated reports, etc.) instead of relying on stdout for large output.",
+				Parameters: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"work_id": map[string]interface{}{
+							"type":        "string",
+							"description": "The work_id returned by a previous skill_execute call.",
+						},
+						"path": map[string]interface{}{
+							"type":        "string",
+							"description": "File path within the /work directory. Examples: 'output.txt', 'results/data.json'.",
+						},
+					},
+					"required": []string{"work_id", "path"},
+				},
+			},
+		},
+	}
+}
+
+// skillActivate returns the SKILL.md body (frontmatter already
+// stripped during parsing) wrapped in <skill_content> tags, plus a
+// list of bundled resources from the conventional scripts/,
+// references/, and assets/ subdirectories. Errors are returned as
+// human-readable strings (no separate error channel for tool
+// results).
+func (te *Executor) skillActivate(args string) string {
+	if te.skills == nil {
+		return "Error: skills support is not enabled."
+	}
+
+	var p struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal([]byte(args), &p); err != nil {
+		return fmt.Sprintf("Error parsing arguments: %s", err)
+	}
+	if p.Name == "" {
+		return "Error: 'name' is required."
+	}
+
+	sk, err := te.skills.Get(p.Name)
+	if err != nil {
+		return fmt.Sprintf("Error: %s", err)
+	}
+
+	resources, truncated, err := te.skills.Resources(sk.Name)
+	if err != nil {
+		te.logger.Warn("skills: resources enumeration failed",
+			slog.String("name", sk.Name),
+			slog.String("err", err.Error()))
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "<skill_content name=%q>\n\n", sk.Name)
+	sb.WriteString(sk.Body)
+	sb.WriteString("\n\n")
+	fmt.Fprintf(&sb, "Skill directory: %s\n", sk.Dir)
+	sb.WriteString("Relative paths in this skill resolve against the skill directory.\n\n")
+
+	if len(resources) > 0 {
+		sb.WriteString("<skill_resources>\n")
+		for _, r := range resources {
+			if r.IsDir {
+				continue
+			}
+			fmt.Fprintf(&sb, "  <file size=\"%d\">%s</file>\n", r.Size, r.Path)
+		}
+		if truncated {
+			fmt.Fprintf(&sb, "  <!-- listing truncated at %d entries; the skill directory has more files than shown -->\n", skillsfs.MaxResourceListing)
+		}
+		sb.WriteString("</skill_resources>\n\n")
+	}
+
+	if sk.Compatibility != "" {
+		fmt.Fprintf(&sb, "Compatibility: %s\n\n", sk.Compatibility)
+	}
+
+	sb.WriteString("</skill_content>\n")
+	return sb.String()
+}
+
+// skillRead reads one resource file from a skill's directory.
+func (te *Executor) skillRead(args string) string {
+	if te.skills == nil {
+		return "Error: skills support is not enabled."
+	}
+
+	var p struct {
+		Name string `json:"name"`
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal([]byte(args), &p); err != nil {
+		return fmt.Sprintf("Error parsing arguments: %s", err)
+	}
+	if p.Name == "" || p.Path == "" {
+		return "Error: 'name' and 'path' are both required."
+	}
+
+	content, err := te.skills.Read(p.Name, p.Path)
+	if err != nil {
+		return fmt.Sprintf("Error: %s", err)
+	}
+	return content
+}
+
+// skillExecute runs a shell command inside the docker sandbox with
+// only the named skill's directory mounted at /skill (ro) plus a
+// per-call /work scratch dir (rw). Returns combined stdout/stderr,
+// the work_id (so the agent can fetch /work files via
+// skill_work_read), and a manifest of files left in /work.
+func (te *Executor) skillExecute(ctx context.Context, args string) string {
+	if te.skills == nil {
+		return "Error: skills support is not enabled."
+	}
+	if te.sandbox == nil {
+		return "Error: sandbox is not enabled; skill_execute requires a working Docker sandbox."
+	}
+
+	var p struct {
+		Name    string `json:"name"`
+		Command string `json:"command"`
+		Network bool   `json:"network"`
+	}
+	if err := json.Unmarshal([]byte(args), &p); err != nil {
+		return fmt.Sprintf("Error parsing arguments: %s", err)
+	}
+	if p.Name == "" || p.Command == "" {
+		return "Error: 'name' and 'command' are both required."
+	}
+
+	sk, err := te.skills.Get(p.Name)
+	if err != nil {
+		return fmt.Sprintf("Error: %s", err)
+	}
+
+	// Per-call /work dir under <sandbox>/skill-work/<call-id>/. The
+	// agent loop wiped the parent at startup, so we never collide
+	// with stale entries.
+	workID := newWorkID()
+	workDir := filepath.Join(te.sandbox.SkillWorkRoot(), workID)
+	if err := os.MkdirAll(workDir, 0755); err != nil {
+		return fmt.Sprintf("Error preparing /work directory: %s", err)
+	}
+
+	// uv-using skills need a writable UV_PROJECT_ENVIRONMENT path
+	// because /skill is read-only. /work/.venv puts the venv inside
+	// the per-call dir, so it's wiped at session reset and doesn't
+	// leak between skill invocations.
+	env := map[string]string{
+		"UV_PROJECT_ENVIRONMENT": "/work/.venv",
+	}
+	mounts := []docker.Mount{
+		{HostPath: sk.Dir, ContainerPath: "/skill", ReadOnly: true},
+		{HostPath: workDir, ContainerPath: "/work", ReadOnly: false},
+		// Share /cache with the regular sandbox so package downloads
+		// (uv, pip, npm, etc.) are reused across runs. Skills are
+		// trusted, and uv/npm caches are content-addressable so
+		// inter-skill collisions are not a concern.
+		{HostPath: filepath.Join(te.sandbox.Dir(), "cache"), ContainerPath: "/cache", ReadOnly: false},
+	}
+
+	output, runErr := te.sandbox.ExecuteIsolated(ctx, p.Command, mounts, p.Network, "/skill", env)
+
+	manifest := buildWorkManifest(workDir)
+	output = te.sandbox.Truncate(output, "Write large output to /work/ from your script and read it back with skill_work_read.")
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "work_id: %s\n\n", workID)
+	if runErr != nil {
+		fmt.Fprintf(&sb, "Error: %s\n\n", runErr)
+	}
+	if output == "" {
+		sb.WriteString("(no stdout/stderr)\n\n")
+	} else {
+		sb.WriteString("Output:\n")
+		sb.WriteString(output)
+		if !strings.HasSuffix(output, "\n") {
+			sb.WriteString("\n")
+		}
+		sb.WriteString("\n")
+	}
+	if len(manifest) == 0 {
+		sb.WriteString("/work is empty; the skill produced no files.\n")
+	} else {
+		sb.WriteString("Files in /work:\n")
+		for _, e := range manifest {
+			fmt.Fprintf(&sb, "  - %s (%d bytes)\n", e.Path, e.Size)
+		}
+		fmt.Fprintf(&sb, "\nUse skill_work_read with work_id=%q to read any of these.\n", workID)
+	}
+	return sb.String()
+}
+
+// skillWorkRead returns the contents of a file inside a previous
+// skill_execute call's /work directory.
+func (te *Executor) skillWorkRead(args string) string {
+	if te.sandbox == nil {
+		return "Error: sandbox is not enabled."
+	}
+
+	var p struct {
+		WorkID string `json:"work_id"`
+		Path   string `json:"path"`
+	}
+	if err := json.Unmarshal([]byte(args), &p); err != nil {
+		return fmt.Sprintf("Error parsing arguments: %s", err)
+	}
+	if p.WorkID == "" || p.Path == "" {
+		return "Error: 'work_id' and 'path' are both required."
+	}
+
+	// Validate work_id shape so a malicious value can't traverse out
+	// of the skill-work root via .. or absolute paths.
+	if !validWorkID(p.WorkID) {
+		return "Error: invalid work_id."
+	}
+
+	root := filepath.Join(te.sandbox.SkillWorkRoot(), p.WorkID)
+	if _, err := os.Stat(root); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Sprintf("Error: work_id %q not found (it may have been wiped on agent restart).", p.WorkID)
+		}
+		return fmt.Sprintf("Error: stat work dir: %s", err)
+	}
+
+	target, err := resolveWorkPath(root, p.Path)
+	if err != nil {
+		return fmt.Sprintf("Error: %s", err)
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		return fmt.Sprintf("Error: read %s: %s", p.Path, err)
+	}
+	out := string(data)
+	if te.sandbox != nil {
+		out = te.sandbox.Truncate(out, "File too large for one read; rerun the skill with output split or written in chunks.")
+	}
+	return out
+}
+
+// workManifestEntry is one entry in the post-execute /work listing.
+type workManifestEntry struct {
+	Path string
+	Size int64
+}
+
+// buildWorkManifest walks the /work host directory after a skill
+// execution and returns a flat list of files (not directories). Used
+// to surface whatever the skill produced so the agent knows what to
+// fetch via skill_work_read.
+func buildWorkManifest(workDir string) []workManifestEntry {
+	var out []workManifestEntry
+	_ = filepath.WalkDir(workDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		// Skip the hidden uv venv we baked into UV_PROJECT_ENVIRONMENT;
+		// the agent never wants to read those files and they would
+		// drown out any real output.
+		rel, relErr := filepath.Rel(workDir, path)
+		if relErr != nil {
+			return nil
+		}
+		if strings.HasPrefix(rel, ".venv/") || rel == ".venv" {
+			return nil
+		}
+		info, infoErr := d.Info()
+		if infoErr != nil {
+			return nil
+		}
+		out = append(out, workManifestEntry{Path: filepath.ToSlash(rel), Size: info.Size()})
+		return nil
+	})
+	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
+	return out
+}
+
+// resolveWorkPath joins workRoot + relPath and verifies the result
+// stays under workRoot. Mirrors the path-escape guard the skills
+// adapter applies for its own resources.
+func resolveWorkPath(workRoot, relPath string) (string, error) {
+	if filepath.IsAbs(relPath) {
+		return "", fmt.Errorf("absolute paths not allowed")
+	}
+	clean := filepath.Clean(filepath.Join(workRoot, relPath))
+	rel, err := filepath.Rel(workRoot, clean)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %q escapes the work directory", relPath)
+	}
+	return clean, nil
+}
+
+// newWorkID returns a 12-hex-character random identifier safe for use
+// as a directory name. Length is enough to make collisions
+// astronomically unlikely within a session.
+func newWorkID() string {
+	b := make([]byte, 6)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+// validWorkID checks the work_id matches the format newWorkID
+// produces: 12 lowercase hex characters. Anything else is treated as
+// invalid input rather than as an existence-check at the filesystem
+// level (defense in depth against path-traversal-style abuse).
+func validWorkID(id string) bool {
+	if len(id) != 12 {
+		return false
+	}
+	for i := 0; i < len(id); i++ {
+		c := id[i]
+		switch {
+		case c >= '0' && c <= '9', c >= 'a' && c <= 'f':
+		default:
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

Adds support for the [Agent Skills](https://agentskills.io) open standard. Skills live at `<skills>/<name>/SKILL.md` outside the memory store; their tier-1 catalog (name + description) is injected into the system prompt at startup and on every context rebuild. Five new tools cover the rest of the lifecycle:

- **`skill_activate`** — load the full SKILL.md body (frontmatter stripped) plus a manifest of bundled `scripts/`/`references/`/`assets/`. Wrapped in `<skill_content>` tags.
- **`skill_read`** — read one bundled resource file. Path-traversal guarded.
- **`skill_execute`** — run an arbitrary shell command in a fresh Docker container with **only** the named skill's directory at `/skill` (ro), the shared `/cache`, and a per-call ephemeral `/work` (rw). No `/scripts`, `/input`, `/output`, `/venv`, `/pyproject.toml`. `--user UID:GID`, `--network=none` by default.
- **`skill_work_read`** — fetch files the skill produced in its `/work` scratch directory after the call returned. `work_id` validated as 12-hex.
- **`skill_install`** *(off by default, gated on \`[skills] install_enabled\`)* — install a new skill autonomously from a tarball URL (`.tar.gz`/`.tgz`/`.tar`/`.zip`) or a git URL. Extract to a temp dir, validate SKILL.md parses cleanly, *then* move into place. Refuses to overwrite existing skills. 50 MiB / 5 min caps; symlinks/devices skipped; path-traversal guards.

The agent's tool surface is gated:
- All five tools are silent when `[skills]` is disabled.
- `skill_activate`/`read`/`execute`/`work_read` advertise only when the catalog has at least one skill (the spec calls out that an empty surface confuses the model).
- `skill_install` advertises as soon as `install_enabled = true`, even with an empty catalog, so a fresh deployment can bootstrap.
- The `name` parameter on activate/read/execute is constrained to the current set of skill names via JSON-schema enum.

## Implementation

- **\`internal/skills/\`** — domain types and validation rules.
- **\`internal/adapters/skills/fs/\`** — filesystem-backed Skills port. Discovery walks \`<root>/<name>/SKILL.md\`. YAML parser (gopkg.in/yaml.v3) with one-shot lenient retry that quotes unquoted-colon values (the spec's most common authoring mistake). Lenient validation: warn-but-load on minor issues, hard skip only when the description is missing.
- **\`internal/agent/ports.go\`** — new \`Skills\` port (\`List\`, \`Reload\`).
- **\`internal/prompts/prompts.go\`** — \`BuildCycleContext\` now takes a skill catalog and renders an \`## Available Skills\` section.
- **\`internal/adapters/sandbox/docker/docker.go\`** — new \`ExecuteIsolated(ctx, command, mounts, network, cwd, env)\` building block + \`SkillWorkRoot\`/\`ResetSkillWork\` helpers for the per-call \`/work\` lifecycle.
- **\`internal/tools/skills.go\`** — four base tool handlers + tool-def gating.
- **\`internal/tools/skill_install.go\`** — install handler (auto-detect kind, tarball/zip via stdlib, git via shell-out), with download caps and path-traversal guards.
- **\`internal/config/config.go\`** — new \`[skills]\` section: \`enabled\`, \`dir\`, \`install_enabled\`.
- Tests covering parser edge cases, store discovery, source detection, name inference, path-escape rejection, and an end-to-end install via httptest.

## Verification

- \`go build ./...\`, \`go vet ./...\`, full \`go test ./...\` — clean.
- \`golangci-lint run ./...\` — 0 issues.
- New tests: parser (5 cases), store discovery (8 cases), skill_install (4 cases — happy path tarball, refuses-existing, disabled-by-default, invalid-name) plus pure-function tests for source detection / name inference / path safety.
- Per-call \`/work\` is wiped at agent startup so stale \`work_id\`s from a previous session can't resolve.
- The agent's lifecycle reload story works: \`Skills.Reload\` runs on every context rebuild, plus immediately after a successful \`skill_install\`, so newly-dropped or just-installed skills become visible without a restart.

## Notes for review

- Commits split per concern (discovery + port, system-prompt integration, four base tools + sandbox isolated exec, docs, then install in a separate commit on top). Squash-merge will collapse them.
- \`allowed-tools\` frontmatter field is preserved on the parsed Skill but **not enforced** — spec marks it experimental.
- Trust gating is none. Skills are operator-supplied and implicitly trusted. \`skill_install\` does not introduce new trust beyond what its config flag implies.
- Previous PRs on this repo confirmed: \`gnu-netcat\` is AUR-only on Arch (use \`openbsd-netcat\`); the sandbox Dockerfile already lands the runtimes a skill is likely to want (uv, python, node, bun, deno, go, plus common CLI tools).