### PR TITLE
fix(ci): set GH_REPO so release-notes step works without checkout

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -46,6 +46,11 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          # gh release view/edit normally derive the repo from the local
+          # .git directory. The release-please job never runs
+          # actions/checkout, so .git is absent and gh fails with
+          # "fatal: not a git repository". GH_REPO bypasses that lookup.
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ steps.release.outputs.tag_name }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

The auto-notes enrichment step shipped in #37 failed on its first real run (the v1.6.0 release). Failing log line:

\`\`\`
failed to run git: fatal: not a git repository (or any of the parent directories): .git
\`\`\`

Cause: \`gh release view\` / \`gh release edit\` derive the repo from the local \`.git\` tree by default. The release-please job never runs \`actions/checkout\`, so there is no \`.git\` to inspect and gh aborts.

Fix: set \`GH_REPO: \${{ github.repository }}\` in the step env. Every \`gh release\` subcommand then resolves the repo from the env without touching git. The \`gh api\` call is unaffected (its URL path already names the repo).

## Verification

- Cannot dry-run release-please end-to-end. The step is gated on \`steps.release.outputs.release_created\`, so it only fires when a release-please PR merges and a release is cut.
- The next release-please PR merge will exercise it; if it still fails, the failure mode will be different and one more iteration.

## Side note

The v1.6.0 release body is currently the bare release-please content (no auto-notes). I can run the enrichment manually against that one release as a one-off if you want — say the word and I'll do it. Otherwise it stays as-is per the original \"going forward only\" decision.