### PR TITLE
feat(admin): per-skill enable/disable persisted to skills.toml

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,6 +308,7 @@ Shared LLM-shaped value types. The OpenAI chat-completions wire shape is treated
 
 `fs.Store` is the filesystem-backed Skills adapter; satisfies the agent's `Skills` port plus extra methods used by the tools layer (`Get`, `Read`, `Resources`).
 
+- Operator-controlled enable/disable via `skills.toml` (path from `cfg.Admin.SkillsFile`). The admin UI's Skills card writes the file on every toggle; the file lists disabled skill names under a `disabled = []` array. `LoadDisabledFromFile` populates the in-memory disabled set; `List` and `Get` filter disabled skills out so the agent never sees them. `ListAll` (admin-only) returns the unfiltered catalog with a per-row `Disabled` flag.
 - Discovery walks `<root>/<name>/SKILL.md` at depth 2; non-skill subdirectories (no SKILL.md) and dotfile dirs (`.git`, etc.) are ignored.
 - Frontmatter parser uses `gopkg.in/yaml.v3` with a one-shot lenient retry that quotes unquoted-colon values (the spec's most common authoring mistake). Strict parse fails with no retry success surface as warnings; the skill is dropped.
 - Lenient validation: name mismatch with directory → use directory name (with diagnostic); over-length name/description/compatibility → diagnostic, still loaded; missing description → hard skip.

--- a/cmd/faultline/admin.go
+++ b/cmd/faultline/admin.go
@@ -107,6 +107,16 @@ func (a *adminServer) AttachInspectors(ag adminhttp.AgentInspector, sub adminhtt
 	a.srv.SetInspectors(ag, sub)
 }
 
+// AttachSkills wires the read+write Skills toggle port. Nil-safe on
+// the receiver; pass a nil sk to leave the Skills section of the
+// dashboard rendering its disabled-feature placeholder.
+func (a *adminServer) AttachSkills(sk adminhttp.SkillsAdmin) {
+	if a == nil {
+		return
+	}
+	a.srv.SetSkillsAdmin(sk)
+}
+
 // ToolObserver returns the tool-call observer the composition root
 // must inject into the primary tools.Executor when admin is enabled.
 // Returns nil when admin is disabled, in which case Executor.observer

--- a/cmd/faultline/main.go
+++ b/cmd/faultline/main.go
@@ -263,6 +263,21 @@ func main() {
 		}
 		logger.Info("skills enabled", "dir", skillStore.Root())
 
+		// Load the operator-controlled enable/disable state file
+		// (admin UI's Skills page persists toggles here). Missing
+		// file is fine: it means "no skills disabled". Parse
+		// errors are loud but not fatal — the agent runs without
+		// the toggle layer in that case.
+		if cfg.Admin.SkillsFile != "" {
+			if err := skillStore.LoadDisabledFromFile(cfg.Admin.SkillsFile); err != nil {
+				logger.Error("skills: failed to load disabled-state file",
+					"path", cfg.Admin.SkillsFile, "error", err)
+			} else {
+				logger.Info("skills: disabled-state file loaded",
+					"path", cfg.Admin.SkillsFile)
+			}
+		}
+
 		// Wipe the per-call /work scratch root from the previous
 		// session so stale work_ids issued before a restart can't
 		// resolve. The Sandbox is already constructed at this point
@@ -390,6 +405,13 @@ func main() {
 			subInspector = subMgr
 		}
 		adminSrv.AttachInspectors(a, subInspector)
+		// Skills admin: wired separately because the skills
+		// store has no dependency on the agent or subagent
+		// manager. nil-safe inside SetSkillsAdmin if skills
+		// support is off entirely.
+		if skillStore != nil {
+			adminSrv.AttachSkills(skillStore)
+		}
 		adminSrv.Start(ctx)
 	}
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -411,9 +411,12 @@ bind = "127.0.0.1:8742"
 # first run (treat its contents as secret material — do not commit).
 users_file = "./users.toml"
 
-# Path to a small TOML file recording skill enable/disable state. Used
-# in a later stage by the admin UI's skills page; missing file means
-# "all skills enabled".
+# Path to a TOML file recording per-skill enable/disable state. The
+# admin UI's Skills card writes to this file when an operator toggles
+# a skill off. Disabled skills are hidden from the agent's catalog
+# (the agent does not see them in its system prompt and cannot run
+# them via skill_activate). Missing file = no skills disabled. Only
+# meaningful when [skills] is also enabled.
 skills_file = "./skills.toml"
 
 # Idle session TTL. Sessions older than this with no activity are

--- a/internal/adapters/admin/http/fragments_test.go
+++ b/internal/adapters/admin/http/fragments_test.go
@@ -40,6 +40,23 @@ func newFragmentsTestServer(t *testing.T,
 	sub SubagentInspector,
 	buf *ToolBuffer,
 ) *testServer {
+	return newAdminTestServer(t, ag, sub, buf, nil)
+}
+
+// newSkillsAdminWiredServer is the skills-test variant: nil agent &
+// subagent inspectors, real tool buffer, real SkillsAdmin.
+func newSkillsAdminWiredServer(t *testing.T, sk SkillsAdmin) *testServer {
+	return newAdminTestServer(t, nil, nil, NewToolBuffer(8), sk)
+}
+
+// newAdminTestServer is the most general builder; the helpers above
+// fill in nils for the subset they don't need.
+func newAdminTestServer(t *testing.T,
+	ag AgentInspector,
+	sub SubagentInspector,
+	buf *ToolBuffer,
+	sk SkillsAdmin,
+) *testServer {
 	t.Helper()
 	dir := t.TempDir()
 	usersPath := filepath.Join(dir, "users.toml")
@@ -65,6 +82,7 @@ func newFragmentsTestServer(t *testing.T,
 		Agent:     ag,
 		Subagents: sub,
 		Tools:     buf,
+		Skills:    sk,
 	})
 	if err != nil {
 		t.Fatalf("adminhttp.New: %v", err)

--- a/internal/adapters/admin/http/handlers_skills.go
+++ b/internal/adapters/admin/http/handlers_skills.go
@@ -1,0 +1,90 @@
+package adminhttp
+
+import (
+	"net/http"
+	"strings"
+
+	skillsfs "github.com/matjam/faultline/internal/adapters/skills/fs"
+)
+
+// fragSkillsData backs frag_skills.html — the per-skill toggle list.
+type fragSkillsData struct {
+	HasSkills bool
+	Skills    []skillsfs.AllSkill
+	CSRFToken string
+
+	// FlashOK / FlashErr surface the result of a recent toggle when
+	// the request came from the toggle endpoint and the response
+	// re-renders the fragment with hx-swap. Both empty on an
+	// ordinary list render.
+	FlashOK  string
+	FlashErr string
+}
+
+// handleFragSkills renders the skills toggle list. Polled by the
+// dashboard at low frequency; also re-rendered as the response of
+// POST /admin/skills/toggle so the operator sees the new state
+// without a page reload.
+func (s *Server) handleFragSkills(w http.ResponseWriter, r *http.Request) {
+	data := s.buildSkillsFragmentData(r)
+	s.renderFragment(w, "frag_skills.html", data)
+}
+
+// handleSkillsToggle is the POST endpoint backing the per-skill
+// switch. Form fields: name=<skill>, enabled=on|off. After applying
+// the change, re-renders the fragment so HTMX can hx-swap the
+// updated row in.
+//
+// Auth + CSRF are enforced by requireAuth in the route registration.
+func (s *Server) handleSkillsToggle(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Skills == nil {
+		http.Error(w, "skills admin not configured", http.StatusServiceUnavailable)
+		return
+	}
+	name := strings.TrimSpace(r.PostFormValue("name"))
+	if name == "" {
+		http.Error(w, "missing skill name", http.StatusBadRequest)
+		return
+	}
+
+	// Form encoding for a checkbox: when checked, the value is
+	// posted as "on" (or whatever value attribute we pick); when
+	// unchecked, the field is OMITTED. We look at presence rather
+	// than value so the standard checkbox encoding works.
+	enabled := r.PostForm.Has("enabled")
+
+	data := s.buildSkillsFragmentData(r)
+	if err := s.deps.Skills.SetEnabled(name, enabled); err != nil {
+		s.deps.Logger.Warn("admin: skills toggle failed",
+			"name", name, "enabled", enabled, "error", err)
+		data.FlashErr = "Could not update " + name + ": " + err.Error()
+	} else {
+		state := "enabled"
+		if !enabled {
+			state = "disabled"
+		}
+		s.deps.Logger.Info("admin: skill toggled",
+			"name", name, "state", state)
+		data.FlashOK = name + " is now " + state + "."
+		// Refresh the data after the mutation so the new state
+		// renders in the response.
+		data.Skills = s.deps.Skills.ListAll()
+	}
+	s.renderFragment(w, "frag_skills.html", data)
+}
+
+// buildSkillsFragmentData populates the fragment data. Lifted out of
+// both handlers so the toggle handler can mutate Flash fields after
+// reading the snapshot.
+func (s *Server) buildSkillsFragmentData(r *http.Request) fragSkillsData {
+	data := fragSkillsData{}
+	if s.deps.Skills == nil {
+		return data
+	}
+	data.HasSkills = true
+	data.Skills = s.deps.Skills.ListAll()
+	if sess := sessionFromContext(r.Context()); sess != nil {
+		data.CSRFToken = sess.CSRFToken
+	}
+	return data
+}

--- a/internal/adapters/admin/http/handlers_skills_test.go
+++ b/internal/adapters/admin/http/handlers_skills_test.go
@@ -1,0 +1,172 @@
+package adminhttp
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+
+	skillsfs "github.com/matjam/faultline/internal/adapters/skills/fs"
+)
+
+// fakeSkillsAdmin lets the fragment + toggle handlers be exercised
+// without the real filesystem-backed store.
+type fakeSkillsAdmin struct {
+	mu     sync.Mutex
+	all    []skillsfs.AllSkill
+	failOn map[string]error
+}
+
+func (f *fakeSkillsAdmin) ListAll() []skillsfs.AllSkill {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]skillsfs.AllSkill, len(f.all))
+	copy(out, f.all)
+	return out
+}
+
+func (f *fakeSkillsAdmin) SetEnabled(name string, enabled bool) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err, ok := f.failOn[name]; ok {
+		return err
+	}
+	for i := range f.all {
+		if f.all[i].Name == name {
+			f.all[i].Disabled = !enabled
+			return nil
+		}
+	}
+	return errors.New("not found")
+}
+
+func makeFakeSkill(name, desc string, disabled bool) skillsfs.AllSkill {
+	var s skillsfs.AllSkill
+	s.Name = name
+	s.Description = desc
+	s.Disabled = disabled
+	return s
+}
+
+func TestFragSkills_RendersList(t *testing.T) {
+	sk := &fakeSkillsAdmin{
+		all: []skillsfs.AllSkill{
+			makeFakeSkill("alpha", "first skill", false),
+			makeFakeSkill("beta", "second skill", true),
+		},
+	}
+	ts := newSkillsAdminWiredServer(t, sk)
+	client := loggedInClient(t, ts)
+
+	resp, err := client.Get(ts.srv.URL + "/admin/fragments/skills")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	got := string(body)
+
+	for _, want := range []string{"alpha", "first skill", "beta", "second skill"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("skills fragment missing %q\n%s", want, got)
+		}
+	}
+	if !strings.Contains(got, `name="enabled"`) {
+		t.Fatalf("missing toggle input:\n%s", got)
+	}
+}
+
+func TestFragSkills_NoSkillsAdmin(t *testing.T) {
+	ts := newFragmentsTestServer(t, nil, nil, NewToolBuffer(8))
+	client := loggedInClient(t, ts)
+
+	resp, err := client.Get(ts.srv.URL + "/admin/fragments/skills")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "Skills support is not enabled") {
+		t.Fatalf("expected disabled placeholder:\n%s", body)
+	}
+}
+
+func TestSkillsToggle_DisablesSkill(t *testing.T) {
+	sk := &fakeSkillsAdmin{
+		all: []skillsfs.AllSkill{
+			makeFakeSkill("alpha", "first", false),
+			makeFakeSkill("beta", "second", false),
+		},
+	}
+	ts := newSkillsAdminWiredServer(t, sk)
+	client := loggedInClient(t, ts)
+
+	// Pull dashboard to grab the session CSRF token.
+	resp, _ := client.Get(ts.srv.URL + "/admin")
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	csrf := extractFormCSRF(string(body))
+	if csrf == "" {
+		t.Fatalf("dashboard missing csrf:\n%s", body)
+	}
+
+	// POST toggle for alpha with the "enabled" field absent
+	// (simulating the unchecked checkbox).
+	resp, err := client.PostForm(ts.srv.URL+"/admin/skills/toggle", url.Values{
+		"_csrf": {csrf},
+		"name":  {"alpha"},
+	})
+	if err != nil {
+		t.Fatalf("POST toggle: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	// Re-listing should report alpha disabled, beta still enabled.
+	all := sk.ListAll()
+	gotAlpha, gotBeta := false, false
+	for _, s := range all {
+		if s.Name == "alpha" && s.Disabled {
+			gotAlpha = true
+		}
+		if s.Name == "beta" && !s.Disabled {
+			gotBeta = true
+		}
+	}
+	if !gotAlpha {
+		t.Fatal("alpha was not disabled by the toggle POST")
+	}
+	if !gotBeta {
+		t.Fatal("beta should not have been touched")
+	}
+
+	// Response body re-renders the fragment with a flash.
+	body, _ = io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "alpha is now disabled") {
+		t.Errorf("expected flash message, got:\n%s", body)
+	}
+}
+
+func TestSkillsToggle_RequiresCSRF(t *testing.T) {
+	sk := &fakeSkillsAdmin{all: []skillsfs.AllSkill{makeFakeSkill("alpha", "x", false)}}
+	ts := newSkillsAdminWiredServer(t, sk)
+	client := loggedInClient(t, ts)
+
+	resp, err := client.PostForm(ts.srv.URL+"/admin/skills/toggle", url.Values{
+		"name":    {"alpha"},
+		"enabled": {"on"},
+		// no _csrf
+	})
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 (CSRF rejected)", resp.StatusCode)
+	}
+}

--- a/internal/adapters/admin/http/inspector.go
+++ b/internal/adapters/admin/http/inspector.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"time"
 
+	skillsfs "github.com/matjam/faultline/internal/adapters/skills/fs"
 	"github.com/matjam/faultline/internal/agent"
 	"github.com/matjam/faultline/internal/subagent"
 	"github.com/matjam/faultline/internal/tools"
@@ -30,6 +31,16 @@ type AgentInspector interface {
 type SubagentInspector interface {
 	Status() []subagent.ActiveStatus
 	Profiles() []subagent.Profile
+}
+
+// SkillsAdmin is the read+write port the admin server uses to list
+// every skill in the catalog (including operator-disabled ones) and
+// toggle their state. Implemented by skills/fs.Store. nil-allowed:
+// when not wired, the Skills card on the dashboard renders a
+// disabled-feature placeholder.
+type SkillsAdmin interface {
+	ListAll() []skillsfs.AllSkill
+	SetEnabled(name string, enabled bool) error
 }
 
 // ToolBuffer is the in-memory ring buffer of recent tool-call events.

--- a/internal/adapters/admin/http/server.go
+++ b/internal/adapters/admin/http/server.go
@@ -64,6 +64,10 @@ type Deps struct {
 	// instance is wired into the primary's tools.Executor as the
 	// Observer, so the admin UI sees every dispatch. nil-allowed.
 	Tools *ToolBuffer
+
+	// Skills is the read+write port for the Skills page.
+	// nil-allowed (skills feature off, or stage 5 not yet wired).
+	Skills SkillsAdmin
 }
 
 // Server is the HTTP admin UI server. Construct with New, run with
@@ -100,6 +104,7 @@ var fragmentTemplates = []string{
 	"frag_status.html",
 	"frag_tools.html",
 	"frag_subagents.html",
+	"frag_skills.html",
 }
 
 // New parses templates and prepares the static-file sub-FS. Returns
@@ -219,6 +224,14 @@ func (s *Server) SetInspectors(agent AgentInspector, subs SubagentInspector) {
 	s.deps.Subagents = subs
 }
 
+// SetSkillsAdmin wires the Skills toggle port. Separate from
+// SetInspectors because the skills store is constructed before the
+// agent (no ordering dependency on the tool buffer), but kept on
+// its own setter for clarity.
+func (s *Server) SetSkillsAdmin(sk SkillsAdmin) {
+	s.deps.Skills = sk
+}
+
 func (s *Server) shutdown() {
 	s.stopOnce.Do(func() {
 		if s.srv == nil {
@@ -252,6 +265,11 @@ func (s *Server) routes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /admin/fragments/status", s.requireAuth(s.handleFragStatus))
 	mux.HandleFunc("GET /admin/fragments/tools", s.requireAuth(s.handleFragTools))
 	mux.HandleFunc("GET /admin/fragments/subagents", s.requireAuth(s.handleFragSubagents))
+	mux.HandleFunc("GET /admin/fragments/skills", s.requireAuth(s.handleFragSkills))
+
+	// Skills toggle action. Re-renders the skills fragment so
+	// HTMX can hx-swap the updated card without a full page load.
+	mux.HandleFunc("POST /admin/skills/toggle", s.requireAuth(s.handleSkillsToggle))
 
 	// Anything not under /admin gets 404. We intentionally don't
 	// take over /; the agent doesn't expose anything else on this

--- a/internal/adapters/admin/http/templates/dashboard.html
+++ b/internal/adapters/admin/http/templates/dashboard.html
@@ -43,6 +43,18 @@
     </div>
   </div>
 
+  <div id="skills-card"
+       hx-get="/admin/fragments/skills"
+       hx-trigger="load"
+       hx-swap="innerHTML">
+    <div class="card bg-base-100 shadow-sm">
+      <div class="card-body">
+        <div class="skeleton h-6 w-32 mb-2"></div>
+        <div class="skeleton h-4 w-full"></div>
+      </div>
+    </div>
+  </div>
+
   <div id="tool-feed"
        hx-get="/admin/fragments/tools"
        hx-trigger="load, every 1s"

--- a/internal/adapters/admin/http/templates/frag_skills.html
+++ b/internal/adapters/admin/http/templates/frag_skills.html
@@ -1,0 +1,74 @@
+<div class="card bg-base-100 shadow-sm">
+  <div class="card-body">
+    <div class="flex items-center justify-between">
+      <h2 class="card-title">Skills</h2>
+      {{if .HasSkills}}
+      <span class="text-sm opacity-70">
+        {{len .Skills}} discovered
+      </span>
+      {{else}}
+      <span class="badge badge-ghost">disabled</span>
+      {{end}}
+    </div>
+
+    {{if .FlashOK}}
+    <div class="alert alert-success py-2">
+      <span>{{.FlashOK}}</span>
+    </div>
+    {{end}}
+    {{if .FlashErr}}
+    <div class="alert alert-error py-2">
+      <span>{{.FlashErr}}</span>
+    </div>
+    {{end}}
+
+    {{if .HasSkills}}
+      {{if .Skills}}
+      <div class="overflow-x-auto">
+        <table class="table table-sm">
+          <thead>
+            <tr>
+              <th class="w-32">Enabled</th>
+              <th>Name</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{range .Skills}}
+            <tr class="{{if .Disabled}}opacity-50{{end}}">
+              <td>
+                <form hx-post="/admin/skills/toggle"
+                      hx-target="#skills-card"
+                      hx-swap="innerHTML">
+                  <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
+                  <input type="hidden" name="name" value="{{.Name}}">
+                  <input type="checkbox" name="enabled"
+                         class="toggle toggle-success"
+                         {{if not .Disabled}}checked{{end}}
+                         onchange="this.form.requestSubmit();">
+                </form>
+              </td>
+              <td class="font-mono text-sm">{{.Name}}</td>
+              <td class="text-sm opacity-80">{{.Description}}</td>
+            </tr>
+            {{end}}
+          </tbody>
+        </table>
+      </div>
+      {{else}}
+      <p class="opacity-60 italic text-sm">
+        No skills discovered. Drop a skill folder into your skills
+        root and the agent will pick it up at the next context
+        rebuild.
+      </p>
+      {{end}}
+    {{else}}
+    <p class="opacity-70 text-sm">
+      Skills support is not enabled. Set
+      <code>[skills] enabled = true</code> in your config to turn
+      it on; once a SKILL.md is discovered it will appear here for
+      enable/disable toggling.
+    </p>
+    {{end}}
+  </div>
+</div>

--- a/internal/adapters/skills/fs/fs.go
+++ b/internal/adapters/skills/fs/fs.go
@@ -45,6 +45,13 @@ type Store struct {
 	mu      sync.RWMutex
 	catalog map[string]*skills.Skill
 	order   []string // sorted skill names for deterministic List output
+
+	// Operator-controlled enable/disable state, loaded from a
+	// TOML file by LoadDisabledFromFile. Disabled skills disappear
+	// from List/Get (the agent never sees them) but remain
+	// visible via ListAll for the admin UI's toggle page.
+	stateFile string
+	disabled  map[string]bool
 }
 
 // New constructs a Store rooted at dir. Reload is called once
@@ -212,26 +219,37 @@ func LoadSkillForValidation(raw []byte, dir, mdPath, dirName string) (*skills.Sk
 	return loadSkill(raw, dir, mdPath, dirName)
 }
 
-// List returns all skills in the catalog, ordered by name. The
-// returned slice is a copy of the underlying records; mutating it does
-// not affect the store.
+// List returns all skills in the catalog that are not operator-
+// disabled, ordered by name. The agent uses this for system-prompt
+// catalog injection and the tools layer uses it for skill_activate;
+// disabled skills are invisible to both. The returned slice is a
+// copy of the underlying records; mutating it does not affect the
+// store.
+//
+// To see every skill regardless of state, use ListAll (admin UI).
 func (s *Store) List() []skills.Skill {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	out := make([]skills.Skill, 0, len(s.order))
 	for _, name := range s.order {
+		if s.disabled[name] {
+			continue
+		}
 		out = append(out, *s.catalog[name])
 	}
 	return out
 }
 
 // Get returns the skill with the given name. Returns ErrNotFound if
-// the skill is not in the catalog.
+// the skill is not in the catalog or is operator-disabled. The same
+// error is used for both cases on purpose: the agent shouldn't
+// distinguish "skill doesn't exist" from "skill turned off by the
+// operator" — either way, it can't run the skill.
 func (s *Store) Get(name string) (skills.Skill, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	sk, ok := s.catalog[name]
-	if !ok {
+	if !ok || s.disabled[name] {
 		return skills.Skill{}, fmt.Errorf("%w: %q", ErrNotFound, name)
 	}
 	return *sk, nil

--- a/internal/adapters/skills/fs/state.go
+++ b/internal/adapters/skills/fs/state.go
@@ -1,0 +1,190 @@
+package fs
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/BurntSushi/toml"
+	"github.com/matjam/faultline/internal/skills"
+)
+
+// stateFileShape is the on-disk shape of skills.toml. Kept simple:
+// a single top-level array of disabled skill names. Adding fields
+// later is trivial because BurntSushi/toml ignores unknown keys.
+type stateFileShape struct {
+	Disabled []string `toml:"disabled"`
+}
+
+// LoadDisabledFromFile reads a TOML file naming skills the operator
+// has marked disabled and applies the result to the in-memory state.
+// Disabled skills disappear from List() and Get() — they are
+// invisible to the agent — but ListAll() still surfaces them so the
+// admin UI can re-enable them.
+//
+// A missing file is not an error: it means "no skills disabled".
+// Parse errors are returned so misconfiguration is loud, not silent.
+//
+// path is recorded so subsequent SetEnabled calls can rewrite it.
+func (s *Store) LoadDisabledFromFile(path string) error {
+	s.mu.Lock()
+	s.stateFile = path
+	if s.disabled == nil {
+		s.disabled = make(map[string]bool)
+	}
+	s.mu.Unlock()
+
+	if path == "" {
+		return nil
+	}
+
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		// Empty disabled set; file will be created on first
+		// SetEnabled(name, false).
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read skills state file: %w", err)
+	}
+
+	var shape stateFileShape
+	if err := toml.Unmarshal(data, &shape); err != nil {
+		return fmt.Errorf("parse skills state file: %w", err)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.disabled = make(map[string]bool, len(shape.Disabled))
+	for _, name := range shape.Disabled {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		s.disabled[name] = true
+	}
+	return nil
+}
+
+// IsDisabled reports whether the named skill is operator-disabled.
+// Always false when no state file has been loaded.
+func (s *Store) IsDisabled(name string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.disabled != nil && s.disabled[name]
+}
+
+// SetEnabled toggles the enabled/disabled state of the named skill
+// and persists the result to the state file. Returns ErrNotFound if
+// the skill is not in the catalog (we want to refuse setting a
+// state for a skill that doesn't exist; otherwise stale entries
+// could pile up in the file). Idempotent: setting an already-
+// enabled skill to enabled is a no-op write.
+func (s *Store) SetEnabled(name string, enabled bool) error {
+	s.mu.Lock()
+	if _, ok := s.catalog[name]; !ok {
+		s.mu.Unlock()
+		return fmt.Errorf("%w: %q", ErrNotFound, name)
+	}
+	if s.disabled == nil {
+		s.disabled = make(map[string]bool)
+	}
+	if enabled {
+		delete(s.disabled, name)
+	} else {
+		s.disabled[name] = true
+	}
+	statePath := s.stateFile
+	disabled := make([]string, 0, len(s.disabled))
+	for n := range s.disabled {
+		disabled = append(disabled, n)
+	}
+	s.mu.Unlock()
+
+	sort.Strings(disabled)
+	if statePath == "" {
+		// No file path configured: in-memory toggle only.
+		return nil
+	}
+	return writeSkillsStateFile(statePath, disabled)
+}
+
+// ListAll returns every skill in the catalog, including operator-
+// disabled ones. The returned skills carry the disabled flag in
+// AllSkill.Disabled so the admin UI can render them appropriately.
+//
+// The agent's existing List() filters disabled skills out, so the
+// agent never sees them in its system prompt.
+func (s *Store) ListAll() []AllSkill {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]AllSkill, 0, len(s.order))
+	for _, name := range s.order {
+		out = append(out, AllSkill{
+			Skill:    *s.catalog[name],
+			Disabled: s.disabled[name],
+		})
+	}
+	return out
+}
+
+// AllSkill pairs a Skill with its admin-side disabled flag. Returned
+// from ListAll. The Disabled field is true when the operator has
+// turned the skill off via skills.toml.
+type AllSkill struct {
+	skills.Skill
+	Disabled bool
+}
+
+// writeSkillsStateFile persists the disabled list with a header
+// comment so an operator inspecting the file by hand sees what it's
+// for and where it's read from. Atomic write via temp + rename.
+func writeSkillsStateFile(path string, disabled []string) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".skills-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		// Best-effort cleanup if rename below didn't happen.
+		_ = os.Remove(tmpPath)
+	}()
+
+	var b strings.Builder
+	b.WriteString("# Faultline skills enable/disable state.\n")
+	b.WriteString("#\n")
+	b.WriteString("# Edited via the admin UI's Skills page; safe to inspect by hand\n")
+	b.WriteString("# but the file may be rewritten on any toggle. Skills listed in\n")
+	b.WriteString("# `disabled` are hidden from the agent's catalog (the agent does\n")
+	b.WriteString("# not see them in its system prompt). Skills not listed here are\n")
+	b.WriteString("# enabled — there is no allow-list mode.\n")
+	b.WriteString("#\n")
+	fmt.Fprintf(&b, "# Last written: %s\n", time.Now().UTC().Format(time.RFC3339))
+	b.WriteString("\n")
+	b.WriteString("disabled = [")
+	if len(disabled) > 0 {
+		b.WriteString("\n")
+		for _, name := range disabled {
+			fmt.Fprintf(&b, "  %q,\n", name)
+		}
+	}
+	b.WriteString("]\n")
+
+	if _, err := tmp.WriteString(b.String()); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}

--- a/internal/adapters/skills/fs/state_test.go
+++ b/internal/adapters/skills/fs/state_test.go
@@ -1,0 +1,192 @@
+package fs
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeSkillTree creates a minimal valid skill at <root>/<name>/SKILL.md
+// for tests that need the catalog to contain a few skills.
+func fakeSkillTree(t *testing.T, root string, names ...string) {
+	t.Helper()
+	for _, name := range names {
+		dir := filepath.Join(root, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+		skill := "---\nname: " + name + "\ndescription: test skill " + name + "\n---\n\nbody\n"
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(skill), 0o644); err != nil {
+			t.Fatalf("write SKILL.md: %v", err)
+		}
+	}
+}
+
+func newQuietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func TestLoadDisabledFromFile_MissingFileIsOK(t *testing.T) {
+	root := t.TempDir()
+	fakeSkillTree(t, root, "alpha", "beta")
+
+	store, err := New(root, newQuietLogger())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// Path that doesn't exist; LoadDisabledFromFile must not error.
+	missing := filepath.Join(t.TempDir(), "skills.toml")
+	if err := store.LoadDisabledFromFile(missing); err != nil {
+		t.Fatalf("LoadDisabledFromFile(missing): %v", err)
+	}
+	if got := len(store.List()); got != 2 {
+		t.Fatalf("List len = %d, want 2 (no disables)", got)
+	}
+}
+
+func TestLoadDisabledFromFile_HidesFromList(t *testing.T) {
+	root := t.TempDir()
+	fakeSkillTree(t, root, "alpha", "beta", "gamma")
+
+	store, err := New(root, newQuietLogger())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	stateFile := filepath.Join(t.TempDir(), "skills.toml")
+	contents := "disabled = [\"alpha\", \"gamma\"]\n"
+	if err := os.WriteFile(stateFile, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write state file: %v", err)
+	}
+	if err := store.LoadDisabledFromFile(stateFile); err != nil {
+		t.Fatalf("LoadDisabledFromFile: %v", err)
+	}
+
+	got := store.List()
+	if len(got) != 1 {
+		t.Fatalf("List len = %d, want 1", len(got))
+	}
+	if got[0].Name != "beta" {
+		t.Fatalf("List[0] = %q, want beta", got[0].Name)
+	}
+
+	// Get on a disabled skill must return ErrNotFound (we
+	// deliberately don't distinguish "missing" from "disabled" to
+	// the agent).
+	if _, err := store.Get("alpha"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get(disabled) err = %v, want ErrNotFound", err)
+	}
+
+	// ListAll surfaces every skill with the Disabled flag so the
+	// admin UI can render toggles.
+	all := store.ListAll()
+	if len(all) != 3 {
+		t.Fatalf("ListAll len = %d, want 3", len(all))
+	}
+	for _, s := range all {
+		want := s.Name == "alpha" || s.Name == "gamma"
+		if s.Disabled != want {
+			t.Errorf("%s Disabled = %v, want %v", s.Name, s.Disabled, want)
+		}
+	}
+}
+
+func TestSetEnabled_PersistsAndRoundTrips(t *testing.T) {
+	root := t.TempDir()
+	fakeSkillTree(t, root, "alpha", "beta")
+
+	store, err := New(root, newQuietLogger())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	stateFile := filepath.Join(t.TempDir(), "skills.toml")
+	if err := store.LoadDisabledFromFile(stateFile); err != nil {
+		t.Fatalf("LoadDisabledFromFile: %v", err)
+	}
+
+	// Disable alpha.
+	if err := store.SetEnabled("alpha", false); err != nil {
+		t.Fatalf("SetEnabled(alpha,false): %v", err)
+	}
+	if !store.IsDisabled("alpha") {
+		t.Fatal("alpha should be disabled")
+	}
+	if got := len(store.List()); got != 1 {
+		t.Fatalf("List len = %d, want 1", got)
+	}
+
+	// File on disk must mention alpha.
+	data, err := os.ReadFile(stateFile)
+	if err != nil {
+		t.Fatalf("read state file: %v", err)
+	}
+	if !strings.Contains(string(data), `"alpha"`) {
+		t.Fatalf("state file does not list alpha:\n%s", data)
+	}
+
+	// Re-load from disk into a fresh Store and confirm the
+	// persisted state survived.
+	store2, err := New(root, newQuietLogger())
+	if err != nil {
+		t.Fatalf("New (second): %v", err)
+	}
+	if err := store2.LoadDisabledFromFile(stateFile); err != nil {
+		t.Fatalf("LoadDisabledFromFile (second): %v", err)
+	}
+	if !store2.IsDisabled("alpha") {
+		t.Fatal("disabled state did not survive reload")
+	}
+	if store2.IsDisabled("beta") {
+		t.Fatal("beta should not be disabled")
+	}
+
+	// Re-enable alpha; file must no longer list it.
+	if err := store2.SetEnabled("alpha", true); err != nil {
+		t.Fatalf("SetEnabled(alpha,true): %v", err)
+	}
+	data, err = os.ReadFile(stateFile)
+	if err != nil {
+		t.Fatalf("read after re-enable: %v", err)
+	}
+	if strings.Contains(string(data), `"alpha"`) {
+		t.Fatalf("state file still lists alpha after re-enable:\n%s", data)
+	}
+}
+
+func TestSetEnabled_UnknownSkill(t *testing.T) {
+	root := t.TempDir()
+	fakeSkillTree(t, root, "alpha")
+
+	store, err := New(root, newQuietLogger())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := store.LoadDisabledFromFile(filepath.Join(t.TempDir(), "skills.toml")); err != nil {
+		t.Fatalf("LoadDisabledFromFile: %v", err)
+	}
+	if err := store.SetEnabled("ghost", false); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for unknown skill, got %v", err)
+	}
+}
+
+func TestLoadDisabledFromFile_BadTOML(t *testing.T) {
+	root := t.TempDir()
+	fakeSkillTree(t, root, "alpha")
+
+	store, err := New(root, newQuietLogger())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	stateFile := filepath.Join(t.TempDir(), "skills.toml")
+	if err := os.WriteFile(stateFile, []byte("this is not = valid = toml ====\n"), 0o644); err != nil {
+		t.Fatalf("write bad state file: %v", err)
+	}
+	if err := store.LoadDisabledFromFile(stateFile); err == nil {
+		t.Fatal("expected parse error on bad TOML, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

Stage 5 of the admin UI. Adds a Skills card to the dashboard with a
daisyUI toggle per skill. State persists to \`skills.toml\` (atomic
write, header comment) and survives restarts. Agent-side: disabled
skills disappear from List() and Get(), so the LLM cannot see or
activate them.

**Stacked on top of #31** (\`feat/admin-ui-inspectors\`); this branch
will rebase cleanly onto main once #31 lands.

## What's in this PR

**\`skills/fs.Store\` additions:**

- \`disabled map[string]bool\` + \`stateFile string\` fields.
- \`LoadDisabledFromFile(path)\` reads the operator's
  \`skills.toml\`. Missing file is fine (no disables).
- \`SetEnabled(name, enabled)\` toggles the in-memory set and
  rewrites the file atomically. Unknown skill → \`ErrNotFound\`
  so stale entries can't accumulate.
- \`IsDisabled(name)\` for direct queries.
- \`ListAll() []AllSkill\` returns every skill paired with a
  \`Disabled\` flag — admin UI only.
- \`List()\` and \`Get()\` now filter disabled skills out. The
  agent's system-prompt catalog injection and \`skill_activate\`
  both use these methods; disabled skills are invisible to the
  LLM, period.

**\`skills.toml\` format:**

\`\`\`toml
# Faultline skills enable/disable state.
# Edited via the admin UI's Skills page; safe to inspect by hand
# but the file may be rewritten on any toggle.
# Last written: 2026-05-01T12:34:56Z

disabled = [
  "noisy-skill",
  "deprecated-skill",
]
\`\`\`

**Admin HTTP:**

- \`SkillsAdmin\` port (consumer-defined in adminhttp).
- \`GET /admin/fragments/skills\` renders the toggle list.
- \`POST /admin/skills/toggle\` applies the change and re-renders
  the fragment so HTMX can hx-swap the updated card with a flash
  message.
- CSRF enforced via the existing \`requireAuth\` middleware.

**Composition:**

\`main.go\` calls \`skillStore.LoadDisabledFromFile(cfg.Admin.SkillsFile)\`
after the skills store is constructed. \`adminSrv.AttachSkills(skillStore)\`
wires the port. Parse errors are logged loudly but never fatal — the
agent keeps working without the toggle layer if the state file is
broken.

## Tests

- \`skills/fs/state_test.go\` — missing file is OK, disabled list
  hides from \`List()\`/\`Get()\` and surfaces from \`ListAll()\`,
  \`SetEnabled\` persists + round-trips through a fresh \`Store\`,
  unknown-skill is rejected, bad TOML is rejected.
- \`adminhttp/handlers_skills_test.go\` — fragment renders the
  toggle list, placeholder when \`SkillsAdmin\` not wired, toggle
  POST disables a skill and produces the flash message, CSRF
  rejection on POST without \`_csrf\`.

\`gofmt\`, \`go vet\`, \`golangci-lint\`, full suite with \`-race\`:
all clean.

## Decisions

- **Same \`ErrNotFound\` for missing and disabled** — the agent
  shouldn't distinguish "skill doesn't exist" from "operator
  turned it off". Either way it can't run the skill.
- **No allow-list mode** — \`disabled\` is the single source of
  truth. Skills not listed are enabled. Inverting this would
  produce surprising behaviour every time someone drops a new
  skill into the root.
- **One state file path, one source** — admin's
  \`cfg.Admin.SkillsFile\` rather than introducing a second
  config key. Stage-1 reserved this field for exactly this use.
- **Single-load-once-then-toggle, not reload-on-every-list** —
  the admin UI rewrites the file on each toggle; we don't
  re-read on every \`List()\` call. Simpler, faster, and the
  in-memory set is the only writer of the file anyway.