### PR TITLE
feat(admin): self-update card with apply-now button

### DIFF
--- a/cmd/faultline/admin.go
+++ b/cmd/faultline/admin.go
@@ -117,6 +117,17 @@ func (a *adminServer) AttachSkills(sk adminhttp.SkillsAdmin) {
 	a.srv.SetSkillsAdmin(sk)
 }
 
+// AttachUpdater wires the self-update port. The Updater is always
+// constructed (even when [update] is disabled) so the get_version
+// tool works; this method is therefore called unconditionally when
+// admin is enabled.
+func (a *adminServer) AttachUpdater(u adminhttp.UpdateInspector) {
+	if a == nil {
+		return
+	}
+	a.srv.SetUpdateInspector(u)
+}
+
 // ToolObserver returns the tool-call observer the composition root
 // must inject into the primary tools.Executor when admin is enabled.
 // Returns nil when admin is disabled, in which case Executor.observer

--- a/cmd/faultline/main.go
+++ b/cmd/faultline/main.go
@@ -412,6 +412,12 @@ func main() {
 		if skillStore != nil {
 			adminSrv.AttachSkills(skillStore)
 		}
+		// Self-update inspector: always wired when admin is on.
+		// The updater itself is harmless when [update] is
+		// disabled — Apply refuses, State() returns the cached
+		// (mostly empty) state, and the UI surfaces "auto-update
+		// off".
+		adminSrv.AttachUpdater(updater)
 		adminSrv.Start(ctx)
 	}
 

--- a/internal/adapters/admin/http/contextutil.go
+++ b/internal/adapters/admin/http/contextutil.go
@@ -1,0 +1,13 @@
+package adminhttp
+
+import (
+	"context"
+	"time"
+)
+
+// contextWithTimeout is a tiny indirection that lets tests stub the
+// timeout without touching context.WithTimeout directly. Production
+// implementation is a thin wrapper.
+var contextWithTimeout = func(parent context.Context, d time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(parent, d)
+}

--- a/internal/adapters/admin/http/fragments_test.go
+++ b/internal/adapters/admin/http/fragments_test.go
@@ -40,13 +40,13 @@ func newFragmentsTestServer(t *testing.T,
 	sub SubagentInspector,
 	buf *ToolBuffer,
 ) *testServer {
-	return newAdminTestServer(t, ag, sub, buf, nil)
+	return newAdminTestServer(t, ag, sub, buf, nil, nil)
 }
 
 // newSkillsAdminWiredServer is the skills-test variant: nil agent &
 // subagent inspectors, real tool buffer, real SkillsAdmin.
 func newSkillsAdminWiredServer(t *testing.T, sk SkillsAdmin) *testServer {
-	return newAdminTestServer(t, nil, nil, NewToolBuffer(8), sk)
+	return newAdminTestServer(t, nil, nil, NewToolBuffer(8), sk, nil)
 }
 
 // newAdminTestServer is the most general builder; the helpers above
@@ -56,6 +56,7 @@ func newAdminTestServer(t *testing.T,
 	sub SubagentInspector,
 	buf *ToolBuffer,
 	sk SkillsAdmin,
+	upd UpdateInspector,
 ) *testServer {
 	t.Helper()
 	dir := t.TempDir()
@@ -83,6 +84,7 @@ func newAdminTestServer(t *testing.T,
 		Subagents: sub,
 		Tools:     buf,
 		Skills:    sk,
+		Update:    upd,
 	})
 	if err != nil {
 		t.Fatalf("adminhttp.New: %v", err)

--- a/internal/adapters/admin/http/handlers_update.go
+++ b/internal/adapters/admin/http/handlers_update.go
@@ -1,0 +1,111 @@
+package adminhttp
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/matjam/faultline/internal/update"
+)
+
+// fragUpdateData backs frag_update.html. The fields all derive from
+// the cached update.State plus a couple of presentation-side
+// helpers; we deliberately do not call Check() from the dashboard
+// poll path (that would hit GitHub on every refresh).
+type fragUpdateData struct {
+	HasUpdater bool
+
+	Enabled         bool
+	CurrentVersion  string
+	LatestVersion   string
+	UpdateAvailable bool
+	LastChecked     string // formatted relative
+	Note            string
+	Err             string
+
+	// FlashOK / FlashErr surface the result of an Apply.
+	FlashOK  string
+	FlashErr string
+
+	CSRFToken string
+}
+
+func (s *Server) handleFragUpdate(w http.ResponseWriter, r *http.Request) {
+	data := s.buildUpdateFragmentData(r)
+	s.renderFragment(w, "frag_update.html", data)
+}
+
+func (s *Server) handleUpdateApply(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Update == nil {
+		http.Error(w, "updater not wired", http.StatusServiceUnavailable)
+		return
+	}
+	if !s.deps.Update.Enabled() {
+		// Re-render the fragment with an explanatory flash.
+		data := s.buildUpdateFragmentData(r)
+		data.FlashErr = "Self-update is disabled in [update]; cannot apply."
+		s.renderFragment(w, "frag_update.html", data)
+		return
+	}
+
+	// Apply blocks while it downloads + swaps + records history,
+	// then triggers shutdown. We give it a generous deadline so a
+	// slow tarball download doesn't cut the process off.
+	ctx, cancel := contextWithTimeout(r.Context(), 5*time.Minute)
+	defer cancel()
+
+	res, err := s.deps.Update.Apply(ctx)
+	data := s.buildUpdateFragmentData(r)
+	if err != nil {
+		s.deps.Logger.Warn("admin: update apply failed", "error", err)
+		data.FlashErr = "Update failed: " + err.Error()
+	} else {
+		s.deps.Logger.Info("admin: update applied; agent will shut down",
+			"from", res.FromVersion, "to", res.ToVersion)
+		data.FlashOK = "Updated " + res.FromVersion + " → " + res.ToVersion +
+			". The agent is shutting down for the new binary to take over."
+		// Reflect the current binary as the new one in the UI;
+		// the old State still shows the pre-update value because
+		// no Check has run since.
+		data.CurrentVersion = res.ToVersion
+		data.UpdateAvailable = false
+	}
+	s.renderFragment(w, "frag_update.html", data)
+}
+
+func (s *Server) buildUpdateFragmentData(r *http.Request) fragUpdateData {
+	data := fragUpdateData{}
+	if s.deps.Update == nil {
+		return data
+	}
+	data.HasUpdater = true
+	data.Enabled = s.deps.Update.Enabled()
+	data.CurrentVersion = s.deps.Update.CurrentVersion()
+	if sess := sessionFromContext(r.Context()); sess != nil {
+		data.CSRFToken = sess.CSRFToken
+	}
+
+	st := s.deps.Update.State()
+	data.LatestVersion = st.LatestVersion
+	data.UpdateAvailable = st.UpdateAvailable
+	if !st.LastChecked.IsZero() {
+		data.LastChecked = FormatRelative(st.LastChecked)
+	} else {
+		data.LastChecked = "—"
+	}
+	data.Note = st.Note
+	if st.Err != nil {
+		data.Err = st.Err.Error()
+	}
+	return data
+}
+
+// stateString is a small helper used by tests to make assertions
+// easier; not used at runtime.
+//
+//nolint:unused // referenced in tests via package-internal access
+func stateString(st update.State) string {
+	if st.UpdateAvailable {
+		return st.CurrentVersion + " -> " + st.LatestVersion
+	}
+	return st.CurrentVersion + " (current)"
+}

--- a/internal/adapters/admin/http/handlers_update_test.go
+++ b/internal/adapters/admin/http/handlers_update_test.go
@@ -1,0 +1,306 @@
+package adminhttp
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/matjam/faultline/internal/update"
+)
+
+// fakeUpdater is a deterministic stand-in for *update.Updater that
+// satisfies the UpdateInspector port.
+type fakeUpdater struct {
+	enabled    bool
+	current    string
+	state      update.State
+	applyErr   error
+	applyRes   *update.Result
+	appliedTo  string
+	applyCalls int
+}
+
+func (f *fakeUpdater) Enabled() bool          { return f.enabled }
+func (f *fakeUpdater) CurrentVersion() string { return f.current }
+func (f *fakeUpdater) State() update.State    { return f.state }
+func (f *fakeUpdater) Apply(ctx context.Context) (*update.Result, error) {
+	f.applyCalls++
+	if f.applyErr != nil {
+		return nil, f.applyErr
+	}
+	f.appliedTo = f.applyRes.ToVersion
+	return f.applyRes, nil
+}
+
+func newUpdateAdminServer(t *testing.T, u UpdateInspector) *testServer {
+	return newAdminTestServer(t, nil, nil, NewToolBuffer(8), nil, u)
+}
+
+// newAdminTestServer-with-update needs a version that takes the
+// UpdateInspector. Add it as an overload of the existing helper.
+func init() {
+	// Plug into the existing helper at compile time via a small
+	// indirection isn't possible because the helper is a package-
+	// scoped function with a fixed signature. Tests below use a
+	// dedicated builder defined in this file.
+	_ = newAdminTestServer
+}
+
+// newAdminTestServerWithUpdate is the same as newAdminTestServer in
+// fragments_test.go but extended with an UpdateInspector. Defined
+// here rather than in the shared test helper to avoid editing every
+// call site.
+func newAdminTestServerWithUpdate(t *testing.T, u UpdateInspector) *testServer {
+	return newAdminTestServer(t, nil, nil, NewToolBuffer(8), nil, u)
+}
+
+func TestFragUpdate_NoUpdater(t *testing.T) {
+	ts := newFragmentsTestServer(t, nil, nil, NewToolBuffer(8))
+	client := loggedInClient(t, ts)
+
+	resp, err := client.Get(ts.srv.URL + "/admin/fragments/update")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "updater is not wired") {
+		t.Fatalf("expected not-wired placeholder:\n%s", body)
+	}
+}
+
+func TestFragUpdate_DisabledRendersNotice(t *testing.T) {
+	u := &fakeUpdater{
+		enabled: false,
+		current: "1.5.0",
+		state:   update.State{CurrentVersion: "1.5.0"},
+	}
+	ts := newAdminTestServerWithUpdate(t, u)
+	client := loggedInClient(t, ts)
+
+	resp, err := client.Get(ts.srv.URL + "/admin/fragments/update")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	got := string(body)
+
+	if !strings.Contains(got, "auto-update off") {
+		t.Errorf("expected auto-update-off badge, got:\n%s", got)
+	}
+	if !strings.Contains(got, "1.5.0") {
+		t.Errorf("expected current version 1.5.0, got:\n%s", got)
+	}
+	if strings.Contains(got, "Apply update") {
+		t.Errorf("apply button should not render when disabled:\n%s", got)
+	}
+}
+
+func TestFragUpdate_AvailableShowsApplyButton(t *testing.T) {
+	u := &fakeUpdater{
+		enabled: true,
+		current: "1.5.0",
+		state: update.State{
+			LastChecked:     time.Now().Add(-2 * time.Minute),
+			CurrentVersion:  "1.5.0",
+			LatestVersion:   "1.6.0",
+			UpdateAvailable: true,
+		},
+	}
+	ts := newAdminTestServerWithUpdate(t, u)
+	client := loggedInClient(t, ts)
+
+	resp, err := client.Get(ts.srv.URL + "/admin/fragments/update")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	got := string(body)
+
+	for _, want := range []string{
+		"auto-update on",
+		"1.5.0",
+		"1.6.0",
+		"new!",
+		"Apply update 1.5.0 → 1.6.0",
+		`hx-post="/admin/update/apply"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q\n%s", want, got)
+		}
+	}
+}
+
+func TestFragUpdate_NoUpdateAvailable(t *testing.T) {
+	u := &fakeUpdater{
+		enabled: true,
+		current: "1.5.0",
+		state: update.State{
+			LastChecked:     time.Now().Add(-30 * time.Second),
+			CurrentVersion:  "1.5.0",
+			LatestVersion:   "1.5.0",
+			UpdateAvailable: false,
+		},
+	}
+	ts := newAdminTestServerWithUpdate(t, u)
+	client := loggedInClient(t, ts)
+
+	resp, err := client.Get(ts.srv.URL + "/admin/fragments/update")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	got := string(body)
+
+	if !strings.Contains(got, "current") {
+		t.Errorf("expected 'current' badge:\n%s", got)
+	}
+	if strings.Contains(got, "Apply update") {
+		t.Errorf("apply button should not render when up to date:\n%s", got)
+	}
+}
+
+func TestFragUpdate_LastErrorRenders(t *testing.T) {
+	u := &fakeUpdater{
+		enabled: true,
+		current: "1.5.0",
+		state: update.State{
+			LastChecked: time.Now().Add(-10 * time.Second),
+			Err:         errors.New("github says rate limited"),
+		},
+	}
+	ts := newAdminTestServerWithUpdate(t, u)
+	client := loggedInClient(t, ts)
+
+	resp, err := client.Get(ts.srv.URL + "/admin/fragments/update")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "github says rate limited") {
+		t.Fatalf("error text not surfaced:\n%s", body)
+	}
+}
+
+func TestUpdateApply_DisabledIsRefused(t *testing.T) {
+	u := &fakeUpdater{enabled: false, current: "1.5.0"}
+	ts := newAdminTestServerWithUpdate(t, u)
+	client := loggedInClient(t, ts)
+
+	resp, _ := client.Get(ts.srv.URL + "/admin")
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	csrf := extractFormCSRF(string(body))
+
+	resp, err := client.PostForm(ts.srv.URL+"/admin/update/apply", url.Values{
+		"_csrf": {csrf},
+	})
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ = io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "Self-update is disabled") {
+		t.Fatalf("expected disabled flash:\n%s", body)
+	}
+	if u.applyCalls != 0 {
+		t.Fatalf("Apply was called %d times despite being disabled", u.applyCalls)
+	}
+}
+
+func TestUpdateApply_Success(t *testing.T) {
+	u := &fakeUpdater{
+		enabled: true,
+		current: "1.5.0",
+		state: update.State{
+			LatestVersion:   "1.6.0",
+			UpdateAvailable: true,
+		},
+		applyRes: &update.Result{
+			FromVersion: "1.5.0",
+			ToVersion:   "1.6.0",
+		},
+	}
+	ts := newAdminTestServerWithUpdate(t, u)
+	client := loggedInClient(t, ts)
+
+	resp, _ := client.Get(ts.srv.URL + "/admin")
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	csrf := extractFormCSRF(string(body))
+
+	resp, err := client.PostForm(ts.srv.URL+"/admin/update/apply", url.Values{
+		"_csrf": {csrf},
+	})
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if u.applyCalls != 1 {
+		t.Fatalf("Apply calls = %d, want 1", u.applyCalls)
+	}
+	body, _ = io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "Updated 1.5.0 → 1.6.0") {
+		t.Errorf("expected success flash:\n%s", body)
+	}
+}
+
+func TestUpdateApply_Failure(t *testing.T) {
+	u := &fakeUpdater{
+		enabled:  true,
+		current:  "1.5.0",
+		applyErr: errors.New("sha256 mismatch"),
+	}
+	ts := newAdminTestServerWithUpdate(t, u)
+	client := loggedInClient(t, ts)
+
+	resp, _ := client.Get(ts.srv.URL + "/admin")
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	csrf := extractFormCSRF(string(body))
+
+	resp, err := client.PostForm(ts.srv.URL+"/admin/update/apply", url.Values{
+		"_csrf": {csrf},
+	})
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ = io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "Update failed: sha256 mismatch") {
+		t.Errorf("expected failure flash:\n%s", body)
+	}
+}
+
+func TestUpdateApply_RequiresCSRF(t *testing.T) {
+	u := &fakeUpdater{enabled: true, current: "1.5.0"}
+	ts := newAdminTestServerWithUpdate(t, u)
+	client := loggedInClient(t, ts)
+
+	resp, err := client.PostForm(ts.srv.URL+"/admin/update/apply", url.Values{
+		// no _csrf
+	})
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if u.applyCalls != 0 {
+		t.Fatalf("Apply was called %d times despite missing CSRF", u.applyCalls)
+	}
+}
+
+// silence unused warning on newUpdateAdminServer when tests use the
+// alias instead.
+var _ = newUpdateAdminServer

--- a/internal/adapters/admin/http/inspector.go
+++ b/internal/adapters/admin/http/inspector.go
@@ -1,6 +1,7 @@
 package adminhttp
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/matjam/faultline/internal/agent"
 	"github.com/matjam/faultline/internal/subagent"
 	"github.com/matjam/faultline/internal/tools"
+	"github.com/matjam/faultline/internal/update"
 )
 
 // AgentInspector is the read-only port the admin server uses to
@@ -41,6 +43,22 @@ type SubagentInspector interface {
 type SkillsAdmin interface {
 	ListAll() []skillsfs.AllSkill
 	SetEnabled(name string, enabled bool) error
+}
+
+// UpdateInspector is the read+write port for the self-update pane.
+// Implemented by *update.Updater. Reads (Enabled, CurrentVersion,
+// State) are pure in-memory lookups; State exposes the most recent
+// poll result without hitting GitHub. Apply is the destructive
+// "update now" action and is only invoked from the dedicated
+// endpoint behind a CSRF check.
+//
+// nil-allowed: when no updater is wired, the Update card on the
+// dashboard renders a disabled-feature placeholder.
+type UpdateInspector interface {
+	Enabled() bool
+	CurrentVersion() string
+	State() update.State
+	Apply(ctx context.Context) (*update.Result, error)
 }
 
 // ToolBuffer is the in-memory ring buffer of recent tool-call events.

--- a/internal/adapters/admin/http/server.go
+++ b/internal/adapters/admin/http/server.go
@@ -68,6 +68,11 @@ type Deps struct {
 	// Skills is the read+write port for the Skills page.
 	// nil-allowed (skills feature off, or stage 5 not yet wired).
 	Skills SkillsAdmin
+
+	// Update is the read+write port for the self-update pane.
+	// nil-allowed: when not set, the Update card renders a
+	// "updater not wired" placeholder.
+	Update UpdateInspector
 }
 
 // Server is the HTTP admin UI server. Construct with New, run with
@@ -105,6 +110,7 @@ var fragmentTemplates = []string{
 	"frag_tools.html",
 	"frag_subagents.html",
 	"frag_skills.html",
+	"frag_update.html",
 }
 
 // New parses templates and prepares the static-file sub-FS. Returns
@@ -232,6 +238,15 @@ func (s *Server) SetSkillsAdmin(sk SkillsAdmin) {
 	s.deps.Skills = sk
 }
 
+// SetUpdateInspector wires the self-update read+write port. The
+// updater is always constructed in main.go (it serves the
+// get_version tool even when self-update is disabled), so this is
+// usually called even when cfg.Update.Enabled is false; the pane
+// renders a "auto-update off" view in that case.
+func (s *Server) SetUpdateInspector(u UpdateInspector) {
+	s.deps.Update = u
+}
+
 func (s *Server) shutdown() {
 	s.stopOnce.Do(func() {
 		if s.srv == nil {
@@ -266,10 +281,17 @@ func (s *Server) routes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /admin/fragments/tools", s.requireAuth(s.handleFragTools))
 	mux.HandleFunc("GET /admin/fragments/subagents", s.requireAuth(s.handleFragSubagents))
 	mux.HandleFunc("GET /admin/fragments/skills", s.requireAuth(s.handleFragSkills))
+	mux.HandleFunc("GET /admin/fragments/update", s.requireAuth(s.handleFragUpdate))
 
 	// Skills toggle action. Re-renders the skills fragment so
 	// HTMX can hx-swap the updated card without a full page load.
 	mux.HandleFunc("POST /admin/skills/toggle", s.requireAuth(s.handleSkillsToggle))
+
+	// Update actions. /apply triggers a destructive update and
+	// graceful shutdown; the response body is the new card with
+	// a flash explaining what happened, but the browser will
+	// likely lose the connection mid-shutdown — that's fine.
+	mux.HandleFunc("POST /admin/update/apply", s.requireAuth(s.handleUpdateApply))
 
 	// Anything not under /admin gets 404. We intentionally don't
 	// take over /; the agent doesn't expose anything else on this

--- a/internal/adapters/admin/http/templates/dashboard.html
+++ b/internal/adapters/admin/http/templates/dashboard.html
@@ -55,6 +55,18 @@
     </div>
   </div>
 
+  <div id="update-card"
+       hx-get="/admin/fragments/update"
+       hx-trigger="load, every 30s"
+       hx-swap="innerHTML">
+    <div class="card bg-base-100 shadow-sm">
+      <div class="card-body">
+        <div class="skeleton h-6 w-32 mb-2"></div>
+        <div class="skeleton h-4 w-full"></div>
+      </div>
+    </div>
+  </div>
+
   <div id="tool-feed"
        hx-get="/admin/fragments/tools"
        hx-trigger="load, every 1s"

--- a/internal/adapters/admin/http/templates/frag_update.html
+++ b/internal/adapters/admin/http/templates/frag_update.html
@@ -1,0 +1,95 @@
+<div class="card bg-base-100 shadow-sm">
+  <div class="card-body">
+    <div class="flex items-center justify-between flex-wrap gap-2">
+      <h2 class="card-title">Self-update</h2>
+      {{if .HasUpdater}}
+        {{if .Enabled}}
+        <span class="badge badge-success">auto-update on</span>
+        {{else}}
+        <span class="badge badge-ghost">auto-update off</span>
+        {{end}}
+      {{else}}
+      <span class="badge badge-ghost">not wired</span>
+      {{end}}
+    </div>
+
+    {{if .FlashOK}}
+    <div class="alert alert-success py-2">
+      <span>{{.FlashOK}}</span>
+    </div>
+    {{end}}
+    {{if .FlashErr}}
+    <div class="alert alert-error py-2">
+      <span>{{.FlashErr}}</span>
+    </div>
+    {{end}}
+
+    {{if .HasUpdater}}
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-2">
+      <div>
+        <div class="text-sm opacity-70">Current version</div>
+        <div class="font-mono text-lg">{{.CurrentVersion}}</div>
+      </div>
+      <div>
+        <div class="text-sm opacity-70">Latest known release</div>
+        <div class="font-mono text-lg">
+          {{if .LatestVersion}}
+            {{.LatestVersion}}
+            {{if .UpdateAvailable}}
+            <span class="badge badge-warning ml-2">new!</span>
+            {{else}}
+            <span class="badge badge-success ml-2">current</span>
+            {{end}}
+          {{else}}—{{end}}
+        </div>
+        <div class="text-xs opacity-60 mt-1">
+          last checked {{.LastChecked}}
+          {{if .Note}}· {{.Note}}{{end}}
+        </div>
+      </div>
+    </div>
+
+    {{if .Err}}
+    <div class="alert alert-warning mt-3">
+      <div class="flex flex-col gap-1">
+        <span class="font-semibold">Last check error</span>
+        <code class="text-xs whitespace-pre-wrap break-words">{{.Err}}</code>
+      </div>
+    </div>
+    {{end}}
+
+    {{if and .Enabled .UpdateAvailable}}
+    <div class="mt-4">
+      <form hx-post="/admin/update/apply"
+            hx-target="#update-card"
+            hx-swap="innerHTML"
+            hx-confirm="Apply the update now? The agent will shut down so the new binary can take over.">
+        <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
+        <button type="submit" class="btn btn-primary">
+          Apply update {{.CurrentVersion}} → {{.LatestVersion}}
+        </button>
+      </form>
+      <p class="text-xs opacity-60 mt-2">
+        Apply downloads the release tarball, verifies it against
+        SHA256SUMS, swaps the binary in place, and triggers
+        graceful shutdown. The supervisor (or your configured
+        restart_mode) brings the new binary up.
+      </p>
+    </div>
+    {{else if not .Enabled}}
+    <p class="opacity-70 text-sm mt-3">
+      Self-update is disabled in <code>[update]</code>. Set
+      <code>enabled = true</code> to allow the agent (and this
+      dashboard) to apply updates.
+    </p>
+    {{end}}
+    {{else}}
+    <p class="opacity-70 text-sm">
+      The updater is not wired into the admin server. This usually
+      means an unusual composition path; the standard
+      <code>cmd/faultline/main.go</code> wiring should always
+      attach it.
+    </p>
+    {{end}}
+  </div>
+</div>


### PR DESCRIPTION
## Summary

Stage 7 of the admin UI. Adds a self-update card to the dashboard
showing the current version, the latest known release (cached, **no
live GitHub poll on render**), and an Apply button when an update is
available. Stacked on top of #32 (\`feat/admin-ui-skills\`).

## What's in this PR

**\`UpdateInspector\` port** (consumer-defined in adminhttp):

\`\`\`go
type UpdateInspector interface {
    Enabled() bool
    CurrentVersion() string
    State() update.State          // cached; no GitHub call
    Apply(ctx) (*update.Result, error)
}
\`\`\`

\`*update.Updater\` already satisfies these methods — nothing on the
domain side changed.

**Frontend:**

- \`frag_update.html\` — auto-update on/off badge, current vs latest
  version side-by-side, last-checked relative time, last-error
  surface, "new!" / "current" badges. Apply button gates on
  \`Enabled && UpdateAvailable\`.
- \`hx-confirm\` on the form so the operator gets a confirm dialog
  before the destructive Apply.
- Dashboard polls the fragment every 30 s (much slower than the
  status fragment because GitHub state moves on the order of
  hours, not milliseconds).

**Backend:**

- \`POST /admin/update/apply\` calls \`Updater.Apply(ctx)\`. On
  success: log the from/to versions and re-render the fragment
  with a green flash explaining the agent is shutting down for
  the new binary. On failure: red flash with the error.
- 5-minute timeout on the Apply path so a slow tarball download
  doesn't get cut off; the request goroutine survives until the
  graceful-shutdown plumbing tears down the listener.
- CSRF + auth enforced through the standard \`requireAuth\`
  middleware.

**Composition:**

\`cmd/faultline/admin.go\` gains \`AttachUpdater\`. \`main.go\`
calls it unconditionally when admin is enabled — the updater is
always constructed (it serves \`get_version\` even when
\`[update].enabled = false\`); the card UI surfaces the
auto-update-off state without disabling itself.

## Tests

- Placeholder when no updater wired.
- Auto-update-off rendering when \`Enabled() == false\`.
- Apply button + "new!" badge appears only when
  \`Enabled && UpdateAvailable\`.
- "current" badge when up to date (no Apply button).
- \`State.Err\` text renders when a recent check errored.
- Apply refused (with flash) when \`Enabled() == false\` — the
  fake updater confirms zero \`Apply\` calls.
- Apply success: \`from → to\` flash, correct version surfaced.
- Apply failure: error text in red flash.
- POST without \`_csrf\` returns 403 and never calls Apply.

\`gofmt\`, \`go vet\`, \`golangci-lint\`, full suite with \`-race\`:
all clean.

## Decisions

- **No live GitHub poll on render.** The dashboard reads
  \`Updater.State()\`, which is the cached result of the most
  recent background poll. Per the original requirements:
  > version in github (read from in memory cache, don't hit github)
- **Apply runs synchronously in the request goroutine** with a
  5-minute timeout. A "fire and async-watch" pattern would need
  a separate progress channel and another fragment; not worth it
  for an action that completes in tens of seconds.
- **\`hx-confirm\` instead of a custom modal.** It's a destructive
  action; the browser-native confirm is fine and saves writing a
  daisyUI modal.
- **Card polls every 30 s, not 1 s.** GitHub release state
  doesn't move that fast; tighter polling would be wasteful and
  noisy in the request log.