### PR TITLE
feat: subagent delegation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,8 @@ faultline/
                               detection, graceful shutdown
       ports.go                interfaces the agent depends on:
                               ChatModel, Memory, Searcher, Operator,
-                              Tokenizer, Tools, StateStore
+                              Tokenizer, Tools, StateStore, Skills,
+                              Subagents
     config/                   TOML config loading
     log/                      DailyFileWriter, MultiHandler (slog)
     prompts/                  embedded prompt templates, Load, LoadAll,
@@ -31,6 +32,11 @@ faultline/
     search/bm25/              pure-Go BM25 search index
     search/vector/            pure-Go in-memory vector index + binary
                               serialization (FVEC v1) for semantic search
+    skills/                   domain types for Agent Skills (Skill, Catalog,
+                              Validate*) — adapter is in adapters/skills/fs
+    subagent/                 domain types + Manager for subagent delegation
+                              (Profile, Report, ActiveStatus); spawnFn
+                              bridge to composition lives in cmd/faultline
     llm/                      shared LLM types (Message, Tool, ChatRequest, ...)
                               + heuristic token estimator
     adapters/
@@ -110,8 +116,19 @@ cmd/faultline/main.go
         |     +-> rebuild_indexes  (force full rebuild of bm25 and/or vector index;
         |                            shared helper in tools/vector.go also drives
         |                            startup reconcile from main.go)
+        |     +-> subagent_run     (sync; subagent.Manager.Run; child agent loop
+        |                            via spawnFn closure in cmd/faultline)
+        |     +-> subagent_spawn   (async; returns work_id; report lands in
+        |                            inbox alongside operator queue)
+        |     +-> subagent_wait    (block until named subagent reports;
+        |                            wakes on operator HasPending)
+        |     +-> subagent_status  (active children with elapsed/prompt preview)
+        |     +-> subagent_cancel  (cooperative cancel via child ctx)
+        |     +-> subagent_report  (child-only; sink closure captures text +
+        |                            calls childAgent.RequestStop)
         |
         +-> Graceful shutdown (on first SIGINT)
+              +-> Subagents.CancelAll (children's goroutines unwind)
               +-> Inject shutdown prompt
               +-> Agent saves state (up to 10 turns, 2min timeout)
 ```
@@ -149,6 +166,7 @@ The hexagon. Pure domain logic with no I/O outside what the ports allow.
   | `Tools` | `*tools.Executor` | ToolDefs, Execute, SetContextInfo, Close. |
   | `StateStore` | `*jsonfile.Persister` | Save/Load conversation log; binds path + logger at construction. |
   | `Skills` | `*skillsfs.Store` | nil-allowed; List/Reload for the tier-1 catalog injection in `BuildCycleContext`. Tools layer drives the rest. |
+  | `Subagents` | `*subagent.Manager` | nil-allowed; Pending/HasPending drive the inbox drain in `injectPendingMessages` (parallel to operator), Profiles feeds the system-prompt catalog, CancelAll fires from `gracefulSave`. Tools layer holds the same pointer for `subagent_run/spawn/wait/status/cancel`. |
 
 ### internal/config/
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ Faultline supports the [Agent Skills](https://agentskills.io) open standard. Whe
 
 When `[skills] install_enabled = true` (off by default), the agent can also install new skills autonomously via `skill_install`, which fetches a tarball URL or git repository into the skills directory after validating that it contains a parseable `SKILL.md`. The catalog reloads on every context rebuild plus immediately after a successful install, so a freshly-installed skill is visible without a restart.
 
+### Subagents (optional)
+
+When `[subagent]` is enabled, the primary agent gains five tools (`subagent_run`, `subagent_spawn`, `subagent_wait`, `subagent_status`, `subagent_cancel`) and can delegate work to a child agent loop running under a configured profile. Profiles select an LLM endpoint, model, and sampler overrides; a synthesized `default` profile (matching `[api]`) is always available. The primary supplies all relevant context as the child's prompt; the child runs a fresh agent loop with the same tool surface (minus `sleep`, `update_*`, and nested `subagent_*`) and terminates by calling `subagent_report`, whose payload is returned to the primary. Synchronous runs (`subagent_run`) block the primary until the child reports; async runs (`subagent_spawn`) let the primary keep working while the report arrives in its inbox like an operator message. `subagent_wait(work_id)` is the bridge — block until a previously-spawned child reports, drain the report inline. Children share the primary's memory, search indexes, sandbox, and skills; they cannot see its conversation log and cannot themselves spawn further subagents.
+
 ## Tools
 
 | Category | Tools |
@@ -185,6 +189,7 @@ When `[skills] install_enabled = true` (off by default), the agent can also inst
 | **Sandbox** (when enabled) | `sandbox_write`, `sandbox_read`, `sandbox_edit`, `sandbox_append`, `sandbox_insert`, `sandbox_delete`, `sandbox_rename`, `sandbox_list`, `sandbox_execute`, `sandbox_shell`, `sandbox_install_package`, `sandbox_upgrade_package`, `sandbox_remove_package`, `sandbox_list_packages` |
 | **Skills** (when enabled, ≥1 skill) | `skill_activate`, `skill_read`, `skill_execute`, `skill_work_read` |
 | **Skills install** (when `install_enabled`) | `skill_install` |
+| **Subagents** (when enabled) | `subagent_run`, `subagent_spawn`, `subagent_wait`, `subagent_status`, `subagent_cancel` |
 | **Email** (when configured) | `email_fetch` |
 
 ## Architecture

--- a/cmd/faultline/main.go
+++ b/cmd/faultline/main.go
@@ -257,14 +257,37 @@ func main() {
 		logger.Info("skills not configured, skill_* tools disabled")
 	}
 
-	toolExec := tools.New(memory, index, tg, sb, email, kb, updater, embedder, vIndex,
-		skillStore, cfg.Skills.InstallEnabled,
-		cfg.Embeddings.BatchSize, logger,
-		cfg.Agent.MaxTokens, cfg.Limits, cfg.Agent.MaxSleep.Duration())
+	// Shared web cache is owned by the composition root, not the
+	// Executor. With subagents enabled, multiple Executors (primary +
+	// children) share one cache; a child's Close must not yank it out
+	// from under the primary, so the cache lifecycle lives here.
+	webCache := tools.NewWebCache(60 * time.Second)
+	defer webCache.Close()
+
+	toolExec := tools.New(tools.Deps{
+		Mode:                tools.ModePrimary,
+		Memory:              memory,
+		Index:               index,
+		VectorIndex:         vIndex,
+		Telegram:            tg,
+		Sandbox:             sb,
+		Email:               email,
+		Kobold:              kb,
+		Updater:             updater,
+		Embedder:            embedder,
+		Skills:              skillStore,
+		SkillInstallEnabled: cfg.Skills.InstallEnabled,
+		EmbedBatchSize:      cfg.Embeddings.BatchSize,
+		Logger:              logger,
+		WebCache:            webCache,
+		MaxTokens:           cfg.Agent.MaxTokens,
+		Limits:              cfg.Limits,
+		MaxSleep:            cfg.Agent.MaxSleep.Duration(),
+	})
 	// NOTE: do not defer toolExec.Close() here. The agent owns the tool
 	// executor's lifecycle via the Tools port; agent.Close() (deferred
-	// below) calls tools.Close() exactly once. A second defer here was
-	// previously closing webCache.stop twice and panicking on shutdown.
+	// below) calls tools.Close() exactly once. The shared webCache has
+	// its own defer above.
 
 	state := jsonfile.NewPersister(cfg.Agent.StateFile, logger)
 

--- a/cmd/faultline/main.go
+++ b/cmd/faultline/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/matjam/faultline/internal/prompts"
 	"github.com/matjam/faultline/internal/search/bm25"
 	"github.com/matjam/faultline/internal/search/vector"
+	"github.com/matjam/faultline/internal/subagent"
 	"github.com/matjam/faultline/internal/tools"
 	"github.com/matjam/faultline/internal/update"
 	"github.com/matjam/faultline/internal/version"
@@ -264,6 +265,29 @@ func main() {
 	webCache := tools.NewWebCache(60 * time.Second)
 	defer webCache.Close()
 
+	// Subagent manager (optional). Constructed before the primary's
+	// tool executor so the SubagentManager pointer can be wired in;
+	// the spawnFn closure shares the primary's adapters.
+	var subMgr *subagent.Manager
+	if cfg.Subagent.Active() {
+		subMgr = buildSubagentManager(cfg, subagentDeps{
+			Memory:      memory,
+			Index:       index,
+			VectorIndex: vIndex,
+			Telegram:    tg,
+			Sandbox:     sb,
+			Email:       email,
+			Kobold:      kb,
+			Updater:     updater,
+			Embedder:    embedder,
+			Skills:      skillStore,
+			WebCache:    webCache,
+			Logger:      logger,
+		})
+	} else {
+		logger.Info("subagent support disabled, subagent_* tools not advertised")
+	}
+
 	toolExec := tools.New(tools.Deps{
 		Mode:                tools.ModePrimary,
 		Memory:              memory,
@@ -283,6 +307,7 @@ func main() {
 		MaxTokens:           cfg.Agent.MaxTokens,
 		Limits:              cfg.Limits,
 		MaxSleep:            cfg.Agent.MaxSleep.Duration(),
+		SubagentManager:     subMgr,
 	})
 	// NOTE: do not defer toolExec.Close() here. The agent owns the tool
 	// executor's lifecycle via the Tools port; agent.Close() (deferred
@@ -302,6 +327,15 @@ func main() {
 		skillsPort = skillStore
 	}
 
+	// agent.Subagents port: wire the manager when subagent support is
+	// enabled. Same nil-interface guard as the Skills port -- a typed
+	// nil pointer would create a non-nil interface, defeating the
+	// nil-allowed check inside the agent loop.
+	var subagentsPort agent.Subagents
+	if subMgr != nil {
+		subagentsPort = subMgr
+	}
+
 	a := agent.New(cfg, agent.Deps{
 		Chat:      chat,
 		Memory:    memory,
@@ -311,6 +345,7 @@ func main() {
 		Tools:     toolExec,
 		State:     state,
 		Skills:    skillsPort,
+		Subagents: subagentsPort,
 	}, logger)
 	defer a.Close()
 

--- a/cmd/faultline/subagent.go
+++ b/cmd/faultline/subagent.go
@@ -1,0 +1,277 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+
+	"github.com/matjam/faultline/internal/adapters/llm/kobold"
+	"github.com/matjam/faultline/internal/adapters/llm/openai"
+	"github.com/matjam/faultline/internal/adapters/memory/fs"
+	"github.com/matjam/faultline/internal/adapters/operator/telegram"
+	"github.com/matjam/faultline/internal/adapters/sandbox/docker"
+	skillsfs "github.com/matjam/faultline/internal/adapters/skills/fs"
+	"github.com/matjam/faultline/internal/adapters/state/jsonfile"
+	"github.com/matjam/faultline/internal/agent"
+	"github.com/matjam/faultline/internal/config"
+	"github.com/matjam/faultline/internal/search/bm25"
+	"github.com/matjam/faultline/internal/search/vector"
+	"github.com/matjam/faultline/internal/subagent"
+	"github.com/matjam/faultline/internal/tools"
+	"github.com/matjam/faultline/internal/update"
+)
+
+// subagentDeps bundles the shared dependencies a subagent needs. All
+// fields are borrowed from the primary's lifecycle -- the spawnFn
+// closure does not own any of them.
+type subagentDeps struct {
+	Memory      *fs.Store
+	Index       *bm25.Index
+	VectorIndex *vector.Index
+	Telegram    *telegram.Bot
+	Sandbox     *docker.Sandbox
+	Email       *config.EmailConfig
+	Kobold      *kobold.Client
+	Updater     *update.Updater
+	Embedder    tools.Embedder
+	Skills      *skillsfs.Store
+	WebCache    *tools.WebCache
+	Logger      *slog.Logger
+}
+
+// buildSubagentManager constructs the subagent.Manager and the
+// SpawnFunc closure that runs a child agent loop. Returns nil when
+// [subagent] is disabled (the primary then runs without subagent
+// support; subagent_* tools are not advertised).
+//
+// Operator-supplied profiles that fail validation are logged and
+// skipped rather than aborting startup; the synthesized "default"
+// profile is always available when the feature is enabled.
+func buildSubagentManager(cfg *config.Config, deps subagentDeps) *subagent.Manager {
+	if !cfg.Subagent.Active() {
+		return nil
+	}
+
+	// The synthesized default profile mirrors the primary's [api]
+	// settings so the agent can delegate to "the same backend" without
+	// any operator config.
+	profiles := []subagent.Profile{
+		{
+			Name:    subagent.DefaultProfileName,
+			APIURL:  cfg.API.URL,
+			APIKey:  cfg.API.Key,
+			Model:   cfg.API.Model,
+			Purpose: "Same backend, model, and sampler settings as the primary agent. Use when no specialized profile fits.",
+		},
+	}
+
+	for _, p := range cfg.Subagent.Profiles {
+		cp := subagent.Profile{
+			Name:              p.Name,
+			APIURL:            p.APIURL,
+			APIKey:            p.APIKey,
+			Model:             p.Model,
+			Purpose:           p.Purpose,
+			Temperature:       p.Temperature,
+			TopP:              p.TopP,
+			TopK:              p.TopK,
+			MinP:              p.MinP,
+			RepetitionPenalty: p.RepetitionPenalty,
+			MaxRespTokens:     p.MaxRespTokens,
+		}
+		if err := subagent.ValidateProfile(cp); err != nil {
+			deps.Logger.Warn("subagent profile invalid; skipping",
+				"name", p.Name, "error", err)
+			continue
+		}
+		profiles = append(profiles, cp)
+	}
+
+	deps.Logger.Info("subagent support enabled",
+		"profiles", len(profiles),
+		"max_concurrent", cfg.Subagent.MaxConcurrent,
+		"max_turns_per_run", cfg.Subagent.MaxTurnsPerRun,
+		"max_inbox", cfg.Subagent.MaxInbox,
+		"run_timeout", cfg.Subagent.RunTimeout.Duration().String(),
+	)
+
+	spawnFn := func(ctx context.Context, workID string, profile subagent.Profile, prompt string, maxTurns int) subagent.Report {
+		return runSubagent(ctx, workID, profile, prompt, maxTurns, cfg, deps)
+	}
+
+	return subagent.New(subagent.Config{
+		MaxConcurrent:  cfg.Subagent.MaxConcurrent,
+		MaxTurnsPerRun: cfg.Subagent.MaxTurnsPerRun,
+		MaxInbox:       cfg.Subagent.MaxInbox,
+		RunTimeout:     cfg.Subagent.RunTimeout.Duration(),
+	}, profiles, spawnFn, deps.Logger)
+}
+
+// subagentSystemPrompt is the system-prompt template used for child
+// agents. The parent's task is interpolated into the body so the
+// child sees its identity, the rules of the road, and the operator's
+// (i.e. primary's) instructions in one message.
+const subagentSystemPrompt = `You are a SUBAGENT of a primary agent. The primary delegated work to you and is waiting for your report.
+
+Rules:
+  - When you have finished (or determined the work cannot be done), call the subagent_report tool with a self-contained summary. After that call, your loop will exit -- do not issue further tool calls.
+  - You have access to the same tools as the primary, EXCEPT: sleep, update_check, update_apply, and the subagent_* tools (no nested delegation). The send_message tool is available; use it sparingly.
+  - You share the primary's memory store, search indexes, sandbox, and skills catalog. Memory writes are visible to the primary and to other subagents.
+  - The primary cannot see your conversation. Only the subagent_report payload reaches them. Put EVERYTHING the primary needs to know in that report.
+
+=== Task from primary agent ===
+
+%s`
+
+// runSubagent constructs and runs a single child agent loop. Called
+// by the SpawnFunc; blocks until the child's loop returns.
+//
+// The returned Report's WorkID/Profile/StartedAt fields are filled in
+// by the Manager's runOne wrapper, so we leave them zero here.
+func runSubagent(
+	ctx context.Context,
+	workID string,
+	profile subagent.Profile,
+	promptText string,
+	maxTurns int,
+	cfg *config.Config,
+	deps subagentDeps,
+) subagent.Report {
+	childLogger := deps.Logger.With("agent", workID, "profile", profile.Name)
+	childLogger.Info("subagent: starting", "max_turns", maxTurns)
+
+	// Per-profile chat client and per-subagent chat log.
+	chat := openai.New(profile.APIURL, profile.APIKey, profile.Model, childLogger)
+	if cl, err := openai.NewChatLoggerPrefixed(cfg.Log.Dir, "chat-"+workID+"-"); err == nil {
+		chat.SetChatLog(cl)
+		defer cl.Close()
+	} else {
+		childLogger.Warn("could not open per-subagent chat log; continuing without it",
+			"error", err)
+	}
+
+	// Forward declaration: the sink closure needs the *Agent so it
+	// can call RequestStop after the report is captured. Assigned
+	// below before any tool call could fire.
+	var (
+		reportText string
+		reported   atomic.Bool
+		childAgent *agent.Agent
+	)
+	sink := func(text string) {
+		reportText = text
+		reported.Store(true)
+		if childAgent != nil {
+			childAgent.RequestStop()
+		}
+	}
+
+	// Per-subagent cfg copy so profile sampler overrides take effect
+	// without mutating the shared cfg pointer the primary is using.
+	// AgentConfig is value-typed; the slices on Config are read-only
+	// here so the shallow copy is safe.
+	childCfg := *cfg
+	childCfg.API.Model = profile.Model
+	if profile.Temperature != 0 {
+		childCfg.Agent.Temperature = profile.Temperature
+	}
+	if profile.TopP != 0 {
+		childCfg.Agent.TopP = profile.TopP
+	}
+	if profile.TopK != 0 {
+		childCfg.Agent.TopK = profile.TopK
+	}
+	if profile.MinP != 0 {
+		childCfg.Agent.MinP = profile.MinP
+	}
+	if profile.RepetitionPenalty != 0 {
+		childCfg.Agent.RepetitionPenalty = profile.RepetitionPenalty
+	}
+	if profile.MaxRespTokens != 0 {
+		childCfg.Agent.MaxRespTokens = profile.MaxRespTokens
+	}
+	// State persistence is off for subagents; conversation is
+	// ephemeral and the primary's state file is the source of truth.
+	childCfg.Agent.StateFile = ""
+
+	// Translate adapters into agent.* ports (nil-allowed).
+	var skillsPort agent.Skills
+	if deps.Skills != nil {
+		skillsPort = deps.Skills
+	}
+	var tokenizerPort agent.Tokenizer
+	if deps.Kobold != nil {
+		tokenizerPort = deps.Kobold
+	}
+
+	// Child Executor in subagent mode. Same shared infrastructure as
+	// the primary (memory, indexes, sandbox, skills, webCache); no
+	// updater (update_* tools are stripped via Mode anyway), no
+	// subagent manager (no nesting), report sink wired so
+	// subagent_report fires the closure above.
+	childExec := tools.New(tools.Deps{
+		Mode:                tools.ModeSubagent,
+		Memory:              deps.Memory,
+		Index:               deps.Index,
+		VectorIndex:         deps.VectorIndex,
+		Telegram:            deps.Telegram,
+		Sandbox:             deps.Sandbox,
+		Email:               deps.Email,
+		Kobold:              deps.Kobold,
+		Embedder:            deps.Embedder,
+		Skills:              deps.Skills,
+		SkillInstallEnabled: false,
+		EmbedBatchSize:      cfg.Embeddings.BatchSize,
+		Logger:              childLogger,
+		WebCache:            deps.WebCache,
+		MaxTokens:           childCfg.Agent.MaxTokens,
+		Limits:              childCfg.Limits,
+		MaxSleep:            childCfg.Agent.MaxSleep.Duration(),
+		SubagentReportFn:    sink,
+	})
+
+	systemPrompt := fmt.Sprintf(subagentSystemPrompt, promptText)
+
+	childAgent = agent.New(&childCfg, agent.Deps{
+		Chat:                 chat,
+		Memory:               deps.Memory,
+		Search:               deps.Index,
+		Operator:             nil, // children never see the operator queue
+		Tokenizer:            tokenizerPort,
+		Tools:                childExec,
+		State:                jsonfile.NewPersister("", childLogger),
+		Skills:               skillsPort,
+		Subagents:            nil, // no nesting
+		MaxTurns:             maxTurns,
+		SystemPromptOverride: systemPrompt,
+	}, childLogger)
+	defer childAgent.Close()
+
+	// shutdownCh: nil for subagents. The Manager's parent ctx already
+	// cancels on the agent's two-phase shutdown via the toolCtx
+	// bridge in agent.Run; a nil shutdownCh just means "no graceful-
+	// save phase for this child", which is what we want -- the child's
+	// state isn't persisted anyway.
+	runErr := childAgent.Run(ctx, nil)
+
+	rep := subagent.Report{Text: reportText}
+	switch {
+	case errors.Is(runErr, context.Canceled), errors.Is(runErr, context.DeadlineExceeded):
+		rep.Canceled = true
+		rep.Err = runErr
+	case runErr != nil:
+		rep.Err = runErr
+	case !reported.Load():
+		// Loop exited cleanly (MaxTurns hit) without subagent_report.
+		rep.Truncated = true
+	}
+	childLogger.Info("subagent: finished",
+		"reported", reported.Load(),
+		"canceled", rep.Canceled,
+		"truncated", rep.Truncated,
+		"err", rep.Err,
+	)
+	return rep
+}

--- a/config.example.toml
+++ b/config.example.toml
@@ -313,3 +313,69 @@ dir = "./skills"
 # the standard sandbox feature -- skill_execute still runs every script
 # in an isolated container with only the skill's own directory mounted.
 install_enabled = false
+
+# ---------------------------------------------------------------------------
+# [subagent] — subagent delegation.
+#
+# When enabled, the primary agent gains four tools: subagent_run (sync,
+# returns the report inline), subagent_spawn (async, report arrives via
+# the same injection point as operator messages), subagent_status (list
+# active spawned children), and subagent_cancel (abort a running child).
+#
+# Each subagent is a fresh agent loop with its own context window and
+# its own LLM client (selected from the configured profiles, or the
+# synthesized "default" profile that inherits from [api]). The primary
+# supplies all the context the child needs as the prompt; the child has
+# no view of the primary's conversation log.
+#
+# Subagents share the primary's memory store, search indexes, sandbox,
+# and skills. They DO NOT inherit the operator (Telegram) channel and
+# they cannot themselves spawn further subagents. Their conversation
+# logs are not persisted across restarts.
+# ---------------------------------------------------------------------------
+[subagent]
+enabled = false
+
+# Cap on simultaneous async (spawned) subagents. Sync (run) subagents
+# don't count -- the primary's tool dispatch is blocked while one
+# is in flight, so at most one sync child exists per primary at any
+# given time.
+max_concurrent = 4
+
+# Cap on a single subagent's loop iterations. The child is told via
+# system prompt to call subagent_report when finished; if it exhausts
+# this budget without reporting, its last assistant text is returned
+# with a truncation notice.
+max_turns_per_run = 50
+
+# Cap on completed async reports queued for the primary to drain.
+# When full, the oldest is dropped with a warning.
+max_inbox = 32
+
+# Wall-clock cap on a single subagent run (sync or async).
+run_timeout = "30m"
+
+# ---------------------------------------------------------------------------
+# Subagent profiles. Each profile is a callable target the primary may
+# select by name. Use as many [[subagent.profiles]] blocks as you need.
+# The reserved name "default" is synthesized from the primary's [api]
+# settings and is always available; operator profiles must use a
+# different name.
+#
+# Sampler fields use zero-value-omitted semantics: a field set to 0 (or
+# omitted entirely) inherits from the primary's [agent] section.
+# ---------------------------------------------------------------------------
+# [[subagent.profiles]]
+# name = "fast"
+# api_url = "http://localhost:5001/v1"
+# api_key = ""
+# model = "qwen2.5-coder-7b"
+# purpose = "Quick lookups and short summaries; cheap and fast."
+# temperature = 0.4
+#
+# [[subagent.profiles]]
+# name = "deep"
+# api_url = "https://api.openai.com/v1"
+# api_key = "sk-..."
+# model = "gpt-4o"
+# purpose = "Deep research, architecture analysis, careful reasoning. Slow."

--- a/internal/adapters/llm/openai/chatlog.go
+++ b/internal/adapters/llm/openai/chatlog.go
@@ -29,7 +29,17 @@ type ChatLogger struct {
 // NewChatLogger returns a logger that writes to dir/chat-YYYY-MM-DD.log.
 // Directory creation and rotation are handled by the writer.
 func NewChatLogger(dir string) (*ChatLogger, error) {
-	w, err := log.NewDailyPrefixed(dir, "chat-")
+	return NewChatLoggerPrefixed(dir, "chat-")
+}
+
+// NewChatLoggerPrefixed returns a logger that writes to
+// dir/<prefix>YYYY-MM-DD.log. Used by subagents so each child agent
+// gets its own daily-rotated transcript file (e.g. chat-sub-<id>-)
+// rather than interleaving with the primary's chat log. The prefix
+// must end in a separator the filename can carry; convention is to
+// end it with a hyphen.
+func NewChatLoggerPrefixed(dir, prefix string) (*ChatLogger, error) {
+	w, err := log.NewDailyPrefixed(dir, prefix)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/matjam/faultline/internal/adapters/llm/kobold"
@@ -19,20 +20,30 @@ import (
 	prompt "github.com/matjam/faultline/internal/prompts"
 	"github.com/matjam/faultline/internal/search/bm25"
 	skillsdomain "github.com/matjam/faultline/internal/skills"
+	"github.com/matjam/faultline/internal/subagent"
 )
 
 // Agent is the autonomous agent that runs in a continuous loop.
 type Agent struct {
-	cfg       *config.Config
-	chat      ChatModel
-	memory    Memory
-	search    Searcher
-	operator  Operator  // nil when no collaborator channel is configured
-	tokenizer Tokenizer // nil when no real tokenizer is detected
-	tools     Tools
-	state     StateStore
-	skills    Skills // nil when skills support is disabled
-	logger    *slog.Logger
+	cfg                  *config.Config
+	chat                 ChatModel
+	memory               Memory
+	search               Searcher
+	operator             Operator  // nil when no collaborator channel is configured
+	tokenizer            Tokenizer // nil when no real tokenizer is detected
+	tools                Tools
+	state                StateStore
+	skills               Skills    // nil when skills support is disabled
+	subagents            Subagents // nil for primaries with [subagent] off and for all children
+	logger               *slog.Logger
+	maxTurns             int    // 0 means unlimited; >0 caps Run loop iterations (subagent use)
+	systemPromptOverride string // when non-empty, replaces prompts["system"] (subagent use)
+
+	// stopRequested is set by RequestStop; the Run loop checks it at
+	// the top of each iteration and exits cleanly when set. Used by
+	// subagent_report to terminate the child loop after the report
+	// has been delivered.
+	stopRequested atomic.Bool
 }
 
 // Deps bundles the agent's port dependencies. Constructing the Agent
@@ -46,25 +57,54 @@ type Deps struct {
 	Tokenizer Tokenizer // optional
 	Tools     Tools
 	State     StateStore
-	Skills    Skills // optional
+	Skills    Skills    // optional
+	Subagents Subagents // optional; primary only
+
+	// MaxTurns caps the Run loop's iteration count. Zero means
+	// unlimited (the normal primary case). Used by subagents to
+	// bound runaway children -- when the cap is hit before the
+	// child calls subagent_report, Run exits cleanly and the
+	// spawnFn closure marks the result truncated.
+	MaxTurns int
+
+	// SystemPromptOverride, when non-empty, replaces prompts["system"]
+	// in initializeContext. The other prompts (cycle-start, continue,
+	// compaction, shutdown) are still loaded from the memory store
+	// because subagents need the same loop scaffolding.
+	SystemPromptOverride string
 }
 
 // New constructs an Agent. Any nil-allowed dependency (Operator,
-// Tokenizer, Skills) may be left as a nil interface; the agent handles
-// those cases internally with heuristic fallbacks or empty catalogs.
+// Tokenizer, Skills, Subagents) may be left as a nil interface; the
+// agent handles those cases internally with heuristic fallbacks or
+// empty catalogs.
 func New(cfg *config.Config, deps Deps, logger *slog.Logger) *Agent {
 	return &Agent{
-		cfg:       cfg,
-		chat:      deps.Chat,
-		memory:    deps.Memory,
-		search:    deps.Search,
-		operator:  deps.Operator,
-		tokenizer: deps.Tokenizer,
-		tools:     deps.Tools,
-		state:     deps.State,
-		skills:    deps.Skills,
-		logger:    logger,
+		cfg:                  cfg,
+		chat:                 deps.Chat,
+		memory:               deps.Memory,
+		search:               deps.Search,
+		operator:             deps.Operator,
+		tokenizer:            deps.Tokenizer,
+		tools:                deps.Tools,
+		state:                deps.State,
+		skills:               deps.Skills,
+		subagents:            deps.Subagents,
+		logger:               logger,
+		maxTurns:             deps.MaxTurns,
+		systemPromptOverride: deps.SystemPromptOverride,
 	}
+}
+
+// RequestStop signals the Run loop to exit cleanly after the current
+// iteration. Used by the tools layer when the child agent's
+// subagent_report tool fires: the report has been delivered to the
+// parent, so the child's loop should not continue.
+//
+// Idempotent and concurrency-safe; calling it multiple times has the
+// same effect as calling it once.
+func (a *Agent) RequestStop() {
+	a.stopRequested.Store(true)
 }
 
 // gatherSkillCatalog returns the current skill catalog for system-prompt
@@ -257,7 +297,29 @@ func (a *Agent) Run(ctx context.Context, shutdownCh <-chan struct{}) error {
 	lastSavedLen := -1
 	lastSavedIdle := -1
 
+	// Subagent loop bound. turn counts iterations (one Chat call per
+	// iteration); we exit when MaxTurns is set and the cap is hit.
+	// Zero MaxTurns (the primary case) disables the check.
+	turn := 0
+
 	for {
+		// Subagents: caller signaled the loop should stop after
+		// delivering the report. Check before any other work so we
+		// don't spend a turn on a doomed iteration.
+		if a.stopRequested.Load() {
+			a.logger.Info("agent: stop requested, exiting Run loop", "turns", turn)
+			return nil
+		}
+
+		// Subagents: enforce the per-run turn cap. The spawnFn closure
+		// in cmd/faultline/main.go inspects whether the report was
+		// delivered to decide whether to mark the result truncated.
+		if a.maxTurns > 0 && turn >= a.maxTurns {
+			a.logger.Warn("agent: max turns reached, exiting Run loop",
+				"turns", turn, "max", a.maxTurns)
+			return nil
+		}
+
 		// Check for shutdown
 		select {
 		case <-ctx.Done():
@@ -375,29 +437,43 @@ func (a *Agent) Run(ctx context.Context, shutdownCh <-chan struct{}) error {
 		// a sudden spike means the KV cache was invalidated.
 		a.logBackendPerf()
 
-		// Drain any collaborator messages that arrived while the LLM was
-		// generating. We will handle them at the next available
-		// opportunity rather than mid-generation.
-		var pending []string
+		// Drain any messages that arrived while the LLM was generating
+		// -- both operator (collaborator) messages and subagent reports.
+		// We will handle them at the next available opportunity rather
+		// than mid-generation.
+		var pendingOp []string
 		if a.operator != nil {
-			pending = a.operator.Pending()
+			pendingOp = a.operator.Pending()
 		}
+		var pendingSub []subagent.Report
+		if a.subagents != nil {
+			pendingSub = a.subagents.Pending()
+		}
+		hasPending := len(pendingOp)+len(pendingSub) > 0
 
 		switch {
-		case len(msg.ToolCalls) > 0 && len(pending) > 0:
-			// A collaborator message arrived while the model wanted to use
-			// tools. Defer the tool calls: every tool_call_id must still
-			// have a matching tool response or the next API call will fail,
-			// so we emit a "deferred" stub for each, then surface the
-			// collaborator message. The agent can reply and decide whether
-			// the deferred actions are still appropriate.
-			a.logger.Info("collaborator message arrived during generation; deferring tool calls",
-				"tool_calls", len(msg.ToolCalls), "pending", len(pending))
-			const deferredBody = "[Deferred] A message from your collaborator arrived before this tool call could run. Read their message below and reply with send_message first. After replying, re-issue this tool call if it still makes sense, or move on if their message changes your plan."
+		case len(msg.ToolCalls) > 0 && hasPending:
+			// New input arrived while the model wanted to use tools.
+			// Defer the tool calls: every tool_call_id must still
+			// have a matching tool response or the next API call will
+			// fail, so we emit a "deferred" stub for each, then
+			// surface the new input. The agent can read it and decide
+			// whether the deferred actions are still appropriate.
+			a.logger.Info("incoming messages arrived during generation; deferring tool calls",
+				"tool_calls", len(msg.ToolCalls),
+				"operator_pending", len(pendingOp),
+				"subagent_pending", len(pendingSub),
+			)
+			const deferredBody = "[Deferred] An incoming message (collaborator turn or subagent report) arrived before this tool call could run. Read it below and respond first. After responding, re-issue this tool call if it still makes sense, or move on if the new input changes your plan."
 			for _, tc := range msg.ToolCalls {
 				messages = append(messages, toolMessage(tc.ID, deferredBody))
 			}
-			messages = a.appendCollaboratorMessages(messages, pending)
+			if len(pendingOp) > 0 {
+				messages = a.appendCollaboratorMessages(messages, pendingOp)
+			}
+			if len(pendingSub) > 0 {
+				messages = a.appendSubagentReports(messages, pendingSub)
+			}
 			// Tool calls + new input both count as the model engaging.
 			idleStreak = 0
 
@@ -413,12 +489,16 @@ func (a *Agent) Run(ctx context.Context, shutdownCh <-chan struct{}) error {
 			}
 			idleStreak = 0
 
-		case len(pending) > 0:
-			// Text-only response with collaborator messages waiting: surface
-			// them in place of the continue prompt so the next turn
-			// addresses the collaborator naturally. New collaborator input
-			// resets the idle counter.
-			messages = a.appendCollaboratorMessages(messages, pending)
+		case hasPending:
+			// Text-only response with new input waiting: surface it in
+			// place of the continue prompt so the next turn addresses
+			// the new input naturally. Resets the idle counter.
+			if len(pendingOp) > 0 {
+				messages = a.appendCollaboratorMessages(messages, pendingOp)
+			}
+			if len(pendingSub) > 0 {
+				messages = a.appendSubagentReports(messages, pendingSub)
+			}
 			idleStreak = 0
 
 		default:
@@ -446,6 +526,7 @@ func (a *Agent) Run(ctx context.Context, shutdownCh <-chan struct{}) error {
 		a.logger.Debug("turn complete",
 			"messages", len(messages),
 			"tokens_est", a.countMessageTokens(messages))
+		turn++
 	}
 }
 
@@ -477,10 +558,21 @@ func (a *Agent) initializeContext() ([]llm.Message, map[string]string, int, erro
 	// Build a fresh system message from current prompts + recent memories
 	// + current skill catalog. This is used both for fresh starts and
 	// for replacing the (stale) system message in a restored state file.
+	//
+	// SystemPromptOverride lets a subagent replace the loaded "system"
+	// base prompt with one supplied by the spawnFn closure (typically
+	// "you are a subagent of the primary; here is your task: ...").
+	// The other prompts (cycle-start, continue, compaction, shutdown)
+	// still come from memory because subagents reuse the same loop
+	// scaffolding.
 	memories := a.gatherContextMemories()
 	skillCatalog := a.gatherSkillCatalog()
 	now := time.Now()
-	fullSystemPrompt := prompt.BuildCycleContext(prompts["system"], memories, skillCatalog, now, a.cfg.Limits.RecentMemoryChars)
+	basePrompt := prompts["system"]
+	if a.systemPromptOverride != "" {
+		basePrompt = a.systemPromptOverride
+	}
+	fullSystemPrompt := prompt.BuildCycleContext(basePrompt, memories, skillCatalog, now, a.cfg.Limits.RecentMemoryChars)
 	systemMsg := llm.Message{
 		Role:    llm.RoleSystem,
 		Content: fullSystemPrompt,
@@ -683,20 +775,35 @@ func (a *Agent) gatherContextMemories() []bm25.Result {
 	return results
 }
 
-// injectPendingMessages checks for queued collaborator messages and appends
-// them to the conversation. Returns the updated messages and whether any
-// were injected.
+// injectPendingMessages drains both the operator and the subagent
+// inboxes and appends any pending entries to the conversation. Returns
+// the updated messages and whether anything was injected.
+//
+// Both queues are drained on every call (rather than checking
+// HasPending first) because the read is the same primitive as the
+// drain in both adapters; there is no probe-then-take race to worry
+// about.
 func (a *Agent) injectPendingMessages(messages []llm.Message) ([]llm.Message, bool) {
-	if a.operator == nil {
+	var pendingOp []string
+	if a.operator != nil {
+		pendingOp = a.operator.Pending()
+	}
+	var pendingSub []subagent.Report
+	if a.subagents != nil {
+		pendingSub = a.subagents.Pending()
+	}
+
+	if len(pendingOp) == 0 && len(pendingSub) == 0 {
 		return messages, false
 	}
 
-	pending := a.operator.Pending()
-	if len(pending) == 0 {
-		return messages, false
+	if len(pendingOp) > 0 {
+		messages = a.appendCollaboratorMessages(messages, pendingOp)
 	}
-
-	return a.appendCollaboratorMessages(messages, pending), true
+	if len(pendingSub) > 0 {
+		messages = a.appendSubagentReports(messages, pendingSub)
+	}
+	return messages, true
 }
 
 // appendCollaboratorMessages formats each collaborator message as a user
@@ -715,6 +822,50 @@ func (a *Agent) appendCollaboratorMessages(messages []llm.Message, pending []str
 	return messages
 }
 
+// appendSubagentReports formats each completed subagent report as a
+// user turn and appends them to the conversation. Used by the same
+// drain points as appendCollaboratorMessages so both queues land in
+// the same place in the conversation.
+//
+// The wrapper format mirrors the [Collaborator message ...] header so
+// the model can pattern-match on a consistent shape; the body
+// includes Truncated/Canceled flags and any error so the parent can
+// react appropriately.
+func (a *Agent) appendSubagentReports(messages []llm.Message, reports []subagent.Report) []llm.Message {
+	for _, r := range reports {
+		a.logger.Info("injecting subagent report into conversation",
+			"work_id", r.WorkID,
+			"profile", r.Profile,
+			"truncated", r.Truncated,
+			"canceled", r.Canceled,
+			"err", r.Err,
+		)
+		var b strings.Builder
+		fmt.Fprintf(&b, "[Subagent report - %s, work_id=%s, profile=%s]\n",
+			time.Now().Format(time.RFC1123), r.WorkID, r.Profile)
+		if r.Truncated {
+			b.WriteString("[truncated -- subagent hit turn or time cap before reporting]\n")
+		}
+		if r.Canceled {
+			b.WriteString("[canceled -- subagent was canceled before reporting]\n")
+		}
+		if r.Err != nil {
+			fmt.Fprintf(&b, "[error: %s]\n", r.Err)
+		}
+		b.WriteString("\n")
+		if r.Text == "" {
+			b.WriteString("(no report content)")
+		} else {
+			b.WriteString(r.Text)
+		}
+		messages = append(messages, llm.Message{
+			Role:    llm.RoleUser,
+			Content: b.String(),
+		})
+	}
+	return messages
+}
+
 // handleShutdown wraps gracefulSave and translates errShutdown to nil.
 func (a *Agent) handleShutdown(ctx context.Context, messages []llm.Message, toolDefs []llm.Tool, prompts map[string]string) error {
 	err := a.gracefulSave(ctx, messages, toolDefs, prompts)
@@ -726,8 +877,17 @@ func (a *Agent) handleShutdown(ctx context.Context, messages []llm.Message, tool
 
 // gracefulSave gives the agent a limited number of turns to save its state
 // before the process exits. Uses a 2-minute timeout.
+//
+// Active subagents are canceled at the very top: their goroutines
+// observe ctx.Done() and exit promptly, freeing the parent's
+// gracefulSave loop from competing for the 2-minute / 10-turn budget
+// with children's in-flight LLM calls. Pending reports are abandoned;
+// the parent's state file is the source of truth across restarts.
 func (a *Agent) gracefulSave(ctx context.Context, messages []llm.Message, toolDefs []llm.Tool, prompts map[string]string) error {
 	a.logger.Info("graceful shutdown: asking agent to save state")
+	if a.subagents != nil {
+		a.subagents.CancelAll()
+	}
 
 	saveCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -123,6 +123,22 @@ func (a *Agent) gatherSkillCatalog() []skillsdomain.Skill {
 	return a.skills.List()
 }
 
+// gatherSubagentCatalog returns the configured subagent profiles
+// projected to {Name, Purpose} for system-prompt injection. Returns
+// nil when subagent support is disabled (or when this Agent is itself
+// a subagent, which doesn't have access to nested delegation).
+func (a *Agent) gatherSubagentCatalog() []subagent.Catalog {
+	if a.subagents == nil {
+		return nil
+	}
+	profiles := a.subagents.Profiles()
+	out := make([]subagent.Catalog, 0, len(profiles))
+	for _, p := range profiles {
+		out = append(out, p.ToCatalog())
+	}
+	return out
+}
+
 // Close releases the resources owned by the agent. Adapters whose
 // lifecycles outlive the agent (the Sandbox, ChatLogger, etc.) are
 // closed by the composition root, not here.
@@ -567,12 +583,13 @@ func (a *Agent) initializeContext() ([]llm.Message, map[string]string, int, erro
 	// scaffolding.
 	memories := a.gatherContextMemories()
 	skillCatalog := a.gatherSkillCatalog()
+	subagentCatalog := a.gatherSubagentCatalog()
 	now := time.Now()
 	basePrompt := prompts["system"]
 	if a.systemPromptOverride != "" {
 		basePrompt = a.systemPromptOverride
 	}
-	fullSystemPrompt := prompt.BuildCycleContext(basePrompt, memories, skillCatalog, now, a.cfg.Limits.RecentMemoryChars)
+	fullSystemPrompt := prompt.BuildCycleContext(basePrompt, memories, skillCatalog, subagentCatalog, now, a.cfg.Limits.RecentMemoryChars)
 	systemMsg := llm.Message{
 		Role:    llm.RoleSystem,
 		Content: fullSystemPrompt,
@@ -707,8 +724,9 @@ func (a *Agent) rebuildContext(summary string) ([]llm.Message, map[string]string
 	// the operator has dropped in since the last cycle become visible.
 	memories := a.gatherContextMemories()
 	skillCatalog := a.gatherSkillCatalog()
+	subagentCatalog := a.gatherSubagentCatalog()
 	now := time.Now()
-	fullSystemPrompt := prompt.BuildCycleContext(prompts["system"], memories, skillCatalog, now, a.cfg.Limits.RecentMemoryChars)
+	fullSystemPrompt := prompt.BuildCycleContext(prompts["system"], memories, skillCatalog, subagentCatalog, now, a.cfg.Limits.RecentMemoryChars)
 
 	messages := []llm.Message{
 		{Role: llm.RoleSystem, Content: fullSystemPrompt},

--- a/internal/agent/ports.go
+++ b/internal/agent/ports.go
@@ -7,6 +7,7 @@ import (
 	"github.com/matjam/faultline/internal/llm"
 	"github.com/matjam/faultline/internal/search/bm25"
 	"github.com/matjam/faultline/internal/skills"
+	"github.com/matjam/faultline/internal/subagent"
 )
 
 // ChatModel is the LLM port. The agent does not care which backend
@@ -94,4 +95,17 @@ type StateStore interface {
 type Skills interface {
 	List() []skills.Skill
 	Reload() error
+}
+
+// Subagents is the inbox port for completed subagent runs. The agent
+// loop drains the inbox between turns (and after each LLM response)
+// alongside the operator queue, and on graceful shutdown it cancels
+// every active subagent so their goroutines unwind promptly.
+//
+// May be nil for the primary agent when the [subagent] feature is
+// disabled, and is always nil for child agents (no nesting).
+type Subagents interface {
+	Pending() []subagent.Report
+	HasPending() bool
+	CancelAll()
 }

--- a/internal/agent/ports.go
+++ b/internal/agent/ports.go
@@ -108,4 +108,10 @@ type Subagents interface {
 	Pending() []subagent.Report
 	HasPending() bool
 	CancelAll()
+
+	// Profiles returns the configured profiles for system-prompt
+	// catalog injection. Static for the agent's lifetime; called on
+	// every context rebuild for consistency with how skills are
+	// surfaced.
+	Profiles() []subagent.Profile
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,13 @@ type Config struct {
 	// and on every context rebuild, injects a tier-1 catalog into the
 	// system prompt, and advertises skill_* tools.
 	Skills SkillsConfig `toml:"skills"`
+
+	// Subagent is optional; when Enabled, the primary agent gains
+	// the subagent_run/spawn/status/cancel tools and can delegate
+	// isolated work to child agent loops. Profiles configure
+	// alternative LLM endpoints; the synthesized "default" profile
+	// (matching [api]) is always available when Enabled is true.
+	Subagent SubagentConfig `toml:"subagent"`
 }
 
 // APIConfig holds LLM API connection settings.
@@ -270,6 +277,93 @@ func (s SkillsConfig) Active() bool {
 	return s.Enabled && s.Dir != ""
 }
 
+// SubagentConfig holds settings for subagent delegation. When
+// Enabled, the primary agent gains four tools (subagent_run,
+// subagent_spawn, subagent_status, subagent_cancel) and may
+// dispatch work to child agent loops running under the configured
+// Profiles, or under a synthesized "default" profile that inherits
+// the primary's [api] / [agent] settings.
+//
+// Subagents share the primary's memory store, indexes, sandbox,
+// and skills; they do NOT inherit the operator (Telegram) port or
+// the conversation state file, and they cannot themselves spawn
+// further subagents (no nesting).
+type SubagentConfig struct {
+	// Enabled toggles the entire feature.
+	Enabled bool `toml:"enabled"`
+
+	// Profiles is the operator-supplied list of LLM-endpoint
+	// profiles the primary may pick when delegating. The reserved
+	// name "default" is synthesized at runtime from [api] / [agent]
+	// and is always available when Enabled is true; operator
+	// profiles must use a different name.
+	Profiles []SubagentProfile `toml:"profiles"`
+
+	// MaxConcurrent caps the number of asynchronous (spawned)
+	// subagents that may run at the same time. Synchronous (run)
+	// subagents are uncounted -- the primary's tool dispatch is
+	// blocked while one is running, so at most one sync child
+	// exists per primary. Defaults to 4.
+	MaxConcurrent int `toml:"max_concurrent"`
+
+	// MaxTurnsPerRun caps the child agent's loop iterations to
+	// bound runaway. The child's system prompt instructs it to
+	// call subagent_report when finished; if it exhausts this
+	// budget without reporting, its last assistant text is
+	// returned with Truncated=true. Defaults to 50.
+	MaxTurnsPerRun int `toml:"max_turns_per_run"`
+
+	// MaxInbox caps the number of completed async reports queued
+	// for the primary to drain. When full, the oldest report is
+	// dropped with a warning log. Defaults to 32.
+	MaxInbox int `toml:"max_inbox"`
+
+	// RunTimeout is the wall-clock cap on a single subagent run.
+	// Defaults to 30m. Zero or negative falls back to the default;
+	// a deliberately huge value disables the cap in practice.
+	RunTimeout duration `toml:"run_timeout"`
+}
+
+// SubagentProfile is one operator-configured execution profile.
+// Sampler fields use zero-value-omitted semantics matching
+// AgentConfig: zero means "inherit the primary's [agent] value",
+// non-zero overrides it.
+type SubagentProfile struct {
+	// Name is the profile identifier, advertised to the primary
+	// agent as a callable target. Lowercase letters/digits/hyphens,
+	// 1-32 chars, not "default".
+	Name string `toml:"name"`
+
+	// APIURL is the OpenAI-compatible chat-completions base URL
+	// (ending in /v1, no trailing slash). Required.
+	APIURL string `toml:"api_url"`
+
+	// APIKey is sent as a Bearer token. May be empty for local
+	// servers that don't authenticate.
+	APIKey string `toml:"api_key"`
+
+	// Model is the model identifier. Required.
+	Model string `toml:"model"`
+
+	// Purpose is operator-supplied free-form text explaining when
+	// the primary should pick this profile. Rendered in the
+	// primary's system prompt next to the profile name.
+	Purpose string `toml:"purpose"`
+
+	// Sampler overrides; zero inherits from [agent].
+	Temperature       float32 `toml:"temperature"`
+	TopP              float32 `toml:"top_p"`
+	TopK              int     `toml:"top_k"`
+	MinP              float32 `toml:"min_p"`
+	RepetitionPenalty float32 `toml:"repetition_penalty"`
+	MaxRespTokens     int     `toml:"max_response_tokens"`
+}
+
+// Active reports whether subagent support is wired up.
+func (s SubagentConfig) Active() bool {
+	return s.Enabled
+}
+
 // EmailConfig holds optional IMAP email connection settings.
 type EmailConfig struct {
 	Host     string `toml:"host"`
@@ -359,6 +453,13 @@ func Default() *Config {
 			Enabled: false,
 			Dir:     "./skills",
 		},
+		Subagent: SubagentConfig{
+			Enabled:        false,
+			MaxConcurrent:  4,
+			MaxTurnsPerRun: 50,
+			MaxInbox:       32,
+			RunTimeout:     duration(30 * time.Minute),
+		},
 	}
 }
 
@@ -396,6 +497,21 @@ func Load(path string) (*Config, error) {
 	}
 	if cfg.Embeddings.BatchSize <= 0 {
 		cfg.Embeddings.BatchSize = 100
+	}
+
+	// Subagent caps: backfill defaults for any zero values when the
+	// operator enables the feature but doesn't override the caps.
+	if cfg.Subagent.MaxConcurrent <= 0 {
+		cfg.Subagent.MaxConcurrent = 4
+	}
+	if cfg.Subagent.MaxTurnsPerRun <= 0 {
+		cfg.Subagent.MaxTurnsPerRun = 50
+	}
+	if cfg.Subagent.MaxInbox <= 0 {
+		cfg.Subagent.MaxInbox = 32
+	}
+	if cfg.Subagent.RunTimeout.Duration() <= 0 {
+		cfg.Subagent.RunTimeout = duration(30 * time.Minute)
 	}
 
 	return cfg, nil

--- a/internal/prompts/cycle_test.go
+++ b/internal/prompts/cycle_test.go
@@ -7,11 +7,12 @@ import (
 
 	"github.com/matjam/faultline/internal/search/bm25"
 	"github.com/matjam/faultline/internal/skills"
+	"github.com/matjam/faultline/internal/subagent"
 )
 
 func TestBuildCycleContext_NoMemories(t *testing.T) {
 	now := time.Date(2026, 4, 27, 10, 30, 0, 0, time.UTC)
-	got := BuildCycleContext("SYSTEM PROMPT", nil, nil, now, 2000)
+	got := BuildCycleContext("SYSTEM PROMPT", nil, nil, nil, now, 2000)
 
 	if !strings.Contains(got, "SYSTEM PROMPT") {
 		t.Error("output missing system prompt")
@@ -25,6 +26,9 @@ func TestBuildCycleContext_NoMemories(t *testing.T) {
 	if strings.Contains(got, "Available Skills") {
 		t.Error("output should not have Available Skills section when no skills provided")
 	}
+	if strings.Contains(got, "Subagent Profiles") {
+		t.Error("output should not have Subagent Profiles section when no profiles provided")
+	}
 }
 
 func TestBuildCycleContext_WithMemories(t *testing.T) {
@@ -33,7 +37,7 @@ func TestBuildCycleContext_WithMemories(t *testing.T) {
 		{Path: "alpha.md", Content: "alpha content"},
 		{Path: "beta.md", Content: "beta content"},
 	}
-	got := BuildCycleContext("SYS", mems, nil, now, 2000)
+	got := BuildCycleContext("SYS", mems, nil, nil, now, 2000)
 
 	if !strings.Contains(got, "Recent Memories") {
 		t.Error("missing Recent Memories header")
@@ -52,7 +56,7 @@ func TestBuildCycleContext_WithMemories(t *testing.T) {
 func TestBuildCycleContext_TruncatesLongMemory(t *testing.T) {
 	long := strings.Repeat("x", 3000)
 	mems := []bm25.Result{{Path: "long.md", Content: long}}
-	got := BuildCycleContext("SYS", mems, nil, time.Now(), 2000)
+	got := BuildCycleContext("SYS", mems, nil, nil, time.Now(), 2000)
 
 	if !strings.Contains(got, "[truncated") {
 		t.Error("expected truncation marker for long memory")
@@ -74,7 +78,7 @@ func TestBuildCycleContext_TruncatesLongMemory(t *testing.T) {
 func TestBuildCycleContext_NoLimitKeepsFullContent(t *testing.T) {
 	long := strings.Repeat("x", 3000)
 	mems := []bm25.Result{{Path: "long.md", Content: long}}
-	got := BuildCycleContext("SYS", mems, nil, time.Now(), 0)
+	got := BuildCycleContext("SYS", mems, nil, nil, time.Now(), 0)
 
 	if strings.Contains(got, "[truncated") {
 		t.Error("did not expect truncation marker when limit is disabled")
@@ -89,7 +93,7 @@ func TestBuildCycleContext_WithSkills(t *testing.T) {
 		{Name: "pdf-processing", Description: "Handle PDFs."},
 		{Name: "data-analysis", Description: "Analyze datasets."},
 	}
-	got := BuildCycleContext("SYS", nil, cat, time.Now(), 2000)
+	got := BuildCycleContext("SYS", nil, cat, nil, time.Now(), 2000)
 
 	if !strings.Contains(got, "## Available Skills") {
 		t.Error("missing Available Skills header")
@@ -108,7 +112,7 @@ func TestBuildCycleContext_WithSkills(t *testing.T) {
 func TestBuildCycleContext_SkillsAndMemoriesTogether(t *testing.T) {
 	cat := []skills.Skill{{Name: "x", Description: "x."}}
 	mems := []bm25.Result{{Path: "m.md", Content: "memory body"}}
-	got := BuildCycleContext("SYS", mems, cat, time.Now(), 2000)
+	got := BuildCycleContext("SYS", mems, cat, nil, time.Now(), 2000)
 
 	skillsIdx := strings.Index(got, "## Available Skills")
 	memIdx := strings.Index(got, "## Recent Memories")
@@ -117,5 +121,43 @@ func TestBuildCycleContext_SkillsAndMemoriesTogether(t *testing.T) {
 	}
 	if skillsIdx > memIdx {
 		t.Error("skills section should appear before memories")
+	}
+}
+
+func TestBuildCycleContext_WithSubagents(t *testing.T) {
+	cat := []subagent.Catalog{
+		{Name: "fast", Purpose: "Quick lookups."},
+		{Name: "deep", Purpose: "Architecture analysis."},
+	}
+	got := BuildCycleContext("SYS", nil, nil, cat, time.Now(), 2000)
+
+	if !strings.Contains(got, "## Available Subagent Profiles") {
+		t.Error("missing Subagent Profiles header")
+	}
+	if !strings.Contains(got, "**fast**: Quick lookups.") {
+		t.Errorf("missing fast entry; got %q", got)
+	}
+	if !strings.Contains(got, "**deep**: Architecture analysis.") {
+		t.Error("missing deep entry")
+	}
+	if !strings.Contains(got, "subagent_run") {
+		t.Error("missing subagent_run instruction")
+	}
+}
+
+func TestBuildCycleContext_SubagentsAfterSkills(t *testing.T) {
+	skl := []skills.Skill{{Name: "x", Description: "x."}}
+	sub := []subagent.Catalog{{Name: "fast", Purpose: "y"}}
+	mems := []bm25.Result{{Path: "m.md", Content: "memory body"}}
+	got := BuildCycleContext("SYS", mems, skl, sub, time.Now(), 2000)
+
+	skillsIdx := strings.Index(got, "## Available Skills")
+	subIdx := strings.Index(got, "## Available Subagent Profiles")
+	memIdx := strings.Index(got, "## Recent Memories")
+	if skillsIdx < 0 || subIdx < 0 || memIdx < 0 {
+		t.Fatalf("missing sections: skills=%d sub=%d mem=%d", skillsIdx, subIdx, memIdx)
+	}
+	if skillsIdx >= subIdx || subIdx >= memIdx {
+		t.Errorf("expected order skills -> subagent -> memories; got %d, %d, %d", skillsIdx, subIdx, memIdx)
 	}
 }

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/matjam/faultline/internal/search/bm25"
 	"github.com/matjam/faultline/internal/skills"
+	"github.com/matjam/faultline/internal/subagent"
 )
 
 // Embedded default prompt contents, compiled into the binary from templates/.
@@ -178,7 +179,7 @@ func Render(template string, now time.Time) string {
 // Skills" section with a brief instruction telling the agent to call
 // skill_activate when a task matches a skill's description. Each
 // entry costs ~50-100 tokens, matching the spec's tier-1 disclosure.
-func BuildCycleContext(systemPrompt string, memories []bm25.Result, skillCatalog []skills.Skill, now time.Time, memoryCharLimit int) string {
+func BuildCycleContext(systemPrompt string, memories []bm25.Result, skillCatalog []skills.Skill, subagentCatalog []subagent.Catalog, now time.Time, memoryCharLimit int) string {
 	var sb strings.Builder
 
 	sb.WriteString(systemPrompt)
@@ -187,6 +188,10 @@ func BuildCycleContext(systemPrompt string, memories []bm25.Result, skillCatalog
 
 	if len(skillCatalog) > 0 {
 		writeSkillCatalog(&sb, skillCatalog)
+	}
+
+	if len(subagentCatalog) > 0 {
+		writeSubagentCatalog(&sb, subagentCatalog)
 	}
 
 	if len(memories) > 0 {
@@ -209,6 +214,29 @@ func BuildCycleContext(systemPrompt string, memories []bm25.Result, skillCatalog
 	}
 
 	return sb.String()
+}
+
+// writeSubagentCatalog renders the subagent profile disclosure
+// section: a brief explanation of the delegation tools followed by a
+// bulleted name/purpose list. The model uses this to pick a profile
+// when calling subagent_run / subagent_spawn.
+func writeSubagentCatalog(sb *strings.Builder, catalog []subagent.Catalog) {
+	sb.WriteString("## Available Subagent Profiles\n\n")
+	sb.WriteString("You can delegate isolated work to a subagent via `subagent_run` ")
+	sb.WriteString("(synchronous; returns the report inline) or `subagent_spawn` ")
+	sb.WriteString("(asynchronous; the report arrives in your context like an operator message). ")
+	sb.WriteString("Use `subagent_wait` to block on a previously-spawned subagent, ")
+	sb.WriteString("`subagent_status` to list active spawns, and `subagent_cancel` to abort one. ")
+	sb.WriteString("The subagent has the same tools you do (minus sleep, update_*, and nested subagent_*) ")
+	sb.WriteString("but cannot see your conversation -- you must put everything it needs in the `prompt`.\n\n")
+	for _, p := range catalog {
+		purpose := strings.TrimSpace(p.Purpose)
+		if purpose == "" {
+			purpose = "(no purpose configured)"
+		}
+		fmt.Fprintf(sb, "- **%s**: %s\n", p.Name, purpose)
+	}
+	sb.WriteString("\n")
 }
 
 // writeSkillCatalog renders the tier-1 skill disclosure section:

--- a/internal/subagent/manager.go
+++ b/internal/subagent/manager.go
@@ -193,6 +193,57 @@ func (m *Manager) ActiveCount() int {
 	return len(m.active)
 }
 
+// Wait blocks until the named subagent's report arrives, ctx cancels,
+// or the subagent is unknown. The returned bool reports whether the
+// report was found; on true the report is also removed from the
+// inbox so a subsequent Pending() drain won't see it twice.
+//
+// Lookup order:
+//  1. Already-pending? Take and return immediately.
+//  2. Currently-active? Block on its done channel, then take.
+//  3. Neither? Return found=false with an error.
+func (m *Manager) Wait(ctx context.Context, workID string) (Report, bool, error) {
+	m.mu.Lock()
+	if r, ok := m.takePendingLocked(workID); ok {
+		m.mu.Unlock()
+		return r, true, nil
+	}
+	ar, alive := m.active[workID]
+	m.mu.Unlock()
+
+	if !alive {
+		return Report{}, false, fmt.Errorf("no subagent with work_id %q (already drained or never existed?)", workID)
+	}
+
+	select {
+	case <-ar.done:
+		// fall through
+	case <-ctx.Done():
+		return Report{}, false, ctx.Err()
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if r, ok := m.takePendingLocked(workID); ok {
+		return r, true, nil
+	}
+	// runOne always appends to pending before closing done for async
+	// runs; for sync runs it doesn't, so fall back to ar.result.
+	return ar.result, true, nil
+}
+
+// takePendingLocked removes and returns the pending report with the
+// given workID. Caller must hold m.mu.
+func (m *Manager) takePendingLocked(workID string) (Report, bool) {
+	for i, r := range m.pending {
+		if r.WorkID == workID {
+			m.pending = append(m.pending[:i], m.pending[i+1:]...)
+			return r, true
+		}
+	}
+	return Report{}, false
+}
+
 // Cancel aborts the named subagent. Safe to call multiple times;
 // the second call returns an error (no such workID) because the
 // goroutine has already cleaned up. The cancellation propagates via

--- a/internal/subagent/manager.go
+++ b/internal/subagent/manager.go
@@ -1,0 +1,379 @@
+package subagent
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// Manager owns the live subagent registry and the report inbox the
+// primary agent drains alongside operator messages.
+//
+// Lifecycle:
+//   - constructed once in cmd/faultline/main.go with the operator's
+//     [subagent] config, the synthesized default profile, and a
+//     SpawnFunc that knows how to construct + run a child agent.
+//   - the agent loop calls Pending() / HasPending() to drain async
+//     reports, parallel to the operator queue.
+//   - the tools layer calls Run() / Spawn() / Status() / Cancel() to
+//     drive the four subagent_* tools.
+//   - on parent shutdown, CancelAll() fires; in-flight goroutines
+//     observe their canceled context and return promptly.
+//
+// The Manager is safe for concurrent use. The internal map and
+// pending slice are mutex-guarded; goroutines launched per Run/Spawn
+// touch only their own activeRun and the inbox.
+type Manager struct {
+	logger *slog.Logger
+
+	profiles   []Profile
+	profileMap map[string]Profile
+
+	spawn SpawnFunc
+
+	maxConcurrent  int
+	maxInbox       int
+	maxTurnsPerRun int
+	runTimeout     time.Duration
+
+	mu      sync.Mutex
+	active  map[string]*activeRun
+	pending []Report
+}
+
+// SpawnFunc is the bridge from domain to composition. It constructs
+// and runs a child agent loop with the supplied profile and prompt,
+// blocking until the child terminates (via subagent_report, turn cap,
+// timeout, or context cancellation). The returned Report's WorkID
+// must equal the workID argument; other fields are populated from
+// the child's behavior.
+//
+// SpawnFunc must respect ctx: when ctx is canceled, the child's
+// in-flight LLM call should abort and the child loop should exit
+// promptly. The Manager wraps the parent's context with the
+// configured run timeout before passing it in.
+type SpawnFunc func(ctx context.Context, workID string, profile Profile, prompt string, maxTurns int) Report
+
+// activeRun is the per-subagent bookkeeping the Manager holds while
+// a child is running. result and done are set/closed exactly once,
+// when the spawn goroutine returns.
+type activeRun struct {
+	workID  string
+	profile string
+	prompt  string
+	started time.Time
+	cancel  context.CancelFunc
+	done    chan struct{}
+	result  Report
+	async   bool
+}
+
+// Config wraps the runtime parameters Manager needs. Mirrors
+// config.SubagentConfig minus the on-disk representation; main.go
+// translates one to the other.
+type Config struct {
+	MaxConcurrent  int
+	MaxTurnsPerRun int
+	MaxInbox       int
+	RunTimeout     time.Duration
+}
+
+// New constructs a Manager. profiles must include the synthesized
+// "default" profile; main.go is responsible for building it from
+// the primary's [api] config. If two profiles share a name, the
+// later one wins and a warning is logged (composition decision; the
+// Manager does not reject duplicates).
+func New(cfg Config, profiles []Profile, spawn SpawnFunc, logger *slog.Logger) *Manager {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if cfg.MaxConcurrent <= 0 {
+		cfg.MaxConcurrent = 4
+	}
+	if cfg.MaxTurnsPerRun <= 0 {
+		cfg.MaxTurnsPerRun = 50
+	}
+	if cfg.MaxInbox <= 0 {
+		cfg.MaxInbox = 32
+	}
+	if cfg.RunTimeout <= 0 {
+		cfg.RunTimeout = 30 * time.Minute
+	}
+
+	pm := make(map[string]Profile, len(profiles))
+	for _, p := range profiles {
+		if _, exists := pm[p.Name]; exists {
+			logger.Warn("duplicate subagent profile name; later definition wins", "name", p.Name)
+		}
+		pm[p.Name] = p
+	}
+
+	return &Manager{
+		logger:         logger,
+		profiles:       profiles,
+		profileMap:     pm,
+		spawn:          spawn,
+		maxConcurrent:  cfg.MaxConcurrent,
+		maxTurnsPerRun: cfg.MaxTurnsPerRun,
+		maxInbox:       cfg.MaxInbox,
+		runTimeout:     cfg.RunTimeout,
+		active:         make(map[string]*activeRun),
+	}
+}
+
+// Profiles returns the configured profiles in deterministic order
+// (the order they were passed to New). Used by the prompts package
+// to render the catalog into the primary's system prompt.
+func (m *Manager) Profiles() []Profile {
+	out := make([]Profile, len(m.profiles))
+	copy(out, m.profiles)
+	return out
+}
+
+// FindProfile returns the named profile and ok=true, or zero+false
+// if no such profile exists.
+func (m *Manager) FindProfile(name string) (Profile, bool) {
+	p, ok := m.profileMap[name]
+	return p, ok
+}
+
+// MaxTurnsPerRun is exposed to the SpawnFunc closure so the child
+// agent can cap its own loop iterations.
+func (m *Manager) MaxTurnsPerRun() int { return m.maxTurnsPerRun }
+
+// Pending drains and returns all queued completion Reports. Mirrors
+// the telegram.Bot contract so the agent loop can treat both queues
+// the same way.
+func (m *Manager) Pending() []Report {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.pending) == 0 {
+		return nil
+	}
+	out := m.pending
+	m.pending = nil
+	return out
+}
+
+// HasPending reports whether any reports are queued, without
+// draining them.
+func (m *Manager) HasPending() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.pending) > 0
+}
+
+// Status returns a snapshot of currently running subagents.
+func (m *Manager) Status() []ActiveStatus {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]ActiveStatus, 0, len(m.active))
+	for _, ar := range m.active {
+		out = append(out, ActiveStatus{
+			WorkID:  ar.workID,
+			Profile: ar.profile,
+			Prompt:  truncate(ar.prompt, 200),
+			Started: ar.started,
+			Async:   ar.async,
+		})
+	}
+	return out
+}
+
+// ActiveCount returns the number of currently running subagents.
+// Used for cap enforcement and the context_status tool.
+func (m *Manager) ActiveCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.active)
+}
+
+// Cancel aborts the named subagent. Safe to call multiple times;
+// the second call returns an error (no such workID) because the
+// goroutine has already cleaned up. The cancellation propagates via
+// the child's context; the spawnFn must return promptly when ctx
+// is done.
+func (m *Manager) Cancel(workID string) error {
+	m.mu.Lock()
+	ar, ok := m.active[workID]
+	m.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("no active subagent with work_id %q", workID)
+	}
+	ar.cancel()
+	return nil
+}
+
+// CancelAll fires Cancel on every active subagent. Used by the
+// agent's gracefulSave path. Does not wait for goroutines to finish;
+// the caller is responsible for that if it cares.
+func (m *Manager) CancelAll() {
+	m.mu.Lock()
+	for _, ar := range m.active {
+		ar.cancel()
+	}
+	m.mu.Unlock()
+}
+
+// Run executes a subagent synchronously: blocks until the child
+// terminates and returns the resulting Report. Used by the
+// subagent_run tool, which wants the report inline as the tool's
+// output.
+//
+// The parent's ctx is honored: if it cancels, the child's ctx
+// cancels and Run returns the partial Report with Canceled=true.
+func (m *Manager) Run(ctx context.Context, profileName, prompt string) (Report, error) {
+	return m.start(ctx, profileName, prompt, false)
+}
+
+// Spawn launches a subagent asynchronously. Returns the workID
+// immediately; the report is delivered to the inbox when the child
+// terminates. Used by the subagent_spawn tool.
+func (m *Manager) Spawn(ctx context.Context, profileName, prompt string) (string, error) {
+	report, err := m.start(ctx, profileName, prompt, true)
+	if err != nil {
+		return "", err
+	}
+	return report.WorkID, nil
+}
+
+// start is the shared launch path. For sync runs (async=false) it
+// blocks waiting for the goroutine to finish and returns the Report.
+// For async runs it returns a stub Report carrying just the workID
+// and lets the goroutine deliver to the inbox.
+func (m *Manager) start(ctx context.Context, profileName, prompt string, async bool) (Report, error) {
+	profile, ok := m.FindProfile(profileName)
+	if !ok {
+		return Report{}, fmt.Errorf("unknown subagent profile %q", profileName)
+	}
+	if prompt == "" {
+		return Report{}, errors.New("subagent prompt is empty")
+	}
+
+	workID, err := newWorkID()
+	if err != nil {
+		return Report{}, fmt.Errorf("allocate work_id: %w", err)
+	}
+
+	// Cap async concurrent subagents. Sync runs are not capped:
+	// the parent's tool dispatch is blocked waiting for the result,
+	// so there is at most one sync child per parent agent.
+	if async {
+		m.mu.Lock()
+		asyncCount := 0
+		for _, ar := range m.active {
+			if ar.async {
+				asyncCount++
+			}
+		}
+		if asyncCount >= m.maxConcurrent {
+			m.mu.Unlock()
+			return Report{}, fmt.Errorf("max_concurrent (%d) async subagents already running", m.maxConcurrent)
+		}
+		m.mu.Unlock()
+	}
+
+	childCtx, cancel := context.WithCancel(ctx)
+	if m.runTimeout > 0 {
+		childCtx, cancel = context.WithTimeout(ctx, m.runTimeout)
+	}
+
+	ar := &activeRun{
+		workID:  workID,
+		profile: profile.Name,
+		prompt:  prompt,
+		started: time.Now(),
+		cancel:  cancel,
+		done:    make(chan struct{}),
+		async:   async,
+	}
+
+	m.mu.Lock()
+	m.active[workID] = ar
+	m.mu.Unlock()
+
+	go m.runOne(childCtx, ar, profile, prompt)
+
+	if async {
+		return Report{WorkID: workID, Profile: profile.Name, StartedAt: ar.started}, nil
+	}
+
+	// Sync: block on the goroutine. Honor parent ctx so the tool
+	// dispatch returns promptly if the parent shuts down.
+	select {
+	case <-ar.done:
+		return ar.result, nil
+	case <-ctx.Done():
+		ar.cancel()
+		<-ar.done
+		return ar.result, nil
+	}
+}
+
+// runOne is the per-subagent goroutine body. Calls the SpawnFunc,
+// captures the Report, removes from active, and either delivers to
+// the inbox (async) or signals the sync caller (waiting on done).
+func (m *Manager) runOne(ctx context.Context, ar *activeRun, profile Profile, prompt string) {
+	defer ar.cancel() // release timeout context resources
+	defer close(ar.done)
+
+	report := m.spawn(ctx, ar.workID, profile, prompt, m.maxTurnsPerRun)
+	report.WorkID = ar.workID
+	report.Profile = profile.Name
+	report.StartedAt = ar.started
+	if report.FinishedAt.IsZero() {
+		report.FinishedAt = time.Now()
+	}
+	ar.result = report
+
+	m.mu.Lock()
+	delete(m.active, ar.workID)
+	if ar.async {
+		// Drop oldest if inbox is full. Better to lose the eldest
+		// report than refuse new ones; the parent has clearly
+		// fallen behind on draining.
+		for len(m.pending) >= m.maxInbox {
+			dropped := m.pending[0]
+			m.pending = m.pending[1:]
+			m.logger.Warn("subagent inbox full; dropping oldest report",
+				"dropped_work_id", dropped.WorkID,
+				"dropped_profile", dropped.Profile,
+				"max_inbox", m.maxInbox,
+			)
+		}
+		m.pending = append(m.pending, report)
+	}
+	m.mu.Unlock()
+
+	m.logger.Info("subagent finished",
+		"work_id", ar.workID,
+		"profile", profile.Name,
+		"async", ar.async,
+		"canceled", report.Canceled,
+		"truncated", report.Truncated,
+		"err", report.Err,
+		"elapsed", time.Since(ar.started),
+	)
+}
+
+// newWorkID allocates a 12-hex-char identifier with the "sub-" prefix.
+// Matches the skill_execute work_id format for visual consistency.
+func newWorkID() (string, error) {
+	var buf [6]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", err
+	}
+	return "sub-" + hex.EncodeToString(buf[:]), nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/internal/subagent/manager_test.go
+++ b/internal/subagent/manager_test.go
@@ -1,0 +1,374 @@
+package subagent
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func newTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func newTestProfiles() []Profile {
+	return []Profile{
+		{
+			Name:    DefaultProfileName,
+			APIURL:  "http://localhost:5001/v1",
+			Model:   "qwen",
+			Purpose: "default backend",
+		},
+		{
+			Name:    "fast",
+			APIURL:  "http://localhost:5001/v1",
+			Model:   "qwen-7b",
+			Purpose: "quick lookups",
+		},
+	}
+}
+
+func TestValidateName(t *testing.T) {
+	cases := []struct {
+		name string
+		ok   bool
+	}{
+		{"fast", true},
+		{"deep-research", true},
+		{"a", true},
+		{"a-1", true},
+
+		{"", false},
+		{"default", false}, // reserved
+		{"FAST", false},    // uppercase
+		{"-fast", false},
+		{"fast-", false},
+		{"fa--st", false},
+		{"with space", false},
+		{"under_score", false},
+		// 33 chars
+		{"abcdefghij-abcdefghij-abcdefghij-x", false},
+	}
+	for _, c := range cases {
+		err := ValidateName(c.name)
+		if c.ok && err != nil {
+			t.Errorf("ValidateName(%q) = %v, want nil", c.name, err)
+		}
+		if !c.ok && err == nil {
+			t.Errorf("ValidateName(%q) = nil, want error", c.name)
+		}
+	}
+}
+
+func TestValidateProfile(t *testing.T) {
+	good := Profile{Name: "fast", APIURL: "http://x/v1", Model: "m"}
+	if err := ValidateProfile(good); err != nil {
+		t.Errorf("ValidateProfile(good) = %v, want nil", err)
+	}
+
+	if err := ValidateProfile(Profile{Name: "fast"}); err == nil {
+		t.Error("missing api_url: want error")
+	}
+	if err := ValidateProfile(Profile{Name: "fast", APIURL: "x"}); err == nil {
+		t.Error("missing model: want error")
+	}
+
+	long := make([]byte, MaxPurposeLen+1)
+	for i := range long {
+		long[i] = 'a'
+	}
+	if err := ValidateProfile(Profile{Name: "fast", APIURL: "x", Model: "m", Purpose: string(long)}); err == nil {
+		t.Error("over-long purpose: want error")
+	}
+}
+
+func TestRunSyncReturnsReport(t *testing.T) {
+	want := "all done"
+	spawn := func(ctx context.Context, workID string, profile Profile, prompt string, maxTurns int) Report {
+		if profile.Name != "fast" {
+			t.Errorf("got profile %q, want fast", profile.Name)
+		}
+		if prompt != "do the thing" {
+			t.Errorf("got prompt %q, want 'do the thing'", prompt)
+		}
+		if maxTurns <= 0 {
+			t.Errorf("maxTurns = %d, want positive", maxTurns)
+		}
+		return Report{Text: want}
+	}
+
+	m := New(Config{}, newTestProfiles(), spawn, newTestLogger())
+	rep, err := m.Run(context.Background(), "fast", "do the thing")
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if rep.Text != want {
+		t.Errorf("rep.Text = %q, want %q", rep.Text, want)
+	}
+	if rep.WorkID == "" {
+		t.Error("WorkID empty")
+	}
+	if rep.Profile != "fast" {
+		t.Errorf("rep.Profile = %q, want fast", rep.Profile)
+	}
+	if m.ActiveCount() != 0 {
+		t.Errorf("ActiveCount = %d after Run, want 0", m.ActiveCount())
+	}
+}
+
+func TestSpawnAsyncReportLandsInInbox(t *testing.T) {
+	released := make(chan struct{})
+	spawn := func(ctx context.Context, workID string, profile Profile, prompt string, maxTurns int) Report {
+		<-released
+		return Report{Text: "async-done"}
+	}
+
+	m := New(Config{}, newTestProfiles(), spawn, newTestLogger())
+	workID, err := m.Spawn(context.Background(), "fast", "off you go")
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if workID == "" {
+		t.Fatal("empty workID")
+	}
+	if !m.HasPending() && m.ActiveCount() != 1 {
+		t.Error("expected one active subagent and no pending yet")
+	}
+
+	close(released)
+
+	// Wait for goroutine to deliver.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if m.HasPending() {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	pending := m.Pending()
+	if len(pending) != 1 {
+		t.Fatalf("Pending() returned %d reports, want 1", len(pending))
+	}
+	if pending[0].Text != "async-done" {
+		t.Errorf("text = %q, want async-done", pending[0].Text)
+	}
+	if pending[0].WorkID != workID {
+		t.Errorf("workID mismatch: got %q want %q", pending[0].WorkID, workID)
+	}
+	if m.HasPending() {
+		t.Error("Pending() did not drain")
+	}
+}
+
+func TestSpawnConcurrentCap(t *testing.T) {
+	hold := make(chan struct{})
+	spawn := func(ctx context.Context, workID string, profile Profile, prompt string, maxTurns int) Report {
+		<-hold
+		return Report{Text: "ok"}
+	}
+
+	m := New(Config{MaxConcurrent: 2}, newTestProfiles(), spawn, newTestLogger())
+
+	if _, err := m.Spawn(context.Background(), "fast", "a"); err != nil {
+		t.Fatalf("first spawn: %v", err)
+	}
+	if _, err := m.Spawn(context.Background(), "fast", "b"); err != nil {
+		t.Fatalf("second spawn: %v", err)
+	}
+	if _, err := m.Spawn(context.Background(), "fast", "c"); err == nil {
+		t.Fatal("third spawn: expected cap error, got nil")
+	}
+
+	// Sync run should still be allowed even at the async cap, because
+	// it doesn't count toward MaxConcurrent.
+	syncDone := make(chan struct{})
+	go func() {
+		_, _ = m.Run(context.Background(), "fast", "sync-while-capped")
+		close(syncDone)
+	}()
+	// Give it a moment to register.
+	time.Sleep(20 * time.Millisecond)
+
+	close(hold)
+	<-syncDone
+	// drain
+	_ = m.Pending()
+}
+
+func TestCancelStopsSubagent(t *testing.T) {
+	var observed atomic.Bool
+	spawn := func(ctx context.Context, workID string, profile Profile, prompt string, maxTurns int) Report {
+		<-ctx.Done()
+		observed.Store(true)
+		return Report{Canceled: true, Err: ctx.Err()}
+	}
+
+	m := New(Config{}, newTestProfiles(), spawn, newTestLogger())
+	workID, err := m.Spawn(context.Background(), "fast", "long task")
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+
+	// Wait for active registration.
+	for i := 0; i < 100; i++ {
+		if m.ActiveCount() == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if err := m.Cancel(workID); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+
+	// Wait for delivery.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if m.HasPending() {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	pending := m.Pending()
+	if len(pending) != 1 {
+		t.Fatalf("len(pending) = %d, want 1", len(pending))
+	}
+	if !pending[0].Canceled {
+		t.Error("Report.Canceled = false, want true")
+	}
+	if !observed.Load() {
+		t.Error("spawnFn did not observe ctx.Done")
+	}
+	if !errors.Is(pending[0].Err, context.Canceled) {
+		t.Errorf("Err = %v, want context.Canceled", pending[0].Err)
+	}
+}
+
+func TestCancelUnknownWorkID(t *testing.T) {
+	m := New(Config{}, newTestProfiles(), func(context.Context, string, Profile, string, int) Report { return Report{} }, newTestLogger())
+	if err := m.Cancel("sub-deadbeef"); err == nil {
+		t.Error("Cancel(unknown) returned nil; want error")
+	}
+}
+
+func TestCancelAllStopsEveryone(t *testing.T) {
+	var wg sync.WaitGroup
+	spawn := func(ctx context.Context, workID string, profile Profile, prompt string, maxTurns int) Report {
+		wg.Add(1)
+		defer wg.Done()
+		<-ctx.Done()
+		return Report{Canceled: true}
+	}
+
+	m := New(Config{MaxConcurrent: 4}, newTestProfiles(), spawn, newTestLogger())
+	for i := 0; i < 3; i++ {
+		if _, err := m.Spawn(context.Background(), "fast", "x"); err != nil {
+			t.Fatalf("spawn %d: %v", i, err)
+		}
+	}
+
+	// Wait until all are registered.
+	for i := 0; i < 100; i++ {
+		if m.ActiveCount() == 3 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	m.CancelAll()
+	wg.Wait()
+}
+
+func TestUnknownProfileRejected(t *testing.T) {
+	m := New(Config{}, newTestProfiles(), func(context.Context, string, Profile, string, int) Report { return Report{} }, newTestLogger())
+	if _, err := m.Run(context.Background(), "no-such", "x"); err == nil {
+		t.Error("Run(unknown profile) returned nil error")
+	}
+	if _, err := m.Spawn(context.Background(), "no-such", "x"); err == nil {
+		t.Error("Spawn(unknown profile) returned nil error")
+	}
+}
+
+func TestEmptyPromptRejected(t *testing.T) {
+	m := New(Config{}, newTestProfiles(), func(context.Context, string, Profile, string, int) Report { return Report{} }, newTestLogger())
+	if _, err := m.Run(context.Background(), "fast", ""); err == nil {
+		t.Error("Run(empty prompt) returned nil error")
+	}
+	if _, err := m.Spawn(context.Background(), "fast", ""); err == nil {
+		t.Error("Spawn(empty prompt) returned nil error")
+	}
+}
+
+func TestInboxDropsOldestWhenFull(t *testing.T) {
+	release := make(chan int, 10)
+	spawn := func(ctx context.Context, workID string, profile Profile, prompt string, maxTurns int) Report {
+		<-release
+		return Report{Text: prompt}
+	}
+
+	m := New(Config{MaxConcurrent: 10, MaxInbox: 2}, newTestProfiles(), spawn, newTestLogger())
+
+	for i := 0; i < 3; i++ {
+		if _, err := m.Spawn(context.Background(), "fast", string(rune('a'+i))); err != nil {
+			t.Fatalf("spawn %d: %v", i, err)
+		}
+	}
+	// Release them in order; final inbox should hold the last 2.
+	for i := 0; i < 3; i++ {
+		release <- i
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if m.ActiveCount() == 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	pending := m.Pending()
+	if len(pending) != 2 {
+		t.Fatalf("len(pending) = %d, want 2 (inbox cap)", len(pending))
+	}
+	// First report (text "a") should be the dropped one; "b" and "c" survive.
+	for _, r := range pending {
+		if r.Text == "a" {
+			t.Errorf("oldest report 'a' was not dropped; got %+v", r)
+		}
+	}
+}
+
+func TestProfilesReturnsCopy(t *testing.T) {
+	in := newTestProfiles()
+	m := New(Config{}, in, func(context.Context, string, Profile, string, int) Report { return Report{} }, newTestLogger())
+	out := m.Profiles()
+	if len(out) != len(in) {
+		t.Fatalf("Profiles len = %d, want %d", len(out), len(in))
+	}
+	out[0].Name = "tampered"
+	if m.profiles[0].Name == "tampered" {
+		t.Error("Profiles() returned underlying slice; mutation leaked back")
+	}
+}
+
+func TestFindProfile(t *testing.T) {
+	m := New(Config{}, newTestProfiles(), func(context.Context, string, Profile, string, int) Report { return Report{} }, newTestLogger())
+	if _, ok := m.FindProfile("fast"); !ok {
+		t.Error("FindProfile(fast) ok=false; want true")
+	}
+	if _, ok := m.FindProfile("no-such"); ok {
+		t.Error("FindProfile(no-such) ok=true; want false")
+	}
+}
+
+func TestMaxTurnsPerRunDefault(t *testing.T) {
+	m := New(Config{}, newTestProfiles(), func(context.Context, string, Profile, string, int) Report { return Report{} }, newTestLogger())
+	if m.MaxTurnsPerRun() != 50 {
+		t.Errorf("default MaxTurnsPerRun = %d, want 50", m.MaxTurnsPerRun())
+	}
+}

--- a/internal/subagent/manager_test.go
+++ b/internal/subagent/manager_test.go
@@ -257,16 +257,17 @@ func TestCancelUnknownWorkID(t *testing.T) {
 }
 
 func TestCancelAllStopsEveryone(t *testing.T) {
+	const N = 3
 	var wg sync.WaitGroup
+	wg.Add(N) // pre-add: wg.Add inside the goroutine races with wg.Wait
 	spawn := func(ctx context.Context, workID string, profile Profile, prompt string, maxTurns int) Report {
-		wg.Add(1)
 		defer wg.Done()
 		<-ctx.Done()
 		return Report{Canceled: true}
 	}
 
-	m := New(Config{MaxConcurrent: 4}, newTestProfiles(), spawn, newTestLogger())
-	for i := 0; i < 3; i++ {
+	m := New(Config{MaxConcurrent: N}, newTestProfiles(), spawn, newTestLogger())
+	for i := 0; i < N; i++ {
 		if _, err := m.Spawn(context.Background(), "fast", "x"); err != nil {
 			t.Fatalf("spawn %d: %v", i, err)
 		}
@@ -274,7 +275,7 @@ func TestCancelAllStopsEveryone(t *testing.T) {
 
 	// Wait until all are registered.
 	for i := 0; i < 100; i++ {
-		if m.ActiveCount() == 3 {
+		if m.ActiveCount() == N {
 			break
 		}
 		time.Sleep(5 * time.Millisecond)
@@ -305,24 +306,49 @@ func TestEmptyPromptRejected(t *testing.T) {
 }
 
 func TestInboxDropsOldestWhenFull(t *testing.T) {
-	release := make(chan int, 10)
+	// Per-spawn release channels keyed by prompt text so the test can
+	// release goroutines in a deterministic order regardless of which
+	// goroutine started first.
+	gates := map[string]chan struct{}{
+		"a": make(chan struct{}),
+		"b": make(chan struct{}),
+		"c": make(chan struct{}),
+	}
 	spawn := func(ctx context.Context, workID string, profile Profile, prompt string, maxTurns int) Report {
-		<-release
+		<-gates[prompt]
 		return Report{Text: prompt}
 	}
 
 	m := New(Config{MaxConcurrent: 10, MaxInbox: 2}, newTestProfiles(), spawn, newTestLogger())
 
-	for i := 0; i < 3; i++ {
-		if _, err := m.Spawn(context.Background(), "fast", string(rune('a'+i))); err != nil {
-			t.Fatalf("spawn %d: %v", i, err)
+	for _, name := range []string{"a", "b", "c"} {
+		if _, err := m.Spawn(context.Background(), "fast", name); err != nil {
+			t.Fatalf("spawn %s: %v", name, err)
 		}
 	}
-	// Release them in order; final inbox should hold the last 2.
-	for i := 0; i < 3; i++ {
-		release <- i
-	}
 
+	// Release one at a time, waiting for each to land in the inbox
+	// before the next. This guarantees deliver order matches release
+	// order, so 'a' is the eldest when 'c' arrives and the cap fires.
+	waitForPending := func(want int) {
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			m.mu.Lock()
+			n := len(m.pending)
+			m.mu.Unlock()
+			if n >= want {
+				return
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		t.Fatalf("timed out waiting for %d pending reports", want)
+	}
+	close(gates["a"])
+	waitForPending(1)
+	close(gates["b"])
+	waitForPending(2)
+	close(gates["c"])
+	// After 'c' delivers, drop-oldest should have evicted 'a'.
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		if m.ActiveCount() == 0 {
@@ -335,7 +361,6 @@ func TestInboxDropsOldestWhenFull(t *testing.T) {
 	if len(pending) != 2 {
 		t.Fatalf("len(pending) = %d, want 2 (inbox cap)", len(pending))
 	}
-	// First report (text "a") should be the dropped one; "b" and "c" survive.
 	for _, r := range pending {
 		if r.Text == "a" {
 			t.Errorf("oldest report 'a' was not dropped; got %+v", r)
@@ -363,6 +388,79 @@ func TestFindProfile(t *testing.T) {
 	}
 	if _, ok := m.FindProfile("no-such"); ok {
 		t.Error("FindProfile(no-such) ok=true; want false")
+	}
+}
+
+func TestWaitReturnsAlreadyPending(t *testing.T) {
+	release := make(chan struct{})
+	spawn := func(ctx context.Context, workID string, p Profile, prompt string, maxTurns int) Report {
+		<-release
+		return Report{Text: "done"}
+	}
+	m := New(Config{}, newTestProfiles(), spawn, newTestLogger())
+	workID, err := m.Spawn(context.Background(), "fast", "x")
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	close(release)
+	// Drain into inbox.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if m.HasPending() {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	rep, found, err := m.Wait(context.Background(), workID)
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if !found {
+		t.Fatal("Wait found=false")
+	}
+	if rep.Text != "done" {
+		t.Errorf("rep.Text = %q, want done", rep.Text)
+	}
+	if m.HasPending() {
+		t.Error("Wait did not drain pending")
+	}
+}
+
+func TestWaitBlocksUntilDone(t *testing.T) {
+	release := make(chan struct{})
+	spawn := func(ctx context.Context, workID string, p Profile, prompt string, maxTurns int) Report {
+		<-release
+		return Report{Text: "blocking-done"}
+	}
+	m := New(Config{}, newTestProfiles(), spawn, newTestLogger())
+	workID, _ := m.Spawn(context.Background(), "fast", "x")
+
+	resultCh := make(chan Report, 1)
+	go func() {
+		rep, _, _ := m.Wait(context.Background(), workID)
+		resultCh <- rep
+	}()
+	time.Sleep(30 * time.Millisecond)
+	close(release)
+
+	select {
+	case rep := <-resultCh:
+		if rep.Text != "blocking-done" {
+			t.Errorf("rep.Text = %q", rep.Text)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Wait did not return")
+	}
+}
+
+func TestWaitUnknownWorkID(t *testing.T) {
+	m := New(Config{}, newTestProfiles(), func(context.Context, string, Profile, string, int) Report { return Report{} }, newTestLogger())
+	_, found, err := m.Wait(context.Background(), "sub-deadbeef")
+	if found {
+		t.Error("Wait(unknown) found=true")
+	}
+	if err == nil {
+		t.Error("Wait(unknown) err=nil")
 	}
 }
 

--- a/internal/subagent/subagent.go
+++ b/internal/subagent/subagent.go
@@ -1,0 +1,183 @@
+// Package subagent holds the domain types for subagent delegation.
+//
+// A subagent is a child agent loop spawned by the primary agent to
+// perform isolated work. The primary chooses which "profile" the child
+// runs under (LLM endpoint, key, model, sampler overrides) and supplies
+// all relevant context as a free-form prompt; the child has no access
+// to the primary's conversation log. The child runs the same agent
+// hexagon as the primary -- with the same tool surface (modulo a small
+// set of restrictions, see internal/tools) -- and terminates by
+// calling the subagent_report tool, whose payload is returned to the
+// primary.
+//
+// This package owns the domain types: Profile, Report, the SpawnFunc
+// signature that bridges domain to composition, and the Manager that
+// owns the active subagent registry and the report inbox the primary
+// agent drains alongside operator messages.
+//
+// Construction of the actual child agent.Agent + tools.Executor +
+// llm.Chat client happens in cmd/faultline/main.go via a SpawnFunc
+// closure; this package never imports the agent or tools packages.
+package subagent
+
+import (
+	"fmt"
+	"time"
+)
+
+// Profile describes one subagent execution profile. Profiles are
+// named, advertised to the primary agent in its system prompt, and
+// selected by name when the primary calls subagent_run / subagent_spawn.
+//
+// The "default" profile name is reserved: it is synthesized at runtime
+// from the primary agent's own [api] / [agent] config and means "run
+// the subagent against the same backend the primary uses." Operator
+// profiles must use a different name.
+type Profile struct {
+	// Name is the profile identifier. Lowercase ASCII letters,
+	// digits, and hyphens; 1-32 chars; no leading/trailing hyphens
+	// and no consecutive hyphens. Cannot be "default".
+	Name string
+
+	// APIURL is the OpenAI-compatible chat-completions base URL
+	// (ending in /v1, no trailing slash). Required for operator
+	// profiles; the synthesized "default" profile inherits from
+	// the primary.
+	APIURL string
+
+	// APIKey is sent as a Bearer token. May be empty for local
+	// servers that don't authenticate.
+	APIKey string
+
+	// Model is the model identifier for the chat-completions call.
+	// Required.
+	Model string
+
+	// Purpose is operator-supplied free-form text that explains
+	// WHEN the primary agent should pick this profile. Rendered in
+	// the primary's system prompt next to the profile name. Empty
+	// is allowed but discouraged -- without it, the primary has to
+	// guess from the model name.
+	Purpose string
+
+	// Sampler overrides. Zero means "inherit from primary's [agent]".
+	// Matches the existing zero-value-omitted convention used by
+	// AgentConfig. (If a profile genuinely needs Temperature == 0,
+	// use 0.0001 -- functionally equivalent for our backends.)
+	Temperature       float32
+	TopP              float32
+	TopK              int
+	MinP              float32
+	RepetitionPenalty float32
+	MaxRespTokens     int
+}
+
+// Catalog is the projection of a Profile suitable for inclusion in
+// the primary agent's system prompt. The agent only needs to see the
+// name and purpose to make a routing decision; URL/key/model are
+// implementation detail.
+type Catalog struct {
+	Name    string
+	Purpose string
+}
+
+// ToCatalog returns the system-prompt projection of this profile.
+func (p Profile) ToCatalog() Catalog {
+	return Catalog{Name: p.Name, Purpose: p.Purpose}
+}
+
+// DefaultProfileName is the reserved profile name that the primary
+// constructs at runtime from its own [api] / [agent] configuration.
+// Operator-supplied profiles must use a different name.
+const DefaultProfileName = "default"
+
+// MaxNameLen is the upper bound on profile name length. Mirrors the
+// skill name cap so log lines stay readable.
+const MaxNameLen = 32
+
+// MaxPurposeLen caps the operator-supplied purpose string. Too long
+// and it dwarfs the system prompt; this is a soft cap that produces
+// a load error.
+const MaxPurposeLen = 512
+
+// ValidateName enforces the profile-name spelling rules. See
+// Profile.Name for the rules. Implemented procedurally because Go's
+// RE2 engine doesn't support the lookahead a one-line pattern would
+// want for the consecutive-hyphen rule.
+func ValidateName(name string) error {
+	if name == "" {
+		return fmt.Errorf("name is empty")
+	}
+	if name == DefaultProfileName {
+		return fmt.Errorf("name %q is reserved", DefaultProfileName)
+	}
+	if len(name) > MaxNameLen {
+		return fmt.Errorf("name %q exceeds %d characters", name, MaxNameLen)
+	}
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= '0' && c <= '9':
+			// allowed
+		case c == '-':
+			if i == 0 || i == len(name)-1 {
+				return fmt.Errorf("name %q: hyphens not allowed at start or end", name)
+			}
+			if name[i-1] == '-' {
+				return fmt.Errorf("name %q: consecutive hyphens not allowed", name)
+			}
+		default:
+			return fmt.Errorf("name %q: only lowercase letters, digits, and hyphens allowed (got %q at index %d)", name, c, i)
+		}
+	}
+	return nil
+}
+
+// ValidateProfile checks all spec rules for a profile loaded from
+// operator config. Returns the first error found; callers should
+// log it and skip the profile (loud failure on bad config rather
+// than silently advertising broken profiles to the agent).
+func ValidateProfile(p Profile) error {
+	if err := ValidateName(p.Name); err != nil {
+		return fmt.Errorf("profile name: %w", err)
+	}
+	if p.APIURL == "" {
+		return fmt.Errorf("profile %q: api_url is required", p.Name)
+	}
+	if p.Model == "" {
+		return fmt.Errorf("profile %q: model is required", p.Name)
+	}
+	if len(p.Purpose) > MaxPurposeLen {
+		return fmt.Errorf("profile %q: purpose exceeds %d characters", p.Name, MaxPurposeLen)
+	}
+	return nil
+}
+
+// Report is what a subagent returns to the primary when its loop
+// terminates. The Text field is the free-form summary the child
+// produced via the subagent_report tool. Truncated is set when the
+// child hit MaxTurnsPerRun or RunTimeout before reporting; in that
+// case Text is whatever last assistant message the child emitted (or
+// empty if it never produced one). Canceled is set when the run was
+// aborted by the primary via subagent_cancel or by parent shutdown.
+type Report struct {
+	WorkID     string
+	Profile    string
+	Text       string
+	Err        error
+	Canceled   bool
+	Truncated  bool
+	StartedAt  time.Time
+	FinishedAt time.Time
+}
+
+// ActiveStatus is the projection of a running subagent surfaced by
+// the subagent_status tool. Just the bookkeeping the primary cares
+// about; the conversation log is private to the child.
+type ActiveStatus struct {
+	WorkID  string
+	Profile string
+	Prompt  string // truncated for display
+	Started time.Time
+	Async   bool
+}

--- a/internal/tools/executor.go
+++ b/internal/tools/executor.go
@@ -30,6 +30,7 @@ import (
 	"github.com/matjam/faultline/internal/llm"
 	"github.com/matjam/faultline/internal/search/bm25"
 	"github.com/matjam/faultline/internal/search/vector"
+	"github.com/matjam/faultline/internal/subagent"
 	"github.com/matjam/faultline/internal/update"
 	"github.com/matjam/faultline/internal/version"
 )
@@ -115,6 +116,7 @@ var subagentForbidden = map[string]struct{}{
 	"update_apply":    {},
 	"subagent_run":    {},
 	"subagent_spawn":  {},
+	"subagent_wait":   {},
 	"subagent_status": {},
 	"subagent_cancel": {},
 }
@@ -927,6 +929,13 @@ func (te *Executor) ToolDefs() []llm.Tool {
 		tools = append(tools, defs...)
 	}
 
+	// Subagent delegation. Mode-aware: primary gets the four
+	// run/spawn/status/cancel tools; subagent gets just the report
+	// tool. Returns nil when not wired.
+	if defs := te.subagentToolDefs(); len(defs) > 0 {
+		tools = append(tools, defs...)
+	}
+
 	// Mode-based filtering: drop tools subagents are not allowed to
 	// call. Applied at the end so the rest of ToolDefs() doesn't have
 	// to be branchy on mode.
@@ -983,6 +992,13 @@ type Executor struct {
 	currentTokens       int
 	limits              config.LimitsConfig
 	maxSleep            time.Duration // upper bound for the `sleep` tool
+
+	// Subagent wiring (optional). subagentMgr is set on the primary
+	// Executor when [subagent] is enabled; subagentReportFn is set on
+	// each child Executor by main.go's spawnFn closure (it captures
+	// the report and signals the child agent to stop).
+	subagentMgr      *subagent.Manager
+	subagentReportFn func(text string)
 }
 
 // Deps bundles the dependencies an Executor needs. Each Executor
@@ -1017,6 +1033,20 @@ type Deps struct {
 	MaxTokens           int
 	Limits              config.LimitsConfig
 	MaxSleep            time.Duration
+
+	// SubagentManager is set on the primary Executor when subagent
+	// support is enabled. nil for child Executors and for primaries
+	// when the feature is off; the four subagent_run/spawn/status/
+	// cancel tools are not advertised in those cases.
+	SubagentManager *subagent.Manager
+
+	// SubagentReportFn is set on child Executors by the spawnFn
+	// closure in cmd/faultline/main.go. When non-nil, the
+	// subagent_report tool is advertised; calling it invokes this
+	// callback with the report text. The callback is responsible
+	// for stashing the text and signaling the child agent loop
+	// to stop on its next iteration.
+	SubagentReportFn func(text string)
 }
 
 // New creates a new tool executor.
@@ -1065,6 +1095,8 @@ func New(deps Deps) *Executor {
 		limits:              deps.Limits,
 		maxSleep:            deps.MaxSleep,
 		cache:               deps.WebCache,
+		subagentMgr:         deps.SubagentManager,
+		subagentReportFn:    deps.SubagentReportFn,
 		http: &http.Client{
 			Timeout: 30 * time.Second,
 			Transport: &http.Transport{
@@ -1216,6 +1248,19 @@ func (te *Executor) Execute(ctx context.Context, call llm.ToolCall) string {
 		return te.skillWorkRead(args)
 	case "skill_install":
 		return te.skillInstall(ctx, args)
+	// Subagent tools
+	case "subagent_run":
+		return te.subagentRun(ctx, args)
+	case "subagent_spawn":
+		return te.subagentSpawn(ctx, args)
+	case "subagent_wait":
+		return te.subagentWait(ctx, args)
+	case "subagent_status":
+		return te.subagentStatus()
+	case "subagent_cancel":
+		return te.subagentCancel(args)
+	case "subagent_report":
+		return te.subagentReport(args)
 	default:
 		return fmt.Sprintf("Unknown tool: %s", name)
 	}

--- a/internal/tools/executor.go
+++ b/internal/tools/executor.go
@@ -16,7 +16,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"sync"
 	"time"
 
 	"golang.org/x/net/html"
@@ -71,86 +70,53 @@ func lineCount(s string) int {
 	return n
 }
 
-// webCacheEntry holds a cached web page fetch result.
-type webCacheEntry struct {
-	content   string
-	fetchedAt time.Time
-}
+// Mode controls which tools an Executor advertises and accepts. The
+// primary agent runs in ModePrimary; child agents spawned via the
+// subagent_* tools run in ModeSubagent and have a reduced surface
+// (no sleep, no update_*, no nested subagent_*).
+type Mode int
 
-// webCache is a TTL cache for web_fetch results with proactive eviction.
-type webCache struct {
-	mu        sync.Mutex
-	entries   map[string]webCacheEntry
-	ttl       time.Duration
-	stop      chan struct{}
-	closeOnce sync.Once
-}
+const (
+	// ModePrimary is the default: full tool surface.
+	ModePrimary Mode = iota
 
-func newWebCache(ttl time.Duration) *webCache {
-	c := &webCache{
-		entries: make(map[string]webCacheEntry),
-		ttl:     ttl,
-		stop:    make(chan struct{}),
-	}
-	go c.evictLoop()
-	return c
-}
+	// ModeSubagent strips operator-style and process-management tools
+	// that don't make sense for a child loop:
+	//   - sleep (subagents have no operator queue to wake them)
+	//   - update_check / update_apply (process management is the
+	//     primary's job)
+	//   - subagent_run / subagent_spawn / subagent_status /
+	//     subagent_cancel (no nesting)
+	//
+	// Subagents retain everything else, including send_message,
+	// memory_*, sandbox_*, and skill_* — the user explicitly opted to
+	// keep send_message so a deep-research subagent can ping the
+	// operator on completion.
+	ModeSubagent
+)
 
-// Close stops the background eviction goroutine. Idempotent: safe to
-// call more than once. The Tools port doc declares Close as the
-// agent's responsibility, but a defensive sync.Once guards against any
-// future caller (or doubled-up defer in the composition root) closing
-// the channel twice and panicking.
-func (c *webCache) Close() {
-	c.closeOnce.Do(func() {
-		close(c.stop)
-	})
-}
-
-// evictLoop periodically removes expired entries.
-func (c *webCache) evictLoop() {
-	ticker := time.NewTicker(c.ttl / 2)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-c.stop:
-			return
-		case <-ticker.C:
-			c.evict()
-		}
+// String returns "primary" or "subagent" for log fields.
+func (m Mode) String() string {
+	switch m {
+	case ModeSubagent:
+		return "subagent"
+	default:
+		return "primary"
 	}
 }
 
-func (c *webCache) evict() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	now := time.Now()
-	for url, entry := range c.entries {
-		if now.Sub(entry.fetchedAt) > c.ttl {
-			delete(c.entries, url)
-		}
-	}
-}
-
-// Get returns cached content and true if the entry exists and hasn't expired.
-func (c *webCache) Get(url string) (string, bool) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	entry, ok := c.entries[url]
-	if !ok || time.Since(entry.fetchedAt) > c.ttl {
-		if ok {
-			delete(c.entries, url)
-		}
-		return "", false
-	}
-	return entry.content, true
-}
-
-// Set stores content for a URL.
-func (c *webCache) Set(url, content string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.entries[url] = webCacheEntry{content: content, fetchedAt: time.Now()}
+// subagentForbidden is the deny list applied when Mode == ModeSubagent.
+// Used for both ToolDefs filtering (advertise nothing the child can't
+// call) and Execute defensive rejection (reject calls anyway, in case
+// a flaky LLM hallucinates one).
+var subagentForbidden = map[string]struct{}{
+	"sleep":           {},
+	"update_check":    {},
+	"update_apply":    {},
+	"subagent_run":    {},
+	"subagent_spawn":  {},
+	"subagent_status": {},
+	"subagent_cancel": {},
 }
 
 // ToolDefs returns the tool definitions for the OpenAI API.
@@ -961,6 +927,24 @@ func (te *Executor) ToolDefs() []llm.Tool {
 		tools = append(tools, defs...)
 	}
 
+	// Mode-based filtering: drop tools subagents are not allowed to
+	// call. Applied at the end so the rest of ToolDefs() doesn't have
+	// to be branchy on mode.
+	if te.mode == ModeSubagent {
+		filtered := tools[:0]
+		for _, t := range tools {
+			if t.Function == nil {
+				filtered = append(filtered, t)
+				continue
+			}
+			if _, banned := subagentForbidden[t.Function.Name]; banned {
+				continue
+			}
+			filtered = append(filtered, t)
+		}
+		tools = filtered
+	}
+
 	return tools
 }
 
@@ -978,6 +962,7 @@ func indexKey(path string) string {
 
 // Executor handles executing tool calls.
 type Executor struct {
+	mode                Mode
 	memory              *fs.Store
 	index               *bm25.Index
 	telegram            *telegram.Bot
@@ -993,51 +978,93 @@ type Executor struct {
 	embedBatchSize      int             // batch size for bulk embed calls (rebuild_indexes); 0 -> default
 	logger              *slog.Logger
 	http                *http.Client
-	cache               *webCache
+	cache               *WebCache // borrowed from composition root; not closed here
 	maxTokens           int
 	currentTokens       int
 	limits              config.LimitsConfig
 	maxSleep            time.Duration // upper bound for the `sleep` tool
 }
 
-// New creates a new tool executor. kb, embedder, vIndex, and skills may
-// be nil. embedder and vIndex must be both nil (feature off) or both
+// Deps bundles the dependencies an Executor needs. Each Executor
+// instance owns very little state of its own (currentTokens, the http
+// client); everything else is borrowed from the composition root.
+//
+// Multiple Executor instances coexist when subagent support is
+// enabled: the primary agent's Executor (Mode = ModePrimary) and one
+// Executor per active subagent (Mode = ModeSubagent). All instances
+// share the WebCache, Memory, Index, VectorIndex, Sandbox, Telegram,
+// Updater, Embedder, and Skills pointers; per-instance fields like
+// CurrentTokens are not shared.
+//
+// Embedder and VectorIndex must be both nil (feature off) or both
 // non-nil (feature on); main.go is responsible for that pairing.
+type Deps struct {
+	Mode                Mode
+	Memory              *fs.Store
+	Index               *bm25.Index
+	VectorIndex         *vector.Index
+	Telegram            *telegram.Bot
+	Sandbox             *docker.Sandbox
+	Email               *config.EmailConfig
+	Kobold              *kobold.Client
+	Updater             *update.Updater
+	Embedder            Embedder
+	Skills              *skillsfs.Store
+	SkillInstallEnabled bool
+	EmbedBatchSize      int
+	Logger              *slog.Logger
+	WebCache            *WebCache
+	MaxTokens           int
+	Limits              config.LimitsConfig
+	MaxSleep            time.Duration
+}
+
+// New creates a new tool executor.
 //
-// embedBatchSize is the batch size used by the rebuild_indexes tool;
-// values <= 0 fall back to a sensible default inside the build helper.
-//
-// skillInstallEnabled gates the skill_install tool. When skills is nil
-// it has no effect; when both skills and skillInstallEnabled are set
-// the tool is advertised and the agent can fetch skills from tarball
-// URLs or git repositories.
-func New(memory *fs.Store, index *bm25.Index, tg *telegram.Bot, sb *docker.Sandbox, email *config.EmailConfig, kb *kobold.Client, updater *update.Updater, embedder Embedder, vIndex *vector.Index, skills *skillsfs.Store, skillInstallEnabled bool, embedBatchSize int, logger *slog.Logger, maxTokens int, limits config.LimitsConfig, maxSleep time.Duration) *Executor {
-	if sb != nil {
-		sb.SetOutputLimit(limits.SandboxOutputChars)
+// The Sandbox output cap is applied as a side effect when Sandbox is
+// non-nil; subagent Executors share the parent's Sandbox and therefore
+// inherit the same cap (the per-call SetOutputLimit is idempotent so
+// this is safe even if called repeatedly).
+func New(deps Deps) *Executor {
+	if deps.Logger == nil {
+		deps.Logger = slog.Default()
+	}
+	if deps.WebCache == nil {
+		// Defensive: if a caller forgets to construct a shared cache,
+		// give this Executor its own. The caller is responsible for
+		// Close in that case (the Executor's Close does NOT touch the
+		// cache because in the normal multi-Executor case the cache is
+		// shared and a child Close would yank it out from under the
+		// primary).
+		deps.WebCache = NewWebCache(60 * time.Second)
+	}
+	if deps.Sandbox != nil {
+		deps.Sandbox.SetOutputLimit(deps.Limits.SandboxOutputChars)
 	}
 	skillsRoot := ""
-	if skills != nil {
-		skillsRoot = skills.Root()
+	if deps.Skills != nil {
+		skillsRoot = deps.Skills.Root()
 	}
 	return &Executor{
-		memory:              memory,
-		index:               index,
-		telegram:            tg,
-		sandbox:             sb,
-		email:               email,
-		kobold:              kb,
-		updater:             updater,
-		embedder:            embedder,
-		vIndex:              vIndex,
-		skills:              skills,
-		skillInstallEnabled: skillInstallEnabled,
+		mode:                deps.Mode,
+		memory:              deps.Memory,
+		index:               deps.Index,
+		telegram:            deps.Telegram,
+		sandbox:             deps.Sandbox,
+		email:               deps.Email,
+		kobold:              deps.Kobold,
+		updater:             deps.Updater,
+		embedder:            deps.Embedder,
+		vIndex:              deps.VectorIndex,
+		skills:              deps.Skills,
+		skillInstallEnabled: deps.SkillInstallEnabled,
 		skillsRoot:          skillsRoot,
-		embedBatchSize:      embedBatchSize,
-		logger:              logger,
-		maxTokens:           maxTokens,
-		limits:              limits,
-		maxSleep:            maxSleep,
-		cache:               newWebCache(60 * time.Second),
+		embedBatchSize:      deps.EmbedBatchSize,
+		logger:              deps.Logger,
+		maxTokens:           deps.MaxTokens,
+		limits:              deps.Limits,
+		maxSleep:            deps.MaxSleep,
+		cache:               deps.WebCache,
 		http: &http.Client{
 			Timeout: 30 * time.Second,
 			Transport: &http.Transport{
@@ -1049,10 +1076,12 @@ func New(memory *fs.Store, index *bm25.Index, tg *telegram.Bot, sb *docker.Sandb
 	}
 }
 
-// Close releases resources held by the tool executor.
-func (te *Executor) Close() {
-	te.cache.Close()
-}
+// Close is a no-op in the current implementation. The shared WebCache
+// is owned by the composition root, not the Executor, because multiple
+// Executor instances (primary + subagents) share one cache and a
+// child's Close must not stop it. Kept on the Tools port surface as a
+// future hook for per-Executor cleanup.
+func (te *Executor) Close() {}
 
 // reindexDir re-indexes all .md files under a memory directory path.
 // Used after directory-level operations (delete, move, restore) to keep the
@@ -1087,7 +1116,16 @@ func (te *Executor) Execute(ctx context.Context, call llm.ToolCall) string {
 	name := call.Function.Name
 	args := call.Function.Arguments
 
-	te.logger.Info("tool call", "name", name, "args_len", len(args))
+	te.logger.Info("tool call", "name", name, "args_len", len(args), "mode", te.mode.String())
+
+	// Defensive surface check: ToolDefs already strips these for
+	// subagents, but a flaky LLM may hallucinate a tool name. Reject
+	// with a useful error rather than dispatching.
+	if te.mode == ModeSubagent {
+		if _, banned := subagentForbidden[name]; banned {
+			return fmt.Sprintf("Tool %q is not available to subagents.", name)
+		}
+	}
 
 	switch name {
 	case "web_fetch":

--- a/internal/tools/skill_install_test.go
+++ b/internal/tools/skill_install_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 
 	skillsfs "github.com/matjam/faultline/internal/adapters/skills/fs"
-	"github.com/matjam/faultline/internal/config"
 )
 
 // silentTestLogger discards all log output so tests don't pollute the run.
@@ -184,10 +183,11 @@ func TestSkillInstall_Tarball(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	te := New(nil, nil, nil, nil, nil, nil, nil, nil, nil,
-		store, true, // install enabled
-		0, silentTestLogger(),
-		0, config.LimitsConfig{}, 0)
+	te := New(Deps{
+		Skills:              store,
+		SkillInstallEnabled: true,
+		Logger:              silentTestLogger(),
+	})
 
 	args := `{"source":"` + srv.URL + `/my-skill.tar.gz","name":"my-skill"}`
 	got := te.skillInstall(context.Background(), args)
@@ -211,10 +211,11 @@ func TestSkillInstall_RejectsExisting(t *testing.T) {
 		[]byte("---\nname: duplicate\ndescription: x.\n---\n"), 0o644)
 
 	store, _ := skillsfs.New(skillsRoot, silentTestLogger())
-	te := New(nil, nil, nil, nil, nil, nil, nil, nil, nil,
-		store, true,
-		0, silentTestLogger(),
-		0, config.LimitsConfig{}, 0)
+	te := New(Deps{
+		Skills:              store,
+		SkillInstallEnabled: true,
+		Logger:              silentTestLogger(),
+	})
 
 	args := `{"source":"https://example.com/duplicate.tar.gz","name":"duplicate"}`
 	got := te.skillInstall(context.Background(), args)
@@ -227,10 +228,11 @@ func TestSkillInstall_DisabledByDefault(t *testing.T) {
 	skillsRoot := t.TempDir()
 	store, _ := skillsfs.New(skillsRoot, silentTestLogger())
 	// install_enabled = false
-	te := New(nil, nil, nil, nil, nil, nil, nil, nil, nil,
-		store, false,
-		0, silentTestLogger(),
-		0, config.LimitsConfig{}, 0)
+	te := New(Deps{
+		Skills:              store,
+		SkillInstallEnabled: false,
+		Logger:              silentTestLogger(),
+	})
 
 	args := `{"source":"https://example.com/x.tar.gz"}`
 	got := te.skillInstall(context.Background(), args)
@@ -249,10 +251,11 @@ func TestSkillInstall_DisabledByDefault(t *testing.T) {
 func TestSkillInstall_RejectsInvalidName(t *testing.T) {
 	skillsRoot := t.TempDir()
 	store, _ := skillsfs.New(skillsRoot, silentTestLogger())
-	te := New(nil, nil, nil, nil, nil, nil, nil, nil, nil,
-		store, true,
-		0, silentTestLogger(),
-		0, config.LimitsConfig{}, 0)
+	te := New(Deps{
+		Skills:              store,
+		SkillInstallEnabled: true,
+		Logger:              silentTestLogger(),
+	})
 
 	// "Bad_Name" sanitizes to "bad-name" via inferSkillName, which is
 	// fine -- we use an explicit name with capitals to force the

--- a/internal/tools/subagent.go
+++ b/internal/tools/subagent.go
@@ -1,0 +1,393 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/matjam/faultline/internal/llm"
+	"github.com/matjam/faultline/internal/subagent"
+)
+
+// subagentToolDefs returns the tool definitions for subagent
+// delegation. The returned slice depends on the Executor's Mode:
+//
+//   - ModePrimary: subagent_run, subagent_spawn, subagent_status,
+//     subagent_cancel — but only when the Manager is wired and at
+//     least one profile is available.
+//   - ModeSubagent: subagent_report — but only when a report sink
+//     is wired (i.e. the spawnFn that constructed this Executor
+//     supplied one).
+//
+// Returning an empty slice (rather than not advertising) keeps the
+// caller's append loop in ToolDefs symmetric with the skill_* path.
+func (te *Executor) subagentToolDefs() []llm.Tool {
+	switch te.mode {
+	case ModePrimary:
+		if te.subagentMgr == nil {
+			return nil
+		}
+		profiles := te.subagentMgr.Profiles()
+		if len(profiles) == 0 {
+			return nil
+		}
+		return te.primarySubagentTools(profiles)
+	case ModeSubagent:
+		if te.subagentReportFn == nil {
+			return nil
+		}
+		return []llm.Tool{te.subagentReportToolDef()}
+	default:
+		return nil
+	}
+}
+
+// primarySubagentTools builds the five primary-side tool defs. The
+// "profile" parameter on subagent_run and subagent_spawn is constrained
+// to a JSON-schema enum of currently-configured profile names, so the
+// model can't hallucinate one.
+func (te *Executor) primarySubagentTools(profiles []subagent.Profile) []llm.Tool {
+	names := make([]string, len(profiles))
+	for i, p := range profiles {
+		names[i] = p.Name
+	}
+	sort.Strings(names)
+
+	profileEnum := make([]interface{}, len(names))
+	for i, n := range names {
+		profileEnum[i] = n
+	}
+
+	// Render the profile catalog as a description hint so the model
+	// knows when to pick which profile. Format: "  - <name>: <purpose>"
+	var catalog strings.Builder
+	catalog.WriteString("\n\nAvailable profiles:")
+	for _, p := range profiles {
+		purpose := strings.TrimSpace(p.Purpose)
+		if purpose == "" {
+			purpose = "(no purpose configured)"
+		}
+		fmt.Fprintf(&catalog, "\n  - %s: %s", p.Name, purpose)
+	}
+
+	runDesc := "Delegate work to a subagent and BLOCK until it returns its report. Use this when you need the subagent's answer to continue. The subagent runs a fresh agent loop with the chosen profile's LLM endpoint and has the same tools you do (minus sleep, update_*, and nested subagent_*); it cannot see your conversation log, so put EVERYTHING it needs to know in `prompt`. The return value is the subagent's free-form report (whatever it produced via subagent_report)." + catalog.String()
+
+	spawnDesc := "Delegate work to a subagent CONCURRENTLY. Returns immediately with a work_id; the subagent runs in the background and its report arrives in your context the same way operator messages do, prefixed with [Subagent report — work_id=...]. Use this when you can keep working while the subagent thinks. Same context-isolation rules as subagent_run: the subagent cannot see your conversation log, so put everything it needs in `prompt`." + catalog.String()
+
+	return []llm.Tool{
+		{
+			Type: llm.ToolTypeFunction,
+			Function: &llm.FunctionDef{
+				Name:        "subagent_run",
+				Description: runDesc,
+				Parameters: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"profile": map[string]interface{}{
+							"type":        "string",
+							"description": "Profile name. Pick the one whose purpose best matches the work.",
+							"enum":        profileEnum,
+						},
+						"prompt": map[string]interface{}{
+							"type":        "string",
+							"description": "Full self-contained instructions for the subagent. Include all context, constraints, success criteria, and the exact format you want the report in. The subagent has no memory of your conversation.",
+						},
+					},
+					"required": []string{"profile", "prompt"},
+				},
+			},
+		},
+		{
+			Type: llm.ToolTypeFunction,
+			Function: &llm.FunctionDef{
+				Name:        "subagent_spawn",
+				Description: spawnDesc,
+				Parameters: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"profile": map[string]interface{}{
+							"type":        "string",
+							"description": "Profile name. Pick the one whose purpose best matches the work.",
+							"enum":        profileEnum,
+						},
+						"prompt": map[string]interface{}{
+							"type":        "string",
+							"description": "Full self-contained instructions for the subagent. Same rules as subagent_run.",
+						},
+					},
+					"required": []string{"profile", "prompt"},
+				},
+			},
+		},
+		{
+			Type: llm.ToolTypeFunction,
+			Function: &llm.FunctionDef{
+				Name:        "subagent_wait",
+				Description: "Block until a previously-spawned subagent reports, then return its report inline (the same shape subagent_run returns). Use this when you spawned async, did some other work, and now you need the answer to continue. The wait wakes early if an operator message arrives -- in that case the subagent is still running and you can call subagent_wait again, or check subagent_status. The report is drained from your inbox here, so you won't see it again in your normal between-turn drain.",
+				Parameters: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"work_id": map[string]interface{}{
+							"type":        "string",
+							"description": "The work_id returned by subagent_spawn.",
+						},
+					},
+					"required": []string{"work_id"},
+				},
+			},
+		},
+		{
+			Type: llm.ToolTypeFunction,
+			Function: &llm.FunctionDef{
+				Name:        "subagent_status",
+				Description: "List currently running subagents (those started with subagent_spawn that haven't reported yet). Returns work_id, profile, elapsed seconds, and a truncated prompt preview for each. Use this if you're not sure whether to wait for a previously-spawned subagent or move on.",
+				Parameters: map[string]interface{}{
+					"type":       "object",
+					"properties": map[string]interface{}{},
+				},
+			},
+		},
+		{
+			Type: llm.ToolTypeFunction,
+			Function: &llm.FunctionDef{
+				Name:        "subagent_cancel",
+				Description: "Cooperatively cancel a running subagent. The subagent's in-flight LLM call aborts and its loop exits; if it had partial work, that's lost. Use this when you've changed your mind or realized the subagent is on the wrong track. Returns immediately; the cancellation report still lands in your inbox shortly after.",
+				Parameters: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"work_id": map[string]interface{}{
+							"type":        "string",
+							"description": "The work_id returned by subagent_spawn (e.g. sub-9af3b2c1bb8d).",
+						},
+					},
+					"required": []string{"work_id"},
+				},
+			},
+		},
+	}
+}
+
+// subagentReportToolDef is the child-only tool. Calling it terminates
+// the child's agent loop; main.go's spawnFn closure delivers the
+// report text back to the parent's Manager.
+func (te *Executor) subagentReportToolDef() llm.Tool {
+	return llm.Tool{
+		Type: llm.ToolTypeFunction,
+		Function: &llm.FunctionDef{
+			Name:        "subagent_report",
+			Description: "Deliver your final report to the parent agent and exit. The text you provide here is what the parent receives -- everything else from your conversation is discarded. Make it self-contained: state what was asked, what you did, what you found, and any caveats. After this returns, your loop will exit; do not continue with further tool calls.",
+			Parameters: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"summary": map[string]interface{}{
+						"type":        "string",
+						"description": "The complete, self-contained report. Markdown is fine. The parent will see this verbatim.",
+					},
+				},
+				"required": []string{"summary"},
+			},
+		},
+	}
+}
+
+// subagentRun handles the synchronous primary-side dispatch.
+func (te *Executor) subagentRun(ctx context.Context, argsJSON string) string {
+	if te.subagentMgr == nil {
+		return "Error: subagent support is not enabled."
+	}
+	var args struct {
+		Profile string `json:"profile"`
+		Prompt  string `json:"prompt"`
+	}
+	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+		return fmt.Sprintf("Error parsing arguments: %s", err)
+	}
+	if args.Profile == "" {
+		return "Error: profile is required."
+	}
+	if args.Prompt == "" {
+		return "Error: prompt is required."
+	}
+	report, err := te.subagentMgr.Run(ctx, args.Profile, args.Prompt)
+	if err != nil {
+		return fmt.Sprintf("Subagent run failed: %s", err)
+	}
+	return formatReport(report)
+}
+
+// subagentSpawn handles asynchronous primary-side dispatch.
+func (te *Executor) subagentSpawn(ctx context.Context, argsJSON string) string {
+	if te.subagentMgr == nil {
+		return "Error: subagent support is not enabled."
+	}
+	var args struct {
+		Profile string `json:"profile"`
+		Prompt  string `json:"prompt"`
+	}
+	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+		return fmt.Sprintf("Error parsing arguments: %s", err)
+	}
+	if args.Profile == "" {
+		return "Error: profile is required."
+	}
+	if args.Prompt == "" {
+		return "Error: prompt is required."
+	}
+	workID, err := te.subagentMgr.Spawn(ctx, args.Profile, args.Prompt)
+	if err != nil {
+		return fmt.Sprintf("Subagent spawn failed: %s", err)
+	}
+	return fmt.Sprintf("Subagent spawned (profile=%s, work_id=%s). The report will arrive in your inbox.", args.Profile, workID)
+}
+
+// subagentWait blocks until the named subagent reports, drains the
+// report from the inbox, and returns it inline. Wakes early on
+// operator messages (sleep parity) so a long-running subagent can't
+// indefinitely hide an incoming collaborator turn.
+func (te *Executor) subagentWait(ctx context.Context, argsJSON string) string {
+	if te.subagentMgr == nil {
+		return "Error: subagent support is not enabled."
+	}
+	var args struct {
+		WorkID string `json:"work_id"`
+	}
+	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+		return fmt.Sprintf("Error parsing arguments: %s", err)
+	}
+	if args.WorkID == "" {
+		return "Error: work_id is required."
+	}
+
+	// Run Manager.Wait in a goroutine so the handler can poll the
+	// operator queue alongside.
+	waitCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	type result struct {
+		rep   subagent.Report
+		found bool
+		err   error
+	}
+	done := make(chan result, 1)
+	go func() {
+		rep, found, err := te.subagentMgr.Wait(waitCtx, args.WorkID)
+		done <- result{rep, found, err}
+	}()
+
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case r := <-done:
+			if r.err != nil {
+				return fmt.Sprintf("subagent_wait: %s", r.err)
+			}
+			if !r.found {
+				return fmt.Sprintf("subagent_wait: no report found for %s", args.WorkID)
+			}
+			return formatReport(r.rep)
+		case <-ctx.Done():
+			cancel()
+			<-done
+			return "subagent_wait: canceled."
+		case <-ticker.C:
+			if te.telegram != nil && te.telegram.HasPending() {
+				cancel()
+				<-done
+				return fmt.Sprintf("subagent_wait: operator message arrived; subagent %s is still running. Drain the operator message, then call subagent_wait again or subagent_status to check progress.", args.WorkID)
+			}
+		}
+	}
+}
+
+// subagentStatus lists active spawned subagents.
+func (te *Executor) subagentStatus() string {
+	if te.subagentMgr == nil {
+		return "Error: subagent support is not enabled."
+	}
+	active := te.subagentMgr.Status()
+	if len(active) == 0 {
+		return "No active subagents."
+	}
+	sort.Slice(active, func(i, j int) bool {
+		return active[i].Started.Before(active[j].Started)
+	})
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d active subagent(s):\n", len(active))
+	for _, a := range active {
+		elapsed := time.Since(a.Started).Round(time.Second)
+		kind := "spawn"
+		if !a.Async {
+			kind = "run"
+		}
+		fmt.Fprintf(&b, "  - %s [%s, profile=%s, %s elapsed]\n      %s\n",
+			a.WorkID, kind, a.Profile, elapsed, a.Prompt)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// subagentCancel cancels a single running subagent.
+func (te *Executor) subagentCancel(argsJSON string) string {
+	if te.subagentMgr == nil {
+		return "Error: subagent support is not enabled."
+	}
+	var args struct {
+		WorkID string `json:"work_id"`
+	}
+	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+		return fmt.Sprintf("Error parsing arguments: %s", err)
+	}
+	if args.WorkID == "" {
+		return "Error: work_id is required."
+	}
+	if err := te.subagentMgr.Cancel(args.WorkID); err != nil {
+		return fmt.Sprintf("Cancel failed: %s", err)
+	}
+	return fmt.Sprintf("Cancellation requested for %s. The cancellation report will arrive in your inbox shortly.", args.WorkID)
+}
+
+// subagentReport is the child-only handler. It calls the report sink
+// supplied by main.go's spawnFn, then returns a confirmation. The
+// spawnFn is responsible for stopping the child agent loop after
+// the sink fires; this handler does not block.
+func (te *Executor) subagentReport(argsJSON string) string {
+	if te.subagentReportFn == nil {
+		return "Error: subagent_report is only available when running as a subagent."
+	}
+	var args struct {
+		Summary string `json:"summary"`
+	}
+	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+		return fmt.Sprintf("Error parsing arguments: %s", err)
+	}
+	if args.Summary == "" {
+		return "Error: summary is required."
+	}
+	te.subagentReportFn(args.Summary)
+	return "Report delivered. The subagent loop will exit on the next iteration."
+}
+
+// formatReport turns a Report into the string the primary's
+// subagent_run tool returns. Includes status flags so the primary
+// can react appropriately to truncation / cancellation.
+func formatReport(r subagent.Report) string {
+	var b strings.Builder
+	if r.Truncated {
+		b.WriteString("[truncated -- subagent hit turn or time cap before reporting]\n\n")
+	}
+	if r.Canceled {
+		b.WriteString("[canceled -- subagent was canceled before reporting]\n\n")
+	}
+	if r.Err != nil {
+		fmt.Fprintf(&b, "[error: %s]\n\n", r.Err)
+	}
+	if r.Text == "" {
+		b.WriteString("(no report content)")
+	} else {
+		b.WriteString(r.Text)
+	}
+	return b.String()
+}

--- a/internal/tools/subagent_test.go
+++ b/internal/tools/subagent_test.go
@@ -1,0 +1,352 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/matjam/faultline/internal/llm"
+	"github.com/matjam/faultline/internal/subagent"
+)
+
+func newPrimaryExecutorWithMgr(t *testing.T, mgr *subagent.Manager) *Executor {
+	t.Helper()
+	return New(Deps{
+		Mode:            ModePrimary,
+		Logger:          silentTestLogger(),
+		SubagentManager: mgr,
+	})
+}
+
+func newSubagentExecutor(t *testing.T, sink func(string)) *Executor {
+	t.Helper()
+	return New(Deps{
+		Mode:             ModeSubagent,
+		Logger:           silentTestLogger(),
+		SubagentReportFn: sink,
+	})
+}
+
+func newTestManager(t *testing.T, spawn subagent.SpawnFunc) *subagent.Manager {
+	t.Helper()
+	profiles := []subagent.Profile{
+		{Name: "default", APIURL: "x", Model: "m", Purpose: "fallback"},
+		{Name: "fast", APIURL: "x", Model: "m", Purpose: "quick lookups"},
+	}
+	if spawn == nil {
+		spawn = func(context.Context, string, subagent.Profile, string, int) subagent.Report { return subagent.Report{} }
+	}
+	return subagent.New(subagent.Config{}, profiles, spawn, silentTestLogger())
+}
+
+func TestSubagentToolDefsPrimary(t *testing.T) {
+	mgr := newTestManager(t, nil)
+	te := newPrimaryExecutorWithMgr(t, mgr)
+	defs := te.subagentToolDefs()
+	wantNames := map[string]bool{
+		"subagent_run":    false,
+		"subagent_spawn":  false,
+		"subagent_wait":   false,
+		"subagent_status": false,
+		"subagent_cancel": false,
+	}
+	for _, d := range defs {
+		if d.Function == nil {
+			continue
+		}
+		if _, ok := wantNames[d.Function.Name]; ok {
+			wantNames[d.Function.Name] = true
+		} else {
+			t.Errorf("unexpected tool advertised: %s", d.Function.Name)
+		}
+	}
+	for name, seen := range wantNames {
+		if !seen {
+			t.Errorf("primary missing tool def: %s", name)
+		}
+	}
+}
+
+func TestSubagentToolDefsPrimaryEmptyWhenNoManager(t *testing.T) {
+	te := New(Deps{Mode: ModePrimary, Logger: silentTestLogger()})
+	if defs := te.subagentToolDefs(); len(defs) != 0 {
+		t.Errorf("expected no subagent tool defs without manager, got %d", len(defs))
+	}
+}
+
+func TestSubagentToolDefsChild(t *testing.T) {
+	te := newSubagentExecutor(t, func(string) {})
+	defs := te.subagentToolDefs()
+	if len(defs) != 1 {
+		t.Fatalf("subagent should advertise 1 tool, got %d", len(defs))
+	}
+	if defs[0].Function == nil || defs[0].Function.Name != "subagent_report" {
+		t.Errorf("subagent should advertise subagent_report, got %+v", defs[0])
+	}
+}
+
+func TestSubagentToolDefsChildEmptyWhenNoSink(t *testing.T) {
+	te := New(Deps{Mode: ModeSubagent, Logger: silentTestLogger()})
+	if defs := te.subagentToolDefs(); len(defs) != 0 {
+		t.Errorf("subagent without sink should advertise nothing; got %d defs", len(defs))
+	}
+}
+
+func TestSubagentRunDispatch(t *testing.T) {
+	wantText := "the answer"
+	spawn := func(ctx context.Context, workID string, p subagent.Profile, prompt string, maxTurns int) subagent.Report {
+		return subagent.Report{Text: wantText}
+	}
+	mgr := newTestManager(t, spawn)
+	te := newPrimaryExecutorWithMgr(t, mgr)
+
+	got := te.subagentRun(context.Background(), `{"profile":"fast","prompt":"do it"}`)
+	if !strings.Contains(got, wantText) {
+		t.Errorf("subagentRun output missing text: got %q", got)
+	}
+}
+
+func TestSubagentRunRejectsEmptyArgs(t *testing.T) {
+	mgr := newTestManager(t, nil)
+	te := newPrimaryExecutorWithMgr(t, mgr)
+	if got := te.subagentRun(context.Background(), `{"prompt":"x"}`); !strings.Contains(got, "profile") {
+		t.Errorf("missing profile not rejected: %s", got)
+	}
+	if got := te.subagentRun(context.Background(), `{"profile":"fast"}`); !strings.Contains(got, "prompt") {
+		t.Errorf("missing prompt not rejected: %s", got)
+	}
+}
+
+func TestSubagentRunUnknownProfile(t *testing.T) {
+	mgr := newTestManager(t, nil)
+	te := newPrimaryExecutorWithMgr(t, mgr)
+	got := te.subagentRun(context.Background(), `{"profile":"no-such","prompt":"x"}`)
+	if !strings.Contains(strings.ToLower(got), "unknown") {
+		t.Errorf("expected unknown-profile error, got: %s", got)
+	}
+}
+
+func TestSubagentSpawnReturnsWorkID(t *testing.T) {
+	hold := make(chan struct{})
+	spawn := func(ctx context.Context, workID string, p subagent.Profile, prompt string, maxTurns int) subagent.Report {
+		<-hold
+		return subagent.Report{Text: "ok"}
+	}
+	mgr := newTestManager(t, spawn)
+	te := newPrimaryExecutorWithMgr(t, mgr)
+
+	got := te.subagentSpawn(context.Background(), `{"profile":"fast","prompt":"go"}`)
+	if !strings.Contains(got, "sub-") {
+		t.Errorf("spawn output missing work_id: %s", got)
+	}
+	close(hold)
+	// Drain to keep tests clean.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if mgr.HasPending() {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	_ = mgr.Pending()
+}
+
+func TestSubagentWaitReturnsReport(t *testing.T) {
+	release := make(chan struct{})
+	spawn := func(ctx context.Context, workID string, p subagent.Profile, prompt string, maxTurns int) subagent.Report {
+		<-release
+		return subagent.Report{Text: "wait-result"}
+	}
+	mgr := newTestManager(t, spawn)
+	te := newPrimaryExecutorWithMgr(t, mgr)
+
+	workID, err := mgr.Spawn(context.Background(), "fast", "task")
+	if err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+
+	// Kick off the wait in a goroutine; release the spawn shortly after.
+	resultCh := make(chan string, 1)
+	go func() {
+		resultCh <- te.subagentWait(context.Background(),
+			`{"work_id":"`+workID+`"}`)
+	}()
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+
+	select {
+	case got := <-resultCh:
+		if !strings.Contains(got, "wait-result") {
+			t.Errorf("subagent_wait output missing report text: %s", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("subagent_wait did not return")
+	}
+
+	// Inbox must be empty: the wait drained the report.
+	if mgr.HasPending() {
+		t.Error("expected inbox to be empty after subagent_wait drained the report")
+	}
+}
+
+func TestSubagentWaitUnknownWorkID(t *testing.T) {
+	mgr := newTestManager(t, nil)
+	te := newPrimaryExecutorWithMgr(t, mgr)
+	got := te.subagentWait(context.Background(), `{"work_id":"sub-deadbeef"}`)
+	if !strings.Contains(strings.ToLower(got), "no subagent") &&
+		!strings.Contains(strings.ToLower(got), "no report") {
+		t.Errorf("expected unknown-work_id error, got: %s", got)
+	}
+}
+
+func TestSubagentWaitCancelOnCtx(t *testing.T) {
+	hold := make(chan struct{})
+	defer close(hold)
+	spawn := func(ctx context.Context, workID string, p subagent.Profile, prompt string, maxTurns int) subagent.Report {
+		select {
+		case <-hold:
+		case <-ctx.Done():
+		}
+		return subagent.Report{}
+	}
+	mgr := newTestManager(t, spawn)
+	te := newPrimaryExecutorWithMgr(t, mgr)
+
+	workID, _ := mgr.Spawn(context.Background(), "fast", "task")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan string, 1)
+	go func() {
+		resultCh <- te.subagentWait(ctx, `{"work_id":"`+workID+`"}`)
+	}()
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+
+	select {
+	case got := <-resultCh:
+		if !strings.Contains(strings.ToLower(got), "canceled") {
+			t.Errorf("expected cancellation message, got: %s", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("subagent_wait did not return after ctx cancel")
+	}
+}
+
+func TestSubagentStatusEmpty(t *testing.T) {
+	mgr := newTestManager(t, nil)
+	te := newPrimaryExecutorWithMgr(t, mgr)
+	got := te.subagentStatus()
+	if !strings.Contains(strings.ToLower(got), "no active") {
+		t.Errorf("expected 'no active' message, got: %s", got)
+	}
+}
+
+func TestSubagentStatusListsActive(t *testing.T) {
+	hold := make(chan struct{})
+	spawn := func(ctx context.Context, workID string, p subagent.Profile, prompt string, maxTurns int) subagent.Report {
+		<-hold
+		return subagent.Report{}
+	}
+	mgr := newTestManager(t, spawn)
+	te := newPrimaryExecutorWithMgr(t, mgr)
+
+	if _, err := mgr.Spawn(context.Background(), "fast", "first task"); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	got := te.subagentStatus()
+	if !strings.Contains(got, "first task") {
+		t.Errorf("status missing prompt preview: %s", got)
+	}
+	if !strings.Contains(got, "fast") {
+		t.Errorf("status missing profile name: %s", got)
+	}
+	close(hold)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if mgr.ActiveCount() == 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	_ = mgr.Pending()
+}
+
+func TestSubagentCancelUnknownWorkID(t *testing.T) {
+	mgr := newTestManager(t, nil)
+	te := newPrimaryExecutorWithMgr(t, mgr)
+	got := te.subagentCancel(`{"work_id":"sub-deadbeef"}`)
+	if !strings.Contains(strings.ToLower(got), "no active") &&
+		!strings.Contains(strings.ToLower(got), "fail") {
+		t.Errorf("expected cancel failure, got: %s", got)
+	}
+}
+
+func TestSubagentReportInvokesSink(t *testing.T) {
+	var got string
+	te := newSubagentExecutor(t, func(text string) { got = text })
+	out := te.subagentReport(`{"summary":"the result"}`)
+	if got != "the result" {
+		t.Errorf("sink got %q, want 'the result'", got)
+	}
+	if !strings.Contains(strings.ToLower(out), "delivered") {
+		t.Errorf("report tool output missing confirmation: %s", out)
+	}
+}
+
+func TestSubagentReportNotAvailableWithoutSink(t *testing.T) {
+	te := New(Deps{Mode: ModeSubagent, Logger: silentTestLogger()})
+	got := te.subagentReport(`{"summary":"x"}`)
+	if !strings.Contains(strings.ToLower(got), "only available") {
+		t.Errorf("expected 'only available' error, got: %s", got)
+	}
+}
+
+func TestSubagentForbiddenStrippedFromSubagentTools(t *testing.T) {
+	te := New(Deps{
+		Mode:             ModeSubagent,
+		Logger:           silentTestLogger(),
+		SubagentReportFn: func(string) {},
+	})
+	defs := te.ToolDefs()
+	for _, d := range defs {
+		if d.Function == nil {
+			continue
+		}
+		if _, banned := subagentForbidden[d.Function.Name]; banned {
+			t.Errorf("subagent advertised forbidden tool %q", d.Function.Name)
+		}
+	}
+}
+
+func TestSubagentExecuteRejectsForbiddenDefensively(t *testing.T) {
+	te := New(Deps{Mode: ModeSubagent, Logger: silentTestLogger()})
+	got := te.Execute(context.Background(), llm.ToolCall{
+		Function: llm.FunctionCall{Name: "sleep", Arguments: `{"seconds":1}`},
+	})
+	if !strings.Contains(strings.ToLower(got), "not available") {
+		t.Errorf("expected 'not available', got: %s", got)
+	}
+}
+
+func TestFormatReportFlags(t *testing.T) {
+	r := subagent.Report{Truncated: true, Text: "partial"}
+	got := formatReport(r)
+	if !strings.Contains(got, "truncated") {
+		t.Errorf("expected truncated flag, got: %s", got)
+	}
+	if !strings.Contains(got, "partial") {
+		t.Errorf("expected text body, got: %s", got)
+	}
+
+	r = subagent.Report{Canceled: true}
+	if !strings.Contains(formatReport(r), "canceled") {
+		t.Error("expected canceled flag")
+	}
+
+	r = subagent.Report{Err: errors.New("boom"), Text: "x"}
+	if !strings.Contains(formatReport(r), "boom") {
+		t.Error("expected error message")
+	}
+}

--- a/internal/tools/webcache.go
+++ b/internal/tools/webcache.go
@@ -1,0 +1,94 @@
+package tools
+
+import (
+	"sync"
+	"time"
+)
+
+// webCacheEntry holds a cached web page fetch result.
+type webCacheEntry struct {
+	content   string
+	fetchedAt time.Time
+}
+
+// WebCache is a TTL cache for web_fetch / wiki_fetch results with
+// proactive eviction. Lifecycle is owned by the composition root, not
+// the Executor: with multiple Executor instances (primary + subagents)
+// sharing one cache, no single Executor's Close() can be allowed to
+// stop the cache. main.go constructs one WebCache and defers its
+// Close() at process exit; per-Executor Close() leaves it alone.
+type WebCache struct {
+	mu        sync.Mutex
+	entries   map[string]webCacheEntry
+	ttl       time.Duration
+	stop      chan struct{}
+	closeOnce sync.Once
+}
+
+// NewWebCache constructs a cache with the given entry TTL and starts
+// a background eviction goroutine that wakes every ttl/2.
+func NewWebCache(ttl time.Duration) *WebCache {
+	c := &WebCache{
+		entries: make(map[string]webCacheEntry),
+		ttl:     ttl,
+		stop:    make(chan struct{}),
+	}
+	go c.evictLoop()
+	return c
+}
+
+// Close stops the background eviction goroutine. Idempotent: safe to
+// call more than once. The composition root is responsible for
+// invoking this exactly once on process exit.
+func (c *WebCache) Close() {
+	c.closeOnce.Do(func() {
+		close(c.stop)
+	})
+}
+
+// evictLoop periodically removes expired entries.
+func (c *WebCache) evictLoop() {
+	ticker := time.NewTicker(c.ttl / 2)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-c.stop:
+			return
+		case <-ticker.C:
+			c.evict()
+		}
+	}
+}
+
+func (c *WebCache) evict() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := time.Now()
+	for url, entry := range c.entries {
+		if now.Sub(entry.fetchedAt) > c.ttl {
+			delete(c.entries, url)
+		}
+	}
+}
+
+// Get returns cached content and true if the entry exists and hasn't
+// expired.
+func (c *WebCache) Get(url string) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[url]
+	if !ok || time.Since(entry.fetchedAt) > c.ttl {
+		if ok {
+			delete(c.entries, url)
+		}
+		return "", false
+	}
+	return entry.content, true
+}
+
+// Set stores content for a URL.
+func (c *WebCache) Set(url, content string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[url] = webCacheEntry{content: content, fetchedAt: time.Now()}
+}


### PR DESCRIPTION
## Summary

Adds subagent delegation: the primary agent can delegate isolated work
to a child agent loop running under a configured profile (LLM endpoint,
model, sampler overrides), with both synchronous and asynchronous
modes plus an explicit wait tool.

## Tools added

- `subagent_run(profile, prompt)` — synchronous; blocks the primary's
  tool dispatch and returns the child's report inline.
- `subagent_spawn(profile, prompt)` — async; returns a `work_id`. The
  report lands in the parent's inbox alongside operator messages.
- `subagent_wait(work_id)` — blocks until the named subagent reports,
  drains it from the inbox, and returns it inline. Wakes early on
  operator messages so a long-running child can't hide a collaborator
  turn (sleep parity).
- `subagent_status()` — list active spawns with elapsed and prompt
  preview.
- `subagent_cancel(work_id)` — cooperative cancel via the child's
  context.
- `subagent_report(summary)` — child-only; terminal. Delivers the
  report to the parent and signals the child loop to exit.

## Profiles

```toml
[subagent]
enabled = true
max_concurrent = 4
max_turns_per_run = 50
max_inbox = 32
run_timeout = "30m"

[[subagent.profiles]]
name = "fast"
api_url = "http://localhost:5001/v1"
model = "qwen2.5-coder-7b"
purpose = "Quick lookups; cheap and fast."

[[subagent.profiles]]
name = "deep"
api_url = "https://api.openai.com/v1"
api_key = "sk-..."
model = "gpt-4o"
purpose = "Architecture analysis; slow but careful."
```

A synthesized `default` profile (matching `[api]`) is always available
when the feature is enabled. Operator profiles must use a different
name. Profile sampler fields use the existing zero-value-omitted
convention; non-zero overrides the primary's `[agent]` setting.

## Architecture

- New `internal/subagent` package owns the domain types (`Profile`,
  `Report`, `Catalog`, `ActiveStatus`) and the `Manager`. The Manager
  mirrors the `telegram.Bot` Pending/HasPending pattern so the
  primary's `injectPendingMessages` drains both queues with the same
  code path.
- `internal/agent` gains a `Subagents` port (Pending, HasPending,
  CancelAll, Profiles), a `RequestStop()` seam, a `MaxTurns` cap, and
  a `SystemPromptOverride` field. Reports format with their own
  `[Subagent report — work_id=..., profile=...]` header in
  conversation; truncation/cancellation/error flags are surfaced
  inline. `gracefulSave` calls `CancelAll` on entry so children
  don't compete with the primary's 10-turn / 2-min save budget.
- `internal/tools/Executor` is now multi-instance-safe: a `Mode` flag
  (`ModePrimary` / `ModeSubagent`) drives `ToolDefs` filtering and
  defensive Execute rejection; the shared `WebCache` is owned by the
  composition root rather than per-Executor; the constructor takes a
  `Deps` struct.
- The composition root in `cmd/faultline/subagent.go` builds the
  Manager with a `SpawnFunc` closure that constructs a per-profile
  `*openai.Client`, a per-subagent `ChatLogger` (`chat-<work_id>-`
  prefix), a child Executor wired with a report sink, and a child
  `agent.Agent` with reduced Deps (Operator: nil, Subagents: nil,
  no nesting).

## Constraints applied to subagents

- No `sleep`, `update_check`, `update_apply`, or nested `subagent_*`
  tools (mode filter at ToolDefs + defensive rejection in Execute).
- `send_message` is kept (deliberate; lets a deep-research subagent
  ping the operator).
- No state persistence — children's conversation logs are ephemeral.
- No operator (Telegram) port — children can't steal the parent's
  message queue.

## Tests

- `internal/subagent`: profile validation, sync/async paths, cap
  enforcement, drop-oldest when inbox full, Cancel + CancelAll, Wait
  semantics (already-pending, blocks-then-resolves, unknown work_id).
- `internal/tools`: tool def filtering by mode, dispatch correctness
  for all five primary tools and the report tool, defensive rejection
  of forbidden tools, Manager.Wait drain semantics from the tool
  layer, formatReport flag rendering.
- `internal/prompts`: subagent catalog rendering and section
  ordering (skills → subagents → memories).

Full test suite + `go vet` + `golangci-lint` clean.

## Next

Mark Ready for review once CI is green.