### PR TITLE
feat(admin): in-place config editor with validate / save / restart

### DIFF
--- a/cmd/faultline/admin.go
+++ b/cmd/faultline/admin.go
@@ -128,6 +128,16 @@ func (a *adminServer) AttachUpdater(u adminhttp.UpdateInspector) {
 	a.srv.SetUpdateInspector(u)
 }
 
+// AttachConfig wires the read+write configuration port. The store
+// itself is built in main.go once the config path and the
+// closeShutdown callback are in scope.
+func (a *adminServer) AttachConfig(c adminhttp.ConfigStore) {
+	if a == nil {
+		return
+	}
+	a.srv.SetConfigStore(c)
+}
+
 // ToolObserver returns the tool-call observer the composition root
 // must inject into the primary tools.Executor when admin is enabled.
 // Returns nil when admin is disabled, in which case Executor.observer

--- a/cmd/faultline/configstore.go
+++ b/cmd/faultline/configstore.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/matjam/faultline/internal/config"
+)
+
+// fileConfigStore satisfies adminhttp.ConfigStore by reading and
+// writing the TOML config file the agent was started with. Validation
+// runs the bytes through config.Load against a temp path so the same
+// defaults backfill / sanity passes apply as on real startup.
+//
+// Restart funnels through the same closeShutdown closure the signal
+// handler and updater use, so a config-driven restart looks identical
+// to a SIGINT to the rest of the system: agent saves state, returns,
+// main.go's restart_mode dispatches.
+type fileConfigStore struct {
+	path     string
+	logger   *slog.Logger
+	shutdown func()
+
+	// mu serializes Write to avoid racing operators clobbering each
+	// other's edits. Read is safe to call without it (os.ReadFile is
+	// atomic enough for our purposes).
+	mu sync.Mutex
+}
+
+func newFileConfigStore(path string, logger *slog.Logger, shutdown func()) (*fileConfigStore, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve config path: %w", err)
+	}
+	return &fileConfigStore{
+		path:     abs,
+		logger:   logger,
+		shutdown: shutdown,
+	}, nil
+}
+
+func (f *fileConfigStore) Path() string { return f.path }
+
+func (f *fileConfigStore) Read() ([]byte, error) {
+	return os.ReadFile(f.path)
+}
+
+// Validate writes the bytes to a temp file and runs config.Load on
+// it. The temp file is removed regardless of outcome. Returns nil iff
+// the bytes parse cleanly and produce a usable Config.
+//
+// Note: config.Load is forgiving on missing fields (defaults are
+// backfilled), so an empty file or a one-line override both validate.
+// The point of this pass is to catch syntax errors and bad enum-ish
+// values before they hit disk.
+func (f *fileConfigStore) Validate(raw []byte) error {
+	dir := filepath.Dir(f.path)
+	tmp, err := os.CreateTemp(dir, ".faultline-config-validate-*.toml")
+	if err != nil {
+		// Fall back to system temp dir if the config dir isn't
+		// writable; we still want validation to work.
+		tmp, err = os.CreateTemp("", ".faultline-config-validate-*.toml")
+		if err != nil {
+			return fmt.Errorf("create temp file: %w", err)
+		}
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	if _, err := tmp.Write(raw); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+
+	if _, err := config.Load(tmpPath); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (f *fileConfigStore) Write(raw []byte) error {
+	if err := f.Validate(raw); err != nil {
+		return err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	dir := filepath.Dir(f.path)
+	tmp, err := os.CreateTemp(dir, ".faultline-config-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	// Best-effort cleanup if we return before rename. The rename
+	// branch sets renamed = true so this defer becomes a no-op
+	// (os.Remove on a path that's been renamed away is a quiet
+	// not-exist).
+	renamed := false
+	defer func() {
+		if !renamed {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err := tmp.Write(raw); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("sync temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+
+	// Preserve the original permissions when possible so the
+	// rewrite doesn't downgrade a 0600 secret-bearing file to
+	// 0644.
+	if info, err := os.Stat(f.path); err == nil {
+		if perr := os.Chmod(tmpPath, info.Mode().Perm()); perr != nil {
+			f.logger.Warn("config save: chmod on temp failed; continuing",
+				"path", tmpPath, "error", perr)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		// Non-not-found stat error is unusual; don't block the
+		// write but log it.
+		f.logger.Warn("config save: stat existing file failed; continuing",
+			"path", f.path, "error", err)
+	}
+
+	if err := os.Rename(tmpPath, f.path); err != nil {
+		return fmt.Errorf("rename temp file: %w", err)
+	}
+	renamed = true
+	return nil
+}
+
+func (f *fileConfigStore) Restart() {
+	if f.shutdown != nil {
+		f.shutdown()
+	}
+}

--- a/cmd/faultline/configstore_test.go
+++ b/cmd/faultline/configstore_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func newSilentLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func TestFileConfigStore_PathIsAbs(t *testing.T) {
+	dir := t.TempDir()
+	rel := filepath.Join(dir, "config.toml")
+
+	// New rejects nothing about missing files; constructing the
+	// store must succeed even if the file isn't there yet.
+	store, err := newFileConfigStore(rel, newSilentLogger(), nil)
+	if err != nil {
+		t.Fatalf("newFileConfigStore: %v", err)
+	}
+	if !filepath.IsAbs(store.Path()) {
+		t.Fatalf("Path() = %q, want absolute", store.Path())
+	}
+}
+
+func TestFileConfigStore_ReadReturnsFileBytes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	want := []byte("[api]\nurl = \"http://localhost:5001/v1\"\nmodel = \"q\"\n")
+	if err := os.WriteFile(path, want, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	store, err := newFileConfigStore(path, newSilentLogger(), nil)
+	if err != nil {
+		t.Fatalf("newFileConfigStore: %v", err)
+	}
+
+	got, err := store.Read()
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("Read returned %q, want %q", got, want)
+	}
+}
+
+func TestFileConfigStore_ValidateAcceptsGood(t *testing.T) {
+	dir := t.TempDir()
+	store, err := newFileConfigStore(filepath.Join(dir, "config.toml"), newSilentLogger(), nil)
+	if err != nil {
+		t.Fatalf("newFileConfigStore: %v", err)
+	}
+	good := []byte("[api]\nurl = \"http://localhost:5001/v1\"\nmodel = \"q\"\n")
+	if err := store.Validate(good); err != nil {
+		t.Fatalf("Validate(good): %v", err)
+	}
+}
+
+func TestFileConfigStore_ValidateRejectsBad(t *testing.T) {
+	dir := t.TempDir()
+	store, err := newFileConfigStore(filepath.Join(dir, "config.toml"), newSilentLogger(), nil)
+	if err != nil {
+		t.Fatalf("newFileConfigStore: %v", err)
+	}
+	bad := []byte("this is not = valid = toml ====\n")
+	if err := store.Validate(bad); err == nil {
+		t.Fatal("Validate(bad) returned nil; expected parse error")
+	}
+}
+
+func TestFileConfigStore_WriteValidatesAndPersists(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte("# old\n"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	store, err := newFileConfigStore(path, newSilentLogger(), nil)
+	if err != nil {
+		t.Fatalf("newFileConfigStore: %v", err)
+	}
+
+	good := []byte("[api]\nurl = \"http://x:1/v1\"\nmodel = \"q\"\n")
+	if err := store.Write(good); err != nil {
+		t.Fatalf("Write(good): %v", err)
+	}
+	// File should now contain the new bytes.
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != string(good) {
+		t.Fatalf("on-disk = %q, want %q", got, good)
+	}
+
+	// Bad config must be rejected and must NOT clobber the file.
+	bad := []byte("not = valid = ====\n")
+	if err := store.Write(bad); err == nil {
+		t.Fatal("Write(bad) returned nil; expected parse error")
+	}
+	got2, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile after rejected write: %v", err)
+	}
+	if string(got2) != string(good) {
+		t.Fatalf("file was clobbered after rejected write\non-disk: %q\nwant: %q", got2, good)
+	}
+}
+
+func TestFileConfigStore_WritePreservesPerms(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	// Seed with 0600 perms; rewriting should keep them.
+	if err := os.WriteFile(path, []byte("# old\n"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	store, err := newFileConfigStore(path, newSilentLogger(), nil)
+	if err != nil {
+		t.Fatalf("newFileConfigStore: %v", err)
+	}
+	good := []byte("[api]\nurl = \"http://x:1/v1\"\nmodel = \"q\"\n")
+	if err := store.Write(good); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("perms = %o, want 0600", got)
+	}
+}
+
+func TestFileConfigStore_RestartFiresShutdown(t *testing.T) {
+	dir := t.TempDir()
+	called := 0
+	store, err := newFileConfigStore(filepath.Join(dir, "config.toml"),
+		newSilentLogger(),
+		func() { called++ })
+	if err != nil {
+		t.Fatalf("newFileConfigStore: %v", err)
+	}
+	store.Restart()
+	store.Restart()
+	if called != 2 {
+		t.Fatalf("shutdown called %d times, want 2", called)
+	}
+}
+
+func TestFileConfigStore_RestartNilSafe(t *testing.T) {
+	dir := t.TempDir()
+	store, err := newFileConfigStore(filepath.Join(dir, "config.toml"), newSilentLogger(), nil)
+	if err != nil {
+		t.Fatalf("newFileConfigStore: %v", err)
+	}
+	// Must not panic.
+	store.Restart()
+}

--- a/cmd/faultline/main.go
+++ b/cmd/faultline/main.go
@@ -418,6 +418,18 @@ func main() {
 		// (mostly empty) state, and the UI surfaces "auto-update
 		// off".
 		adminSrv.AttachUpdater(updater)
+
+		// Configuration store: lets the operator edit
+		// config.toml from the UI, validate, save, and trigger a
+		// graceful restart through the same closeShutdown the
+		// SIGINT handler and updater use.
+		cfgStore, err := newFileConfigStore(*configPath, logger, func() { closeShutdown(nil) })
+		if err != nil {
+			logger.Error("admin: failed to construct config store", "error", err)
+			os.Exit(1)
+		}
+		adminSrv.AttachConfig(cfgStore)
+
 		adminSrv.Start(ctx)
 	}
 

--- a/internal/adapters/admin/http/fragments_test.go
+++ b/internal/adapters/admin/http/fragments_test.go
@@ -40,13 +40,13 @@ func newFragmentsTestServer(t *testing.T,
 	sub SubagentInspector,
 	buf *ToolBuffer,
 ) *testServer {
-	return newAdminTestServer(t, ag, sub, buf, nil, nil)
+	return newAdminTestServer(t, ag, sub, buf, nil, nil, nil)
 }
 
 // newSkillsAdminWiredServer is the skills-test variant: nil agent &
 // subagent inspectors, real tool buffer, real SkillsAdmin.
 func newSkillsAdminWiredServer(t *testing.T, sk SkillsAdmin) *testServer {
-	return newAdminTestServer(t, nil, nil, NewToolBuffer(8), sk, nil)
+	return newAdminTestServer(t, nil, nil, NewToolBuffer(8), sk, nil, nil)
 }
 
 // newAdminTestServer is the most general builder; the helpers above
@@ -57,6 +57,7 @@ func newAdminTestServer(t *testing.T,
 	buf *ToolBuffer,
 	sk SkillsAdmin,
 	upd UpdateInspector,
+	cfg ConfigStore,
 ) *testServer {
 	t.Helper()
 	dir := t.TempDir()
@@ -85,6 +86,7 @@ func newAdminTestServer(t *testing.T,
 		Tools:     buf,
 		Skills:    sk,
 		Update:    upd,
+		Config:    cfg,
 	})
 	if err != nil {
 		t.Fatalf("adminhttp.New: %v", err)

--- a/internal/adapters/admin/http/handlers_config.go
+++ b/internal/adapters/admin/http/handlers_config.go
@@ -1,0 +1,116 @@
+package adminhttp
+
+import (
+	"net/http"
+	"strings"
+)
+
+// fragConfigData backs frag_config.html. Either Raw or Err is
+// populated when reading from disk fails; the rest are presentation
+// helpers.
+type fragConfigData struct {
+	HasConfig bool
+
+	Path string
+	Raw  string
+
+	// FlashOK / FlashErr surface the result of validate / save /
+	// restart. ReadErr is populated when the disk read itself
+	// failed; the textarea is then disabled.
+	FlashOK  string
+	FlashErr string
+	ReadErr  string
+
+	// Saved is set after a successful save so the UI can prompt
+	// the operator to restart (without losing the just-saved
+	// content).
+	Saved bool
+
+	CSRFToken string
+}
+
+func (s *Server) handleFragConfig(w http.ResponseWriter, r *http.Request) {
+	data := s.buildConfigFragmentData(r, "")
+	s.renderFragment(w, "frag_config.html", data)
+}
+
+func (s *Server) handleConfigValidate(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Config == nil {
+		http.Error(w, "config store not wired", http.StatusServiceUnavailable)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	raw := r.PostFormValue("content")
+	data := s.buildConfigFragmentData(r, raw)
+	if err := s.deps.Config.Validate([]byte(raw)); err != nil {
+		data.FlashErr = "Validation failed: " + err.Error()
+	} else {
+		data.FlashOK = "Looks good. The config parses cleanly and would load on next start."
+	}
+	s.renderFragment(w, "frag_config.html", data)
+}
+
+func (s *Server) handleConfigSave(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Config == nil {
+		http.Error(w, "config store not wired", http.StatusServiceUnavailable)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	raw := r.PostFormValue("content")
+	data := s.buildConfigFragmentData(r, raw)
+	if err := s.deps.Config.Write([]byte(raw)); err != nil {
+		s.deps.Logger.Warn("admin: config save failed", "error", err)
+		data.FlashErr = "Save failed: " + err.Error()
+	} else {
+		s.deps.Logger.Info("admin: config saved", "path", s.deps.Config.Path())
+		data.FlashOK = "Saved. Restart the agent to apply changes."
+		data.Saved = true
+	}
+	s.renderFragment(w, "frag_config.html", data)
+}
+
+func (s *Server) handleConfigRestart(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Config == nil {
+		http.Error(w, "config store not wired", http.StatusServiceUnavailable)
+		return
+	}
+	s.deps.Logger.Info("admin: restart requested via config page")
+	s.deps.Config.Restart()
+	data := s.buildConfigFragmentData(r, "")
+	data.FlashOK = "Restart signal sent. The agent is shutting down; the supervisor (or configured restart_mode) will bring the new process up."
+	s.renderFragment(w, "frag_config.html", data)
+}
+
+func (s *Server) buildConfigFragmentData(r *http.Request, override string) fragConfigData {
+	data := fragConfigData{}
+	if s.deps.Config == nil {
+		return data
+	}
+	data.HasConfig = true
+	data.Path = s.deps.Config.Path()
+	if sess := sessionFromContext(r.Context()); sess != nil {
+		data.CSRFToken = sess.CSRFToken
+	}
+
+	if override != "" {
+		// The form posted content; show it back so the operator
+		// doesn't lose their edits when re-rendering.
+		data.Raw = override
+	} else {
+		raw, err := s.deps.Config.Read()
+		if err != nil {
+			data.ReadErr = err.Error()
+		} else {
+			// Trim trailing whitespace and ensure the textarea
+			// shows the file as-is. CRLF stays as written.
+			data.Raw = strings.TrimRight(string(raw), "\n") + "\n"
+		}
+	}
+	return data
+}

--- a/internal/adapters/admin/http/handlers_config_test.go
+++ b/internal/adapters/admin/http/handlers_config_test.go
@@ -1,0 +1,313 @@
+package adminhttp
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// fakeConfigStore lets us drive the config handlers without a real
+// TOML file or shutdown plumbing.
+type fakeConfigStore struct {
+	mu sync.Mutex
+
+	path    string
+	content []byte
+	readErr error
+
+	validateErr   error
+	writeErr      error
+	restartCalls  int
+	lastWritten   []byte
+	lastValidated []byte
+}
+
+func (f *fakeConfigStore) Path() string { return f.path }
+
+func (f *fakeConfigStore) Read() ([]byte, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.readErr != nil {
+		return nil, f.readErr
+	}
+	out := make([]byte, len(f.content))
+	copy(out, f.content)
+	return out, nil
+}
+
+func (f *fakeConfigStore) Validate(raw []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.lastValidated = append([]byte(nil), raw...)
+	return f.validateErr
+}
+
+func (f *fakeConfigStore) Write(raw []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.validateErr != nil {
+		return f.validateErr
+	}
+	if f.writeErr != nil {
+		return f.writeErr
+	}
+	f.content = append([]byte(nil), raw...)
+	f.lastWritten = f.content
+	return nil
+}
+
+func (f *fakeConfigStore) Restart() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.restartCalls++
+}
+
+func newConfigAdminServer(t *testing.T, c ConfigStore) *testServer {
+	return newAdminTestServer(t, nil, nil, NewToolBuffer(8), nil, nil, c)
+}
+
+func TestFragConfig_NoStore(t *testing.T) {
+	ts := newFragmentsTestServer(t, nil, nil, NewToolBuffer(8))
+	client := loggedInClient(t, ts)
+
+	resp, err := client.Get(ts.srv.URL + "/admin/fragments/config")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "configuration store is not wired") {
+		t.Fatalf("expected not-wired placeholder:\n%s", body)
+	}
+}
+
+func TestFragConfig_RendersExisting(t *testing.T) {
+	c := &fakeConfigStore{
+		path:    "/etc/faultline/config.toml",
+		content: []byte("[api]\nurl = \"http://example/v1\"\n"),
+	}
+	ts := newConfigAdminServer(t, c)
+	client := loggedInClient(t, ts)
+
+	resp, err := client.Get(ts.srv.URL + "/admin/fragments/config")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	got := string(body)
+
+	for _, want := range []string{
+		"/etc/faultline/config.toml",
+		"http://example/v1",
+		`name="content"`,
+		"Validate", "Save",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q\n%s", want, got)
+		}
+	}
+}
+
+func TestFragConfig_SurfacesReadErr(t *testing.T) {
+	c := &fakeConfigStore{
+		path:    "/missing/config.toml",
+		readErr: errors.New("permission denied"),
+	}
+	ts := newConfigAdminServer(t, c)
+	client := loggedInClient(t, ts)
+
+	resp, err := client.Get(ts.srv.URL + "/admin/fragments/config")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "permission denied") {
+		t.Fatalf("expected read error in body:\n%s", body)
+	}
+	// Save / Validate buttons are disabled when the read failed.
+	if !strings.Contains(string(body), "disabled") {
+		t.Fatalf("expected disabled buttons after read error:\n%s", body)
+	}
+}
+
+func TestConfigValidate_OK(t *testing.T) {
+	c := &fakeConfigStore{path: "/x/config.toml", content: []byte("hello = 1\n")}
+	ts := newConfigAdminServer(t, c)
+	client := loggedInClient(t, ts)
+
+	resp, _ := client.Get(ts.srv.URL + "/admin")
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	csrf := extractFormCSRF(string(body))
+
+	resp, err := client.PostForm(ts.srv.URL+"/admin/config/validate", url.Values{
+		"_csrf":   {csrf},
+		"content": {"new = true\n"},
+	})
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ = io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "Looks good") {
+		t.Fatalf("expected validate-OK flash:\n%s", body)
+	}
+	// The textarea should now show the posted content, not the
+	// on-disk content (we don't want to lose the operator's edits).
+	if !strings.Contains(string(body), "new = true") {
+		t.Fatalf("textarea did not retain posted content:\n%s", body)
+	}
+}
+
+func TestConfigValidate_Error(t *testing.T) {
+	c := &fakeConfigStore{
+		path:        "/x/config.toml",
+		content:     []byte("hello = 1\n"),
+		validateErr: errors.New("toml: invalid syntax at line 1"),
+	}
+	ts := newConfigAdminServer(t, c)
+	client := loggedInClient(t, ts)
+
+	resp, _ := client.Get(ts.srv.URL + "/admin")
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	csrf := extractFormCSRF(string(body))
+
+	resp, err := client.PostForm(ts.srv.URL+"/admin/config/validate", url.Values{
+		"_csrf":   {csrf},
+		"content": {"this is = nonsense ===\n"},
+	})
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ = io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "Validation failed") {
+		t.Fatalf("expected validation-failed flash:\n%s", body)
+	}
+	if !strings.Contains(string(body), "invalid syntax at line 1") {
+		t.Fatalf("expected error text in flash:\n%s", body)
+	}
+}
+
+func TestConfigSave_PersistsAndPromptsRestart(t *testing.T) {
+	c := &fakeConfigStore{path: "/x/config.toml", content: []byte("old\n")}
+	ts := newConfigAdminServer(t, c)
+	client := loggedInClient(t, ts)
+
+	resp, _ := client.Get(ts.srv.URL + "/admin")
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	csrf := extractFormCSRF(string(body))
+
+	resp, err := client.PostForm(ts.srv.URL+"/admin/config/save", url.Values{
+		"_csrf":   {csrf},
+		"content": {"new\n"},
+	})
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ = io.ReadAll(resp.Body)
+
+	if string(c.lastWritten) != "new\n" {
+		t.Fatalf("Write was called with %q, want %q", c.lastWritten, "new\n")
+	}
+	if !strings.Contains(string(body), "Saved") {
+		t.Fatalf("expected saved flash:\n%s", body)
+	}
+	if !strings.Contains(string(body), "Restart agent now") {
+		t.Fatalf("expected post-save restart button:\n%s", body)
+	}
+}
+
+func TestConfigSave_RejectsBadConfig(t *testing.T) {
+	c := &fakeConfigStore{
+		path:        "/x/config.toml",
+		content:     []byte("old\n"),
+		validateErr: errors.New("syntax error at line 3"),
+	}
+	ts := newConfigAdminServer(t, c)
+	client := loggedInClient(t, ts)
+
+	resp, _ := client.Get(ts.srv.URL + "/admin")
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	csrf := extractFormCSRF(string(body))
+
+	resp, err := client.PostForm(ts.srv.URL+"/admin/config/save", url.Values{
+		"_csrf":   {csrf},
+		"content": {"broken\n"},
+	})
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ = io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "Save failed: syntax error") {
+		t.Fatalf("expected save-failed flash:\n%s", body)
+	}
+	if c.lastWritten != nil {
+		t.Fatalf("Write should not have been called on bad content; got %q", c.lastWritten)
+	}
+}
+
+func TestConfigRestart_TriggersShutdown(t *testing.T) {
+	c := &fakeConfigStore{path: "/x/config.toml", content: []byte("ok\n")}
+	ts := newConfigAdminServer(t, c)
+	client := loggedInClient(t, ts)
+
+	resp, _ := client.Get(ts.srv.URL + "/admin")
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	csrf := extractFormCSRF(string(body))
+
+	resp, err := client.PostForm(ts.srv.URL+"/admin/config/restart", url.Values{
+		"_csrf": {csrf},
+	})
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if c.restartCalls != 1 {
+		t.Fatalf("Restart calls = %d, want 1", c.restartCalls)
+	}
+	body, _ = io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "Restart signal sent") {
+		t.Fatalf("expected restart flash:\n%s", body)
+	}
+}
+
+func TestConfig_RequireCSRF(t *testing.T) {
+	c := &fakeConfigStore{path: "/x/config.toml", content: []byte("ok\n")}
+	ts := newConfigAdminServer(t, c)
+	client := loggedInClient(t, ts)
+
+	for _, path := range []string{
+		"/admin/config/validate",
+		"/admin/config/save",
+		"/admin/config/restart",
+	} {
+		t.Run(path, func(t *testing.T) {
+			resp, err := client.PostForm(ts.srv.URL+path, url.Values{
+				"content": {"hello\n"},
+			})
+			if err != nil {
+				t.Fatalf("POST: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusForbidden {
+				t.Fatalf("status = %d, want 403", resp.StatusCode)
+			}
+		})
+	}
+	if c.restartCalls != 0 {
+		t.Fatalf("Restart was called despite missing CSRF: %d", c.restartCalls)
+	}
+}

--- a/internal/adapters/admin/http/handlers_update_test.go
+++ b/internal/adapters/admin/http/handlers_update_test.go
@@ -38,7 +38,7 @@ func (f *fakeUpdater) Apply(ctx context.Context) (*update.Result, error) {
 }
 
 func newUpdateAdminServer(t *testing.T, u UpdateInspector) *testServer {
-	return newAdminTestServer(t, nil, nil, NewToolBuffer(8), nil, u)
+	return newAdminTestServer(t, nil, nil, NewToolBuffer(8), nil, u, nil)
 }
 
 // newAdminTestServer-with-update needs a version that takes the
@@ -56,7 +56,7 @@ func init() {
 // here rather than in the shared test helper to avoid editing every
 // call site.
 func newAdminTestServerWithUpdate(t *testing.T, u UpdateInspector) *testServer {
-	return newAdminTestServer(t, nil, nil, NewToolBuffer(8), nil, u)
+	return newAdminTestServer(t, nil, nil, NewToolBuffer(8), nil, u, nil)
 }
 
 func TestFragUpdate_NoUpdater(t *testing.T) {

--- a/internal/adapters/admin/http/inspector.go
+++ b/internal/adapters/admin/http/inspector.go
@@ -61,6 +61,45 @@ type UpdateInspector interface {
 	Apply(ctx context.Context) (*update.Result, error)
 }
 
+// ConfigStore is the read+write port for the configuration page.
+// Implemented in cmd/faultline/admin.go where the file path and the
+// graceful-shutdown trigger are available; the admin server only
+// needs a small surface.
+//
+// All paths are relative to the operator's working directory; the
+// implementation handles atomic writes (temp + rename) and full
+// config.Load round-trips for validation.
+//
+// nil-allowed: when not wired, the Config card on the dashboard
+// renders a not-wired placeholder.
+type ConfigStore interface {
+	// Path returns the absolute path of the config file currently
+	// loaded. Surfaced in the UI so the operator knows what
+	// they're editing.
+	Path() string
+
+	// Read returns the raw TOML bytes from disk.
+	Read() ([]byte, error)
+
+	// Validate parses raw as TOML and runs the same defaults
+	// backfill / sanity passes that config.Load applies on real
+	// startup. Returns nil iff the bytes would load cleanly. Does
+	// NOT touch disk.
+	Validate(raw []byte) error
+
+	// Write atomically replaces the config file with raw after
+	// running Validate. Returns the validation error if the bytes
+	// don't parse; otherwise the write error.
+	Write(raw []byte) error
+
+	// Restart triggers graceful agent shutdown. The composition
+	// root's restart_mode in [update] dictates how the new
+	// process comes up — exit / self-exec / command. Idempotent:
+	// repeated calls are no-ops once the shutdown channel has
+	// been closed.
+	Restart()
+}
+
 // ToolBuffer is the in-memory ring buffer of recent tool-call events.
 // Implements tools.Observer so a single instance plugs straight into
 // the primary's Executor (and into each subagent's Executor too,

--- a/internal/adapters/admin/http/server.go
+++ b/internal/adapters/admin/http/server.go
@@ -73,6 +73,11 @@ type Deps struct {
 	// nil-allowed: when not set, the Update card renders a
 	// "updater not wired" placeholder.
 	Update UpdateInspector
+
+	// Config is the read+write port for the configuration editor
+	// page. nil-allowed; the Config card surfaces a not-wired
+	// placeholder otherwise.
+	Config ConfigStore
 }
 
 // Server is the HTTP admin UI server. Construct with New, run with
@@ -111,6 +116,7 @@ var fragmentTemplates = []string{
 	"frag_subagents.html",
 	"frag_skills.html",
 	"frag_update.html",
+	"frag_config.html",
 }
 
 // New parses templates and prepares the static-file sub-FS. Returns
@@ -247,6 +253,11 @@ func (s *Server) SetUpdateInspector(u UpdateInspector) {
 	s.deps.Update = u
 }
 
+// SetConfigStore wires the read+write configuration port.
+func (s *Server) SetConfigStore(c ConfigStore) {
+	s.deps.Config = c
+}
+
 func (s *Server) shutdown() {
 	s.stopOnce.Do(func() {
 		if s.srv == nil {
@@ -282,6 +293,7 @@ func (s *Server) routes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /admin/fragments/subagents", s.requireAuth(s.handleFragSubagents))
 	mux.HandleFunc("GET /admin/fragments/skills", s.requireAuth(s.handleFragSkills))
 	mux.HandleFunc("GET /admin/fragments/update", s.requireAuth(s.handleFragUpdate))
+	mux.HandleFunc("GET /admin/fragments/config", s.requireAuth(s.handleFragConfig))
 
 	// Skills toggle action. Re-renders the skills fragment so
 	// HTMX can hx-swap the updated card without a full page load.
@@ -292,6 +304,13 @@ func (s *Server) routes(mux *http.ServeMux) {
 	// a flash explaining what happened, but the browser will
 	// likely lose the connection mid-shutdown — that's fine.
 	mux.HandleFunc("POST /admin/update/apply", s.requireAuth(s.handleUpdateApply))
+
+	// Config actions: validate, save, restart. Each re-renders
+	// the config fragment with a flash so the operator sees the
+	// outcome inline.
+	mux.HandleFunc("POST /admin/config/validate", s.requireAuth(s.handleConfigValidate))
+	mux.HandleFunc("POST /admin/config/save", s.requireAuth(s.handleConfigSave))
+	mux.HandleFunc("POST /admin/config/restart", s.requireAuth(s.handleConfigRestart))
 
 	// Anything not under /admin gets 404. We intentionally don't
 	// take over /; the agent doesn't expose anything else on this

--- a/internal/adapters/admin/http/templates/dashboard.html
+++ b/internal/adapters/admin/http/templates/dashboard.html
@@ -67,6 +67,18 @@
     </div>
   </div>
 
+  <div id="config-card"
+       hx-get="/admin/fragments/config"
+       hx-trigger="load"
+       hx-swap="innerHTML">
+    <div class="card bg-base-100 shadow-sm">
+      <div class="card-body">
+        <div class="skeleton h-6 w-32 mb-2"></div>
+        <div class="skeleton h-4 w-full"></div>
+      </div>
+    </div>
+  </div>
+
   <div id="tool-feed"
        hx-get="/admin/fragments/tools"
        hx-trigger="load, every 1s"

--- a/internal/adapters/admin/http/templates/frag_config.html
+++ b/internal/adapters/admin/http/templates/frag_config.html
@@ -1,0 +1,75 @@
+<div class="card bg-base-100 shadow-sm">
+  <div class="card-body">
+    <div class="flex items-center justify-between">
+      <h2 class="card-title">Configuration</h2>
+      {{if .HasConfig}}
+      <span class="text-sm opacity-70 font-mono">{{.Path}}</span>
+      {{else}}
+      <span class="badge badge-ghost">not wired</span>
+      {{end}}
+    </div>
+
+    {{if .FlashOK}}
+    <div class="alert alert-success py-2">
+      <span>{{.FlashOK}}</span>
+    </div>
+    {{end}}
+    {{if .FlashErr}}
+    <div class="alert alert-error py-2">
+      <pre class="text-xs whitespace-pre-wrap break-words">{{.FlashErr}}</pre>
+    </div>
+    {{end}}
+    {{if .ReadErr}}
+    <div class="alert alert-warning py-2">
+      <span>Could not read config file: {{.ReadErr}}</span>
+    </div>
+    {{end}}
+
+    {{if .HasConfig}}
+    <form id="config-form" hx-target="#config-card" hx-swap="innerHTML">
+      <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
+      <textarea name="content"
+                spellcheck="false"
+                class="textarea textarea-bordered font-mono w-full min-h-[400px] mt-2"
+                {{if .ReadErr}}disabled{{end}}>{{.Raw}}</textarea>
+
+      <div class="flex flex-wrap gap-2 mt-3">
+        <button type="submit"
+                class="btn btn-outline"
+                hx-post="/admin/config/validate"
+                {{if .ReadErr}}disabled{{end}}>
+          Validate
+        </button>
+        <button type="submit"
+                class="btn btn-primary"
+                hx-post="/admin/config/save"
+                hx-confirm="Save this configuration to disk? Existing file will be overwritten atomically."
+                {{if .ReadErr}}disabled{{end}}>
+          Save
+        </button>
+        {{if .Saved}}
+        <button type="button"
+                class="btn btn-warning ml-auto"
+                hx-post="/admin/config/restart"
+                hx-confirm="Restart the agent now? It will save state and then exit; the supervisor (or [update] restart_mode) will bring the new process up.">
+          Restart agent now
+        </button>
+        {{end}}
+      </div>
+    </form>
+
+    <div class="text-xs opacity-60 mt-3">
+      <strong>Note:</strong> most config values are read once at startup
+      (sandbox image, embeddings model, skills root, etc.). Save here
+      writes to disk; the agent must restart for changes to take
+      effect. Sampler parameters (temperature, top-p, etc.) likewise
+      take effect on the next process start.
+    </div>
+    {{else}}
+    <p class="opacity-70 text-sm">
+      The configuration store is not wired into the admin server.
+      Check <code>cmd/faultline/admin.go</code>.
+    </p>
+    {{end}}
+  </div>
+</div>


### PR DESCRIPTION
## Summary

Final stage of the admin UI. Adds a Configuration card with a
textarea showing the live \`config.toml\`, plus Validate / Save /
Restart actions. Save runs the same \`config.Load\` round-trip the
real startup uses, so syntax errors and bad enum values are caught
before they hit disk. Save then prompts an operator-driven restart
(reusing the existing graceful-shutdown plumbing).

Stacked on top of #33 (\`feat/admin-ui-update\`).

## What's in this PR

**\`ConfigStore\` port** (consumer-defined in adminhttp):

\`\`\`go
type ConfigStore interface {
    Path() string
    Read() ([]byte, error)
    Validate(raw []byte) error
    Write(raw []byte) error   // validates first
    Restart()                 // graceful shutdown
}
\`\`\`

Implementation lives in \`cmd/faultline/configstore.go\` — the file
path and the \`closeShutdown\` closure are only available at the
composition root.

**Validate / Write semantics:**

- \`Validate\` writes raw bytes to a sibling temp file and runs
  \`config.Load\` against it. Same defaults backfill / sanity passes
  that real startup uses.
- \`Write\` calls \`Validate\` first, then atomically renames a
  fresh temp file into place.
- Existing file permissions are preserved — a \`0600\` secret-bearing
  file stays \`0600\`.
- Bad input cannot clobber the live file: validation runs before
  any rename.

**Frontend (\`frag_config.html\`):**

- File path in the header so the operator knows what they're editing.
- \`<textarea spellcheck="false" class="font-mono">\` with the live
  contents.
- Three buttons: Validate (no-op if good, flash with error if bad),
  Save (validates + writes, prompts restart on success), Restart
  (fires \`closeShutdown\`).
- \`hx-confirm\` on Save and Restart so the operator gets a browser
  confirm dialog before destructive actions.
- After a successful save the fragment re-renders with a Restart
  button so the operator can apply changes in one click.

## Tests

Handlers (\`handlers_config_test.go\`):

- placeholder when \`ConfigStore\` not wired
- existing content + path render
- read errors surface and disable Save / Validate buttons
- validate OK / failure flashes
- save persists, prompts restart, retains operator edits on re-render
- save rejects invalid TOML and does NOT clobber the file
- restart triggers the shutdown callback once per click
- CSRF rejection on every state-changing endpoint

Concrete store (\`cmd/faultline/configstore_test.go\`):

- Read returns the file bytes verbatim
- Validate accepts good / rejects bad TOML
- Write round-trips and refuses to clobber on bad input
- Write preserves file permissions
- Restart fires the shutdown closure each call
- Restart with nil shutdown is safe

\`gofmt\`, \`go vet\`, \`golangci-lint\`, full suite with \`-race\`:
all clean.

## Decisions

- **Textarea, not a structured form.** A per-field form would
  duplicate every config schema choice in HTML / Go binding code
  and fight \`config.Default()\`'s zero-value-omitted semantics.
  The textarea is honest, lets the operator see the comments
  in \`config.example.toml\` style, and validates against the
  same code path startup uses.
- **Validate via \`config.Load\` round-trip.** Cheaper than
  duplicating the schema, and guaranteed to stay in sync because
  it IS the schema.
- **Write-then-restart, not hot-reload.** Most config values
  are read once at startup (sandbox image, embeddings model,
  skills root, telegram credentials, …); pretending we can
  hot-swap them is dishonest. Save lands the bytes on disk;
  Restart kicks the agent through the graceful-shutdown path
  and the configured \`restart_mode\` brings the new process up.
- **One \`closeShutdown\`, three triggers.** SIGINT, the updater,
  and now the config Restart button all funnel through the same
  closure. The agent loop, save plumbing, restart-mode dispatch,
  and supervisor integration are unchanged.

## End of admin UI scope

This PR closes the original feature list:

- ✅ Administrate all configuration options (textarea + validation)
- ✅ Monitor primary agent + subagents (live, polling)
- ✅ Monitor all tool calls (ring buffer + feed)
- ✅ Administrate skills (toggles persisted to skills.toml)
- ✅ Stats: context size, request/response counts, token usage
- ✅ System uptime, auto-update on/off, current vs latest version,
  update-now button (cached, no live GitHub poll)

Open follow-ups (deliberately deferred):

- Password change UI for the bootstrap admin user
- SSE in place of polling for high-frequency surfaces
- Per-field structured form for the most-edited config sections