### PR TITLE
fix(update): back off polling on GitHub rate-limit responses

### DIFF
--- a/internal/update/github.go
+++ b/internal/update/github.go
@@ -6,9 +6,51 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 )
+
+// RateLimitError indicates the GitHub API rejected the request
+// because the rate limit is exhausted. ResetAt is when the limit
+// resets, derived from the X-RateLimit-Reset header; a zero ResetAt
+// means the header was missing or unparseable and the caller should
+// fall back to a default backoff.
+//
+// GitHub's anonymous core API limit is 60 requests per hour per
+// source IP. Authenticated requests get higher limits but the
+// updater intentionally runs anonymously (no token required).
+type RateLimitError struct {
+	ResetAt time.Time
+	Body    string
+}
+
+// Error implements error.
+func (e *RateLimitError) Error() string {
+	if e.ResetAt.IsZero() {
+		return "github rate limit exceeded; reset time unknown"
+	}
+	return fmt.Sprintf("github rate limit exceeded; resets at %s (in %s)",
+		e.ResetAt.Format(time.RFC3339),
+		time.Until(e.ResetAt).Round(time.Second))
+}
+
+// parseRateLimit returns a *RateLimitError when the response headers
+// indicate rate-limit exhaustion. The 403/429 status alone is not
+// sufficient -- 403 is also used for permission errors -- so we key
+// on X-RateLimit-Remaining: 0 specifically.
+func parseRateLimit(resp *http.Response, body string) *RateLimitError {
+	if resp.Header.Get("X-RateLimit-Remaining") != "0" {
+		return nil
+	}
+	e := &RateLimitError{Body: body}
+	if reset := resp.Header.Get("X-RateLimit-Reset"); reset != "" {
+		if ts, err := strconv.ParseInt(reset, 10, 64); err == nil {
+			e.ResetAt = time.Unix(ts, 0)
+		}
+	}
+	return e
+}
 
 // githubClient is a tiny client for the subset of GitHub releases API
 // the updater needs. No external SDK because we only consume two
@@ -104,8 +146,19 @@ func (c *githubClient) getRelease(ctx context.Context, path string) (*Release, e
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		bodyStr := strings.TrimSpace(string(body))
+		// Rate-limit detection on 403 (anonymous limit exhaustion)
+		// and 429 (secondary rate limit / abuse detection). The
+		// caller's polling loop uses the typed error to back off
+		// until the documented reset time rather than retrying on
+		// the configured CheckInterval.
+		if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests {
+			if rle := parseRateLimit(resp, bodyStr); rle != nil {
+				return nil, rle
+			}
+		}
 		return nil, fmt.Errorf("github releases: HTTP %d: %s",
-			resp.StatusCode, strings.TrimSpace(string(body)))
+			resp.StatusCode, bodyStr)
 	}
 
 	var rel Release

--- a/internal/update/github_test.go
+++ b/internal/update/github_test.go
@@ -2,9 +2,12 @@ package update
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
+	"time"
 )
 
 func TestLatest_FiltersDraft(t *testing.T) {
@@ -75,6 +78,67 @@ func TestRelease_FindAsset(t *testing.T) {
 	}
 	if a := r.FindAsset("missing"); a != nil {
 		t.Errorf("expected nil for missing asset, got %+v", a)
+	}
+}
+
+func TestLatest_RateLimited(t *testing.T) {
+	resetAt := time.Now().Add(45 * time.Minute).Unix()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-RateLimit-Limit", "60")
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(resetAt, 10))
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"API rate limit exceeded"}`))
+	}))
+	defer srv.Close()
+
+	c := newGitHubClient("o/r")
+	c.apiBase = srv.URL
+	_, err := c.Latest(context.Background(), false)
+	if err == nil {
+		t.Fatal("expected rate limit error")
+	}
+	var rle *RateLimitError
+	if !errors.As(err, &rle) {
+		t.Fatalf("expected *RateLimitError, got %T: %v", err, err)
+	}
+	if rle.ResetAt.Unix() != resetAt {
+		t.Errorf("ResetAt = %d, want %d", rle.ResetAt.Unix(), resetAt)
+	}
+}
+
+func TestLatest_403WithoutRateLimitHeadersIsGenericError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// 403 with no X-RateLimit-* headers (e.g. permission error,
+		// not a rate-limit) must NOT be classified as a rate-limit
+		// error -- otherwise we'd back off for hours on a benign
+		// permission glitch.
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"Forbidden"}`))
+	}))
+	defer srv.Close()
+
+	c := newGitHubClient("o/r")
+	c.apiBase = srv.URL
+	_, err := c.Latest(context.Background(), false)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var rle *RateLimitError
+	if errors.As(err, &rle) {
+		t.Errorf("403 without rate-limit headers should not classify as RateLimitError: %v", err)
+	}
+}
+
+func TestParseRateLimit_MissingResetHeader(t *testing.T) {
+	resp := &http.Response{Header: http.Header{}}
+	resp.Header.Set("X-RateLimit-Remaining", "0")
+	rle := parseRateLimit(resp, "body")
+	if rle == nil {
+		t.Fatal("expected non-nil RateLimitError when remaining=0")
+	}
+	if !rle.ResetAt.IsZero() {
+		t.Errorf("ResetAt should be zero when header is missing, got %v", rle.ResetAt)
 	}
 }
 

--- a/internal/update/ratelimit_test.go
+++ b/internal/update/ratelimit_test.go
@@ -1,0 +1,113 @@
+package update
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestRateLimitDelay_NotRateLimitErr(t *testing.T) {
+	if d, ok := rateLimitDelay(errors.New("ordinary network error")); ok {
+		t.Errorf("non-rate-limit error returned ok=true (%v)", d)
+	}
+	if d, ok := rateLimitDelay(nil); ok {
+		t.Errorf("nil error returned ok=true (%v)", d)
+	}
+}
+
+func TestRateLimitDelay_UsesResetAt(t *testing.T) {
+	resetAt := time.Now().Add(45 * time.Minute)
+	err := &RateLimitError{ResetAt: resetAt}
+	d, ok := rateLimitDelay(err)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	// Should be ~45m + jitter (0-30s); allow generous slack for the
+	// time we spent in the call itself.
+	min := 44 * time.Minute
+	max := 46*time.Minute + time.Second
+	if d < min || d > max {
+		t.Errorf("delay = %v; want roughly 45m", d)
+	}
+}
+
+func TestRateLimitDelay_PastResetUsesFloor(t *testing.T) {
+	// ResetAt in the past (clock skew, late wakeup) should not produce
+	// a negative or zero delay.
+	err := &RateLimitError{ResetAt: time.Now().Add(-1 * time.Hour)}
+	d, ok := rateLimitDelay(err)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if d < rateLimitMinBackoff {
+		t.Errorf("delay = %v; want at least %v", d, rateLimitMinBackoff)
+	}
+}
+
+func TestRateLimitDelay_FutureResetCappedAtMax(t *testing.T) {
+	// ResetAt absurdly far in the future (server clock skew, bug)
+	// should be capped so the updater doesn't lock up.
+	err := &RateLimitError{ResetAt: time.Now().Add(48 * time.Hour)}
+	d, ok := rateLimitDelay(err)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if d > rateLimitMaxBackoff {
+		t.Errorf("delay = %v; want at most %v", d, rateLimitMaxBackoff)
+	}
+}
+
+func TestRateLimitDelay_MissingResetUsesDefault(t *testing.T) {
+	err := &RateLimitError{}
+	d, ok := rateLimitDelay(err)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	// Default + jitter: between rateLimitDefaultBackoff and
+	// rateLimitDefaultBackoff + 30s.
+	if d < rateLimitDefaultBackoff || d > rateLimitDefaultBackoff+30*time.Second {
+		t.Errorf("delay = %v; want default ~%v", d, rateLimitDefaultBackoff)
+	}
+}
+
+func TestRateLimitDelay_UnwrapsWrappedError(t *testing.T) {
+	inner := &RateLimitError{ResetAt: time.Now().Add(10 * time.Minute)}
+	wrapped := fmt.Errorf("github releases: %w", inner)
+	d, ok := rateLimitDelay(wrapped)
+	if !ok {
+		t.Fatal("expected ok=true through error wrap")
+	}
+	if d < 9*time.Minute {
+		t.Errorf("delay = %v; want roughly 10m", d)
+	}
+}
+
+func TestRateLimitError_MessageWithReset(t *testing.T) {
+	resetAt := time.Now().Add(30 * time.Minute)
+	err := &RateLimitError{ResetAt: resetAt}
+	msg := err.Error()
+	if msg == "" {
+		t.Error("empty error message")
+	}
+	if !contains(msg, "rate limit exceeded") {
+		t.Errorf("message missing 'rate limit exceeded': %q", msg)
+	}
+}
+
+func TestRateLimitError_MessageWithoutReset(t *testing.T) {
+	err := &RateLimitError{}
+	msg := err.Error()
+	if !contains(msg, "reset time unknown") {
+		t.Errorf("message should note unknown reset; got %q", msg)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/update/updater.go
+++ b/internal/update/updater.go
@@ -13,12 +13,59 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math/rand/v2"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/matjam/faultline/internal/version"
 )
+
+// rateLimitDefaultBackoff is the delay used when GitHub returns a
+// rate-limit error without a parseable X-RateLimit-Reset header. An
+// hour matches the anonymous-limit reset cadence and is a safe
+// fallback regardless of which clock the server is on.
+const rateLimitDefaultBackoff = 1 * time.Hour
+
+// rateLimitMaxBackoff caps the backoff so an absurdly-far-future or
+// clock-skewed reset time can't lock the updater out indefinitely.
+const rateLimitMaxBackoff = 6 * time.Hour
+
+// rateLimitMinBackoff is the floor applied when ResetAt is in the
+// past (clock skew, rounding) -- we'd rather wait a moment than
+// hammer the API again instantly.
+const rateLimitMinBackoff = 30 * time.Second
+
+// rateLimitDelay extracts a backoff duration from a *RateLimitError
+// in the error chain. Returns ok=false when err is not a rate-limit
+// error. When ResetAt is unknown, returns the default backoff. The
+// returned duration includes a small jitter so multiple agents
+// sharing an IP don't synchronize their retries against the same
+// reset boundary.
+func rateLimitDelay(err error) (time.Duration, bool) {
+	var rle *RateLimitError
+	if !errors.As(err, &rle) {
+		return 0, false
+	}
+	if rle.ResetAt.IsZero() {
+		return rateLimitDefaultBackoff + rateLimitJitter(), true
+	}
+	d := time.Until(rle.ResetAt) + rateLimitJitter()
+	if d < rateLimitMinBackoff {
+		d = rateLimitMinBackoff
+	}
+	if d > rateLimitMaxBackoff {
+		d = rateLimitMaxBackoff
+	}
+	return d, true
+}
+
+// rateLimitJitter returns a small randomized backoff component to
+// de-synchronize multiple agents whose check intervals would otherwise
+// all expire at the same X-RateLimit-Reset boundary. 0-30s.
+func rateLimitJitter() time.Duration {
+	return time.Duration(rand.IntN(30)) * time.Second
+}
 
 // Memory is the subset of the agent's memory store the updater uses.
 // *fs.Store satisfies it. Defined here so the updater package doesn't
@@ -152,9 +199,21 @@ func (u *Updater) Run(ctx context.Context) {
 			}
 			// Errors here are already logged inside checkAndMaybeApply
 			// via u.logger; the polling loop just retries on the next
-			// tick.
-			_, _ = u.checkAndMaybeApply(ctx, false)
-			timer.Reset(u.cfg.CheckInterval)
+			// tick -- except for rate-limit errors, where we extend
+			// the next interval to (or past) the documented reset
+			// time so we don't burn the remaining quota on retries
+			// that will all fail.
+			next := u.cfg.CheckInterval
+			if _, err := u.checkAndMaybeApply(ctx, false); err != nil {
+				if d, ok := rateLimitDelay(err); ok && d > next {
+					u.logger.Warn("github rate-limited; deferring next update check",
+						"delay", d.Round(time.Second),
+						"resume_at", time.Now().Add(d).Format(time.RFC3339),
+					)
+					next = d
+				}
+			}
+			timer.Reset(next)
 		}
 	}
 }
@@ -196,7 +255,16 @@ func (u *Updater) check(ctx context.Context) State {
 	}
 	if err != nil {
 		s.Err = err
-		s.Note = fmt.Sprintf("check failed: %s", err)
+		// Surface rate-limit details specifically so the operator
+		// (or the agent invoking update_check) sees a clear "wait
+		// until X" message rather than a raw HTTP 403.
+		var rle *RateLimitError
+		if errors.As(err, &rle) && !rle.ResetAt.IsZero() {
+			s.Note = fmt.Sprintf("rate-limited by GitHub; next check after %s",
+				rle.ResetAt.Format(time.RFC3339))
+		} else {
+			s.Note = fmt.Sprintf("check failed: %s", err)
+		}
 		u.logger.Warn("update check failed", "error", err)
 		u.state.Store(&s)
 		return s


### PR DESCRIPTION
## Summary

The updater currently retries on the configured `check_interval` even
after GitHub returns 403 with `X-RateLimit-Remaining: 0`. With a tight
poll interval (e.g. `1m` for proof-of-life testing) and the anonymous
60-req/hour-per-IP limit, this immediately exhausts the next quota
window on requests that all fail, and floods the log with the same
warning.

This PR detects rate-limit responses from headers (not status alone)
and parks the polling loop until the documented `X-RateLimit-Reset`
time plus jitter.

## Changes

- `internal/update/github.go`: `parseRateLimit` keys on
  `X-RateLimit-Remaining: 0` (status 403 or 429). Returns a typed
  `*RateLimitError` carrying `ResetAt` parsed from
  `X-RateLimit-Reset`. 403 without rate-limit headers (e.g. a
  permission error) stays a generic error so it doesn't trigger a
  multi-hour backoff.

- `internal/update/updater.go`: the polling loop's tick handler
  inspects the error chain for `*RateLimitError`. When found, the
  next timer firing is deferred until the reset time plus 0-30s
  of jitter. Bounded by `rateLimitMinBackoff` (30s, when ResetAt
  is in the past from clock skew) and `rateLimitMaxBackoff` (6h,
  in case of far-future reset). Missing/unparseable
  `X-RateLimit-Reset` falls back to a 1-hour default.

- `State.Note` surfaces a `"rate-limited; next check after <RFC3339>"`
  message specifically for rate-limit errors, so the agent invoking
  `update_check` sees a clear timeline rather than a raw HTTP 403.

## Tests

- 403 with rate-limit headers parses to `*RateLimitError`.
- 403 without rate-limit headers stays a generic error (regression
  guard against treating every 403 as a rate-limit).
- `rateLimitDelay` handles ResetAt past / future / missing /
  wrapped-in-`fmt.Errorf`, with min/max bounds enforced.

## Operational impact

Operators running with tight `check_interval` settings (the example
config has `1m` for proof-of-life testing) will see polling park
quietly for ~1 hour on rate-limit hits instead of generating one
WARN per minute.