### PR TITLE
ci: enrich GitHub Release body with auto-generated PR list

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,7 +20,8 @@ jobs:
     name: release-please
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - id: release
+        uses: googleapis/release-please-action@v4
         with:
           # Push tags using a Personal Access Token rather than the
           # default GITHUB_TOKEN. GitHub deliberately suppresses
@@ -34,3 +35,29 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # When release-please cuts a release (i.e. the release PR was just
+      # merged), augment the GitHub Release body with GitHub's auto-
+      # generated "What's Changed" section. release-please's own body is
+      # built from conventional-commit subjects only; auto-notes pull in
+      # PR titles, authors, and links so the release page actually tells
+      # readers what landed. CHANGELOG.md in the repo is left untouched.
+      - name: Enrich release body with auto-generated PR list
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          TAG: ${{ steps.release.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          generated=$(gh api \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+            -f tag_name="$TAG" \
+            --jq .body)
+          existing=$(gh release view "$TAG" --json body --jq .body)
+          {
+            printf '%s\n\n---\n\n' "$existing"
+            printf '%s\n' "$generated"
+          } > release-body.md
+          gh release edit "$TAG" --notes-file release-body.md

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,19 @@
   "packages": {
     ".": {
       "package-name": "faultline",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "changelog-sections": [
+        { "type": "feat",     "section": "Features" },
+        { "type": "fix",      "section": "Bug Fixes" },
+        { "type": "perf",     "section": "Performance Improvements" },
+        { "type": "revert",   "section": "Reverts" },
+        { "type": "refactor", "section": "Refactors" },
+        { "type": "docs",     "section": "Documentation", "hidden": true },
+        { "type": "test",     "section": "Tests", "hidden": true },
+        { "type": "build",    "section": "Build System", "hidden": true },
+        { "type": "ci",       "section": "Continuous Integration", "hidden": true },
+        { "type": "chore",    "section": "Miscellaneous Chores", "hidden": true }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

- release-please builds the release body from conventional-commit subjects only, so releases land with terse one-liners and no link to the PRs that shipped each change. Add a follow-up workflow step (gated on `steps.release.outputs.release_created`) that calls `/repos/.../releases/generate-notes` and combines its output with the existing release body via `gh release edit --notes-file`.
- Broaden `changelog-sections` so `refactor` / `perf` / `revert` get their own sections in `CHANGELOG.md`; `docs` / `test` / `build` / `ci` / `chore` stay hidden.
- `CHANGELOG.md` is left untouched. The release-please **PR body** is also unchanged — only the GitHub Release body on tag is enriched.

## What it'll look like

\`\`\`
### Features
* feat A (#XX)
* feat B (#YY)
### Bug Fixes
* fix Z (#ZZ)

---

## What's Changed
* feat A by @matjam in https://github.com/matjam/faultline/pull/XX
* feat B by @matjam in https://github.com/matjam/faultline/pull/YY
* fix Z by @matjam in https://github.com/matjam/faultline/pull/ZZ

**Full Changelog**: https://github.com/matjam/faultline/compare/v1.5.0...v1.6.0
\`\`\`

## Caveats

- The release-please PR body itself is **not** enriched. The new tag doesn't exist at PR-open time, so \`generate-notes\` has nothing to anchor against. Doable as a follow-up if wanted (compare against the prior tag from the PR's commit list).
- Cannot dry-run. First real exercise is whenever the next release-please PR is merged.
- \`RELEASE_PLEASE_TOKEN\` already has \`Contents: write\`, which is what \`gh release edit\` needs.

## Files

- \`release-please-config.json\` — added \`changelog-sections\` array.
- \`.github/workflows/release-please.yml\` — added \`id: release\` and a conditional follow-up step.