### PR TITLE
feat(mcp): require current config for updates

### DIFF
--- a/internal/adapters/mcp/router.go
+++ b/internal/adapters/mcp/router.go
@@ -15,6 +15,10 @@ type stdioRestarter interface {
 	Restart(ctx context.Context, serverName string) (DiscoveredServer, error)
 }
 
+type stdioConfigRestarter interface {
+	RestartWithConfig(ctx context.Context, server ServerConfig) (DiscoveredServer, error)
+}
+
 // NewRouter creates a caller that can route by server name.
 func NewRouter() *Router {
 	return &Router{callers: make(map[string]Caller)}
@@ -46,6 +50,20 @@ func (r *Router) RestartStdioServer(ctx context.Context, serverName string) (Dis
 		return DiscoveredServer{}, fmt.Errorf("mcp server %q is not a stdio server", serverName)
 	}
 	return restarter.Restart(ctx, serverName)
+}
+
+// RestartStdioServerWithConfig refreshes one stdio server's live config before
+// restarting its session.
+func (r *Router) RestartStdioServerWithConfig(ctx context.Context, server ServerConfig) (DiscoveredServer, error) {
+	caller, ok := r.callers[server.Name]
+	if !ok {
+		return DiscoveredServer{}, fmt.Errorf("mcp server %q is not configured", server.Name)
+	}
+	restarter, ok := caller.(stdioConfigRestarter)
+	if !ok {
+		return DiscoveredServer{}, fmt.Errorf("mcp server %q is not a stdio server", server.Name)
+	}
+	return restarter.RestartWithConfig(ctx, server)
 }
 
 // Close releases transport clients that hold long-lived resources.

--- a/internal/adapters/mcp/router.go
+++ b/internal/adapters/mcp/router.go
@@ -11,6 +11,10 @@ type Router struct {
 	callers map[string]Caller
 }
 
+type stdioRestarter interface {
+	Restart(ctx context.Context, serverName string) (DiscoveredServer, error)
+}
+
 // NewRouter creates a caller that can route by server name.
 func NewRouter() *Router {
 	return &Router{callers: make(map[string]Caller)}
@@ -28,6 +32,20 @@ func (r *Router) CallTool(ctx context.Context, serverName, toolName string, args
 		return "", fmt.Errorf("mcp server %q is not configured", serverName)
 	}
 	return caller.CallTool(ctx, serverName, toolName, args)
+}
+
+// RestartStdioServer restarts a single stdio server session when the registered
+// caller supports that transport-specific lifecycle operation.
+func (r *Router) RestartStdioServer(ctx context.Context, serverName string) (DiscoveredServer, error) {
+	caller, ok := r.callers[serverName]
+	if !ok {
+		return DiscoveredServer{}, fmt.Errorf("mcp server %q is not configured", serverName)
+	}
+	restarter, ok := caller.(stdioRestarter)
+	if !ok {
+		return DiscoveredServer{}, fmt.Errorf("mcp server %q is not a stdio server", serverName)
+	}
+	return restarter.Restart(ctx, serverName)
 }
 
 // Close releases transport clients that hold long-lived resources.

--- a/internal/adapters/mcp/stdio.go
+++ b/internal/adapters/mcp/stdio.go
@@ -100,6 +100,21 @@ func (c *StdioClient) Restart(ctx context.Context, serverName string) (Discovere
 	return c.Discover(ctx, server.Name)
 }
 
+// RestartWithConfig replaces one server's live config, closes its current
+// session, then re-runs discovery with the fresh config.
+func (c *StdioClient) RestartWithConfig(ctx context.Context, server ServerConfig) (DiscoveredServer, error) {
+	if err := server.Validate(); err != nil {
+		return DiscoveredServer{}, err
+	}
+	if server.Transport != "stdio" {
+		return DiscoveredServer{}, fmt.Errorf("mcp server %q is not a stdio server", server.Name)
+	}
+	if err := c.replaceServer(server); err != nil {
+		return DiscoveredServer{}, err
+	}
+	return c.Discover(ctx, server.Name)
+}
+
 // Discover runs tools/list for one configured stdio server.
 func (c *StdioClient) Discover(ctx context.Context, serverName string) (DiscoveredServer, error) {
 	server, err := c.server(serverName)
@@ -238,6 +253,22 @@ func (c *StdioClient) closeSession(name string) {
 	if session != nil {
 		_ = session.Close()
 	}
+}
+
+func (c *StdioClient) replaceServer(server ServerConfig) error {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return fmt.Errorf("stdio MCP client is closed")
+	}
+	c.servers[server.Name] = server
+	session := c.sessions[server.Name]
+	delete(c.sessions, server.Name)
+	c.mu.Unlock()
+	if session != nil {
+		_ = session.Close()
+	}
+	return nil
 }
 
 type stdioRequest struct {

--- a/internal/adapters/mcp/stdio.go
+++ b/internal/adapters/mcp/stdio.go
@@ -89,6 +89,17 @@ func (c *StdioClient) Close() error {
 	return firstErr
 }
 
+// Restart closes one server's live session, then re-runs discovery to start a
+// fresh process with the current server configuration.
+func (c *StdioClient) Restart(ctx context.Context, serverName string) (DiscoveredServer, error) {
+	server, err := c.server(serverName)
+	if err != nil {
+		return DiscoveredServer{}, err
+	}
+	c.closeSession(serverName)
+	return c.Discover(ctx, server.Name)
+}
+
 // Discover runs tools/list for one configured stdio server.
 func (c *StdioClient) Discover(ctx context.Context, serverName string) (DiscoveredServer, error) {
 	server, err := c.server(serverName)
@@ -217,6 +228,16 @@ func (c *StdioClient) dropSession(name string, session *stdioSession) {
 	}
 	c.mu.Unlock()
 	_ = session.Close()
+}
+
+func (c *StdioClient) closeSession(name string) {
+	c.mu.Lock()
+	session := c.sessions[name]
+	delete(c.sessions, name)
+	c.mu.Unlock()
+	if session != nil {
+		_ = session.Close()
+	}
 }
 
 type stdioRequest struct {

--- a/internal/adapters/mcp/stdio_test.go
+++ b/internal/adapters/mcp/stdio_test.go
@@ -102,6 +102,30 @@ func TestStdioClientClosesIdleSession(t *testing.T) {
 	}
 }
 
+func TestStdioClientRestartClosesNamedSessionAndRediscoverStartsFresh(t *testing.T) {
+	runner := &restartableStdioRunner{}
+	client := NewStdioClient(
+		[]ServerConfig{helperStdioServerConfig(t, "tools/list")},
+		runner,
+		time.Minute,
+	)
+	defer client.Close()
+
+	if _, err := client.Discover(context.Background(), "local"); err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if _, err := client.Restart(context.Background(), "local"); err != nil {
+		t.Fatalf("Restart: %v", err)
+	}
+
+	if got := runner.starts.Load(); got != 2 {
+		t.Fatalf("runner starts = %d, want 2", got)
+	}
+	if got := runner.closed.Load(); got != 1 {
+		t.Fatalf("closed sessions = %d, want 1", got)
+	}
+}
+
 func TestStdioClientIncludesStderrWhenResponseEOF(t *testing.T) {
 	client := NewStdioClient(
 		[]ServerConfig{helperStdioServerConfig(t, "tools/list")},
@@ -365,6 +389,54 @@ func (p *statefulStdioProcess) Wait() error {
 		p.closed.Add(1)
 	})
 	return p.waitError
+}
+
+type restartableStdioRunner struct {
+	starts atomic.Int32
+	closed atomic.Int32
+}
+
+func (r *restartableStdioRunner) Start(ctx context.Context, cmd StdioCommand) (StdioProcess, error) {
+	r.starts.Add(1)
+	stdinReader, stdinWriter := io.Pipe()
+	stdoutReader, stdoutWriter := io.Pipe()
+	proc := &statefulStdioProcess{
+		stdin:  stdinWriter,
+		stdout: stdoutReader,
+		stderr: strings.NewReader(""),
+		done:   make(chan error, 1),
+		closed: &r.closed,
+	}
+
+	go func() {
+		defer stdoutWriter.Close()
+		defer stdinReader.Close()
+		scanner := bufio.NewScanner(stdinReader)
+		for scanner.Scan() {
+			var req jsonRPCRequest
+			if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+				proc.done <- err
+				return
+			}
+			switch req.Method {
+			case "initialize":
+				_, _ = stdoutWriter.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18"}}` + "\n"))
+			case "notifications/initialized":
+			case "tools/list":
+				_, _ = stdoutWriter.Write([]byte(`{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"local_search","description":"Search locally."}]}}` + "\n"))
+			default:
+				proc.done <- &unexpectedMethodError{method: req.Method}
+				return
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			proc.done <- err
+			return
+		}
+		proc.done <- nil
+	}()
+
+	return proc, nil
 }
 
 func waitForCondition(t *testing.T, timeout time.Duration, condition func() bool) {

--- a/internal/adapters/mcp/stdio_test.go
+++ b/internal/adapters/mcp/stdio_test.go
@@ -126,6 +126,29 @@ func TestStdioClientRestartClosesNamedSessionAndRediscoverStartsFresh(t *testing
 	}
 }
 
+func TestStdioClientRestartWithConfigUsesFreshServerConfig(t *testing.T) {
+	runner := &restartableStdioRunner{}
+	client := NewStdioClient(
+		[]ServerConfig{helperStdioServerConfig(t, "tools/list")},
+		runner,
+		time.Minute,
+	)
+	defer client.Close()
+
+	if _, err := client.Discover(context.Background(), "local"); err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	fresh := helperStdioServerConfig(t, "tools/list")
+	fresh.Command = "fresh-mcp"
+	if _, err := client.RestartWithConfig(context.Background(), fresh); err != nil {
+		t.Fatalf("RestartWithConfig: %v", err)
+	}
+
+	if got := runner.commands[1]; got != "fresh-mcp" {
+		t.Fatalf("second command = %q, want fresh-mcp", got)
+	}
+}
+
 func TestStdioClientIncludesStderrWhenResponseEOF(t *testing.T) {
 	client := NewStdioClient(
 		[]ServerConfig{helperStdioServerConfig(t, "tools/list")},
@@ -392,12 +415,14 @@ func (p *statefulStdioProcess) Wait() error {
 }
 
 type restartableStdioRunner struct {
-	starts atomic.Int32
-	closed atomic.Int32
+	starts   atomic.Int32
+	closed   atomic.Int32
+	commands []string
 }
 
 func (r *restartableStdioRunner) Start(ctx context.Context, cmd StdioCommand) (StdioProcess, error) {
 	r.starts.Add(1)
+	r.commands = append(r.commands, cmd.Command)
 	stdinReader, stdinWriter := io.Pipe()
 	stdoutReader, stdoutWriter := io.Pipe()
 	proc := &statefulStdioProcess{

--- a/internal/prompts/prompts_test.go
+++ b/internal/prompts/prompts_test.go
@@ -183,6 +183,9 @@ func TestDefaultSystemPromptIncludesMCPGuidance(t *testing.T) {
 		"npm install --prefix /node",
 		"/node/node_modules/.bin",
 		"git-diff-style Markdown code block",
+		"mcp_read_config",
+		"base_config_hash",
+		"mcp_restart_stdio_server",
 	} {
 		if !strings.Contains(defaultSystem, want) {
 			t.Fatalf("default system prompt missing %q", want)

--- a/internal/prompts/templates/system.md
+++ b/internal/prompts/templates/system.md
@@ -38,7 +38,8 @@ Your goal is to learn about the world and become a positive force in it. How you
 - When diagnosing stdio MCP setup, read **runtime_notes** from **mcp_discover_tools()**. Stdio MCP uses the same sandbox paths as sandbox_shell: `/output`, `/node`, `/cache`, `/venv`, plus `/mcp/<server>` for per-server workdirs.
 - For Node-based stdio MCP servers, use **sandbox_shell()** with `npm install --prefix /node <package>` to prepare packages. Prefer stable binaries under `/node/node_modules/.bin/` in MCP config over repeated `npx` downloads.
 - Recommend the smallest useful **allow_tools** list in plain language. Prefer read-only tools; avoid broad, write, admin, or destructive tools unless the collaborator explicitly asks for that capability.
-- MCP config changes require collaborator approval. When asking to change `mcp.json`, show the collaborator the exact proposed diff in a readable git-diff-style Markdown code block. Use **mcp_propose_config_update()**, ask the collaborator to approve the exact text it returns, then call **mcp_update_config()** only after approval.
+- MCP config changes require collaborator approval. Before proposing any `mcp.json` change, call **mcp_read_config()** and preserve existing server entries unless the collaborator asked to change them. Pass the returned **config_hash** as **base_config_hash** to **mcp_propose_config_update()**. When asking to change `mcp.json`, show the collaborator the exact proposed diff in a readable git-diff-style Markdown code block. Ask the collaborator to approve the exact text returned by **mcp_propose_config_update()**, then call **mcp_update_config()** only after approval.
+- Use **mcp_restart_stdio_server(server_name)** when a stdio MCP server needs to pick up changed setup files or a fresh long-lived session without changing `mcp.json`.
 
 ## Memory
 

--- a/internal/tools/executor.go
+++ b/internal/tools/executor.go
@@ -117,6 +117,8 @@ var subagentForbidden = map[string]struct{}{
 	"update_apply":              {},
 	"mcp_list_servers":          {},
 	"mcp_discover_tools":        {},
+	"mcp_read_config":           {},
+	"mcp_restart_stdio_server":  {},
 	"mcp_propose_config_update": {},
 	"mcp_update_config":         {},
 	"subagent_run":              {},
@@ -1305,6 +1307,10 @@ func (te *Executor) dispatch(ctx context.Context, call llm.ToolCall) string {
 		return te.mcpListServers()
 	case "mcp_discover_tools":
 		return te.mcpDiscoverTools()
+	case "mcp_read_config":
+		return te.mcpReadConfig()
+	case "mcp_restart_stdio_server":
+		return te.mcpRestartStdioServer(ctx, args)
 	case "mcp_propose_config_update":
 		return te.mcpProposeConfigUpdate(args)
 	case "mcp_update_config":
@@ -1396,6 +1402,20 @@ func (te *Executor) mcpManagementToolDefs() []llm.Tool {
 				Parameters:  params,
 			},
 		},
+		{
+			Type: llm.ToolTypeFunction,
+			Function: &llm.FunctionDef{
+				Name:        "mcp_restart_stdio_server",
+				Description: "Restart one configured stdio MCP server session and refresh discovery for that server. Use after changing stdio setup files or when a long-lived stdio server needs to pick up local changes.",
+				Parameters: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"server_name": map[string]interface{}{"type": "string"},
+					},
+					"required": []string{"server_name"},
+				},
+			},
+		},
 	}
 }
 
@@ -1412,14 +1432,26 @@ func (te *Executor) mcpConfigToolDefs() []llm.Tool {
 		{
 			Type: llm.ToolTypeFunction,
 			Function: &llm.FunctionDef{
+				Name:        "mcp_read_config",
+				Description: "Read the current dedicated MCP config before proposing a change. Returns the full current config and config_hash; pass that hash as base_config_hash to mcp_propose_config_update.",
+				Parameters: map[string]interface{}{
+					"type":       "object",
+					"properties": map[string]interface{}{},
+				},
+			},
+		},
+		{
+			Type: llm.ToolTypeFunction,
+			Function: &llm.FunctionDef{
 				Name:        "mcp_propose_config_update",
 				Description: "Validate and propose an MCP config update. This creates a pending approval and does not write any files.",
 				Parameters: map[string]interface{}{
 					"type": "object",
 					"properties": map[string]interface{}{
-						"config": configParam,
+						"base_config_hash": map[string]interface{}{"type": "string"},
+						"config":           configParam,
 					},
-					"required": []string{"config"},
+					"required": []string{"base_config_hash", "config"},
 				},
 			},
 		},
@@ -1457,15 +1489,43 @@ func (te *Executor) mcpDiscoverTools() string {
 	return marshalToolResult(statuses)
 }
 
+func (te *Executor) mcpReadConfig() string {
+	if !te.mcpConfigEdit || te.mcpConfigFile == "" || te.mcpApprovals == nil {
+		return "MCP config updates are not configured."
+	}
+	cfg, hash, _, err := te.currentMCPConfig()
+	if err != nil {
+		return fmt.Sprintf("Error: %s", err)
+	}
+	return marshalToolResult(struct {
+		Config     mcp.Config `json:"config"`
+		ConfigHash string     `json:"config_hash"`
+	}{
+		Config:     cfg,
+		ConfigHash: hash,
+	})
+}
+
 func (te *Executor) mcpProposeConfigUpdate(argsJSON string) string {
 	var args struct {
-		Config mcp.Config `json:"config"`
+		BaseConfigHash string     `json:"base_config_hash"`
+		Config         mcp.Config `json:"config"`
 	}
 	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
 		return fmt.Sprintf("Error parsing arguments: %s", err)
 	}
 	if !te.mcpConfigEdit || te.mcpConfigFile == "" || te.mcpApprovals == nil {
 		return "MCP config updates are not configured."
+	}
+	if args.BaseConfigHash == "" {
+		return "Error: base_config_hash is required. Call mcp_read_config before proposing MCP config changes."
+	}
+	_, currentHash, _, err := te.currentMCPConfig()
+	if err != nil {
+		return fmt.Sprintf("Error: %s", err)
+	}
+	if args.BaseConfigHash != currentHash {
+		return "Error: stale base_config_hash. Call mcp_read_config again and propose a change against the current MCP config."
 	}
 	if err := args.Config.Validate(); err != nil {
 		return fmt.Sprintf("Error: %s", err)
@@ -1485,26 +1545,36 @@ func (te *Executor) mcpProposeConfigUpdate(argsJSON string) string {
 	return fmt.Sprintf("MCP config update proposed.\napproval_id: %s\nconfig_hash: %s\n\nExact proposed diff:\n```diff\n%s```\nAsk the collaborator to reply exactly with:\n%s", id, hash, diff, approvalText)
 }
 
+func (te *Executor) currentMCPConfig() (mcp.Config, string, string, error) {
+	cfg := mcp.Config{Servers: []mcp.ServerConfig{}}
+	currentJSON, err := canonicalMCPConfigJSON(cfg)
+	if err != nil {
+		return mcp.Config{}, "", "", err
+	}
+	data, err := os.ReadFile(te.mcpConfigFile)
+	if err != nil && !os.IsNotExist(err) {
+		return mcp.Config{}, "", "", fmt.Errorf("read current MCP config: %w", err)
+	}
+	if err == nil {
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			return mcp.Config{}, "", "", fmt.Errorf("parse current MCP config: %w", err)
+		}
+		if err := cfg.Validate(); err != nil {
+			return mcp.Config{}, "", "", fmt.Errorf("validate current MCP config: %w", err)
+		}
+		currentJSON = string(data)
+	}
+	hash, err := mcp.ConfigHash(cfg)
+	if err != nil {
+		return mcp.Config{}, "", "", fmt.Errorf("hash current MCP config: %w", err)
+	}
+	return cfg, hash, currentJSON, nil
+}
+
 func (te *Executor) mcpConfigDiff(proposed mcp.Config) (string, error) {
-	current := mcp.Config{Servers: []mcp.ServerConfig{}}
-	currentJSON, err := canonicalMCPConfigJSON(current)
+	_, _, currentJSON, err := te.currentMCPConfig()
 	if err != nil {
 		return "", err
-	}
-	if te.mcpConfigFile != "" {
-		data, err := os.ReadFile(te.mcpConfigFile)
-		if err != nil && !os.IsNotExist(err) {
-			return "", fmt.Errorf("read current MCP config for diff: %w", err)
-		}
-		if err == nil {
-			if err := json.Unmarshal(data, &current); err != nil {
-				return "", fmt.Errorf("parse current MCP config for diff: %w", err)
-			}
-			if err := current.Validate(); err != nil {
-				return "", fmt.Errorf("validate current MCP config for diff: %w", err)
-			}
-			currentJSON = string(data)
-		}
 	}
 
 	proposedJSON, err := canonicalMCPConfigJSON(proposed)
@@ -1592,6 +1662,67 @@ func (te *Executor) mcpUpdateConfig(ctx context.Context, argsJSON string) string
 		te.mcpDiscovered = discovered
 	}
 	return "MCP config updated."
+}
+
+func (te *Executor) mcpRestartStdioServer(ctx context.Context, argsJSON string) string {
+	var args struct {
+		ServerName string `json:"server_name"`
+	}
+	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+		return fmt.Sprintf("Error parsing arguments: %s", err)
+	}
+	if args.ServerName == "" {
+		return "Error: server_name is required"
+	}
+	if !te.knownMCPServer(args.ServerName) {
+		return fmt.Sprintf("Error: mcp server %q is not configured", args.ServerName)
+	}
+	if !te.knownStdioMCPServer(args.ServerName) {
+		return fmt.Sprintf("Error: mcp server %q is not a stdio server", args.ServerName)
+	}
+	if te.mcpCaller == nil {
+		return "MCP caller is not configured."
+	}
+	restarter, ok := te.mcpCaller.(interface {
+		RestartStdioServer(context.Context, string) (mcp.DiscoveredServer, error)
+	})
+	if !ok {
+		return "MCP caller does not support stdio restart."
+	}
+	discovered, err := restarter.RestartStdioServer(ctx, args.ServerName)
+	if err != nil {
+		return fmt.Sprintf("Error: %s", err)
+	}
+	te.replaceMCPDiscovery(discovered)
+	return fmt.Sprintf("MCP stdio server %q restarted.", args.ServerName)
+}
+
+func (te *Executor) knownMCPServer(name string) bool {
+	for _, discovered := range te.mcpDiscovered {
+		if discovered.Server.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (te *Executor) knownStdioMCPServer(name string) bool {
+	for _, discovered := range te.mcpDiscovered {
+		if discovered.Server.Name == name {
+			return discovered.Server.Transport == "stdio"
+		}
+	}
+	return false
+}
+
+func (te *Executor) replaceMCPDiscovery(updated mcp.DiscoveredServer) {
+	for i, discovered := range te.mcpDiscovered {
+		if discovered.Server.Name == updated.Server.Name {
+			te.mcpDiscovered[i] = updated
+			return
+		}
+	}
+	te.mcpDiscovered = append(te.mcpDiscovered, updated)
 }
 
 func (te *Executor) retireMCPCaller(caller mcp.Caller) {

--- a/internal/tools/executor.go
+++ b/internal/tools/executor.go
@@ -1674,22 +1674,26 @@ func (te *Executor) mcpRestartStdioServer(ctx context.Context, argsJSON string) 
 	if args.ServerName == "" {
 		return "Error: server_name is required"
 	}
+	freshServer, err := te.currentMCPServer(args.ServerName)
+	if err != nil {
+		return fmt.Sprintf("Error: %s", err)
+	}
+	if freshServer.Transport != "stdio" {
+		return fmt.Sprintf("Error: mcp server %q is not a stdio server", args.ServerName)
+	}
 	if !te.knownMCPServer(args.ServerName) {
 		return fmt.Sprintf("Error: mcp server %q is not configured", args.ServerName)
-	}
-	if !te.knownStdioMCPServer(args.ServerName) {
-		return fmt.Sprintf("Error: mcp server %q is not a stdio server", args.ServerName)
 	}
 	if te.mcpCaller == nil {
 		return "MCP caller is not configured."
 	}
 	restarter, ok := te.mcpCaller.(interface {
-		RestartStdioServer(context.Context, string) (mcp.DiscoveredServer, error)
+		RestartStdioServerWithConfig(context.Context, mcp.ServerConfig) (mcp.DiscoveredServer, error)
 	})
 	if !ok {
 		return "MCP caller does not support stdio restart."
 	}
-	discovered, err := restarter.RestartStdioServer(ctx, args.ServerName)
+	discovered, err := restarter.RestartStdioServerWithConfig(ctx, freshServer)
 	if err != nil {
 		return fmt.Sprintf("Error: %s", err)
 	}
@@ -1697,19 +1701,26 @@ func (te *Executor) mcpRestartStdioServer(ctx context.Context, argsJSON string) 
 	return fmt.Sprintf("MCP stdio server %q restarted.", args.ServerName)
 }
 
+func (te *Executor) currentMCPServer(name string) (mcp.ServerConfig, error) {
+	if te.mcpConfigFile == "" {
+		return mcp.ServerConfig{}, fmt.Errorf("MCP config file is not configured")
+	}
+	cfg, _, _, err := te.currentMCPConfig()
+	if err != nil {
+		return mcp.ServerConfig{}, err
+	}
+	for _, server := range cfg.Servers {
+		if server.Name == name {
+			return server, nil
+		}
+	}
+	return mcp.ServerConfig{}, fmt.Errorf("mcp server %q is not present in current MCP config", name)
+}
+
 func (te *Executor) knownMCPServer(name string) bool {
 	for _, discovered := range te.mcpDiscovered {
 		if discovered.Server.Name == name {
 			return true
-		}
-	}
-	return false
-}
-
-func (te *Executor) knownStdioMCPServer(name string) bool {
-	for _, discovered := range te.mcpDiscovered {
-		if discovered.Server.Name == name {
-			return discovered.Server.Transport == "stdio"
 		}
 	}
 	return false

--- a/internal/tools/mcp_test.go
+++ b/internal/tools/mcp_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -239,20 +240,26 @@ func TestSubagentExecuteRejectsMCPManagementTools(t *testing.T) {
 }
 
 func TestExecuteMCPRestartStdioServerUpdatesDiscovery(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp.json")
+	freshServer := mcp.ServerConfig{
+		Name:       "local",
+		Transport:  "stdio",
+		Command:    "local-mcp",
+		AllowTools: []string{"new_search"},
+	}
+	if err := mcp.SaveConfig(path, mcp.Config{Servers: []mcp.ServerConfig{freshServer}}); err != nil {
+		t.Fatal(err)
+	}
 	caller := &fakeRestartMCPCaller{
 		discovered: mcp.DiscoveredServer{
-			Server: mcp.ServerConfig{
-				Name:       "local",
-				Transport:  "stdio",
-				Command:    "local-mcp",
-				AllowTools: []string{"new_search"},
-			},
-			Tools: []mcp.DiscoveredTool{{Name: "new_search"}},
+			Server: freshServer,
+			Tools:  []mcp.DiscoveredTool{{Name: "new_search"}},
 		},
 	}
 	te := New(Deps{
-		Logger:    silentTestLogger(),
-		MCPCaller: caller,
+		Logger:        silentTestLogger(),
+		MCPCaller:     caller,
+		MCPConfigFile: path,
 		MCPDiscovered: []mcp.DiscoveredServer{
 			{
 				Server: mcp.ServerConfig{
@@ -279,6 +286,9 @@ func TestExecuteMCPRestartStdioServerUpdatesDiscovery(t *testing.T) {
 	if caller.serverName != "local" {
 		t.Fatalf("serverName = %q, want local", caller.serverName)
 	}
+	if caller.server.AllowTools[0] != "new_search" {
+		t.Fatalf("restart used stale config: allow_tools = %#v", caller.server.AllowTools)
+	}
 	names := toolDefNames(te.ToolDefs())
 	if !names["mcp_local_new_search"] {
 		t.Fatal("expected restarted discovery to update ToolDefs")
@@ -289,9 +299,16 @@ func TestExecuteMCPRestartStdioServerUpdatesDiscovery(t *testing.T) {
 }
 
 func TestExecuteMCPRestartStdioServerRejectsHTTPServer(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp.json")
+	if err := mcp.SaveConfig(path, mcp.Config{Servers: []mcp.ServerConfig{
+		{Name: "remote", Transport: "http", URL: "https://example.invalid/mcp"},
+	}}); err != nil {
+		t.Fatal(err)
+	}
 	te := New(Deps{
-		Logger:    silentTestLogger(),
-		MCPCaller: &fakeRestartMCPCaller{},
+		Logger:        silentTestLogger(),
+		MCPCaller:     &fakeRestartMCPCaller{},
+		MCPConfigFile: path,
 		MCPDiscovered: []mcp.DiscoveredServer{
 			{
 				Server: mcp.ServerConfig{
@@ -363,13 +380,15 @@ func (f *fakeMCPCaller) CallTool(_ context.Context, serverName, toolName string,
 type fakeRestartMCPCaller struct {
 	discovered mcp.DiscoveredServer
 	serverName string
+	server     mcp.ServerConfig
 }
 
 func (f *fakeRestartMCPCaller) CallTool(context.Context, string, string, json.RawMessage) (string, error) {
 	return "", nil
 }
 
-func (f *fakeRestartMCPCaller) RestartStdioServer(_ context.Context, serverName string) (mcp.DiscoveredServer, error) {
-	f.serverName = serverName
+func (f *fakeRestartMCPCaller) RestartStdioServerWithConfig(_ context.Context, server mcp.ServerConfig) (mcp.DiscoveredServer, error) {
+	f.serverName = server.Name
+	f.server = server
 	return f.discovered, nil
 }

--- a/internal/tools/mcp_test.go
+++ b/internal/tools/mcp_test.go
@@ -238,6 +238,83 @@ func TestSubagentExecuteRejectsMCPManagementTools(t *testing.T) {
 	}
 }
 
+func TestExecuteMCPRestartStdioServerUpdatesDiscovery(t *testing.T) {
+	caller := &fakeRestartMCPCaller{
+		discovered: mcp.DiscoveredServer{
+			Server: mcp.ServerConfig{
+				Name:       "local",
+				Transport:  "stdio",
+				Command:    "local-mcp",
+				AllowTools: []string{"new_search"},
+			},
+			Tools: []mcp.DiscoveredTool{{Name: "new_search"}},
+		},
+	}
+	te := New(Deps{
+		Logger:    silentTestLogger(),
+		MCPCaller: caller,
+		MCPDiscovered: []mcp.DiscoveredServer{
+			{
+				Server: mcp.ServerConfig{
+					Name:       "local",
+					Transport:  "stdio",
+					Command:    "local-mcp",
+					AllowTools: []string{"old_search"},
+				},
+				Tools: []mcp.DiscoveredTool{{Name: "old_search"}},
+			},
+		},
+	})
+
+	got := te.Execute(context.Background(), llm.ToolCall{
+		Function: llm.FunctionCall{
+			Name:      "mcp_restart_stdio_server",
+			Arguments: `{"server_name":"local"}`,
+		},
+	})
+
+	if !strings.Contains(got, "restarted") {
+		t.Fatalf("expected restart success, got %q", got)
+	}
+	if caller.serverName != "local" {
+		t.Fatalf("serverName = %q, want local", caller.serverName)
+	}
+	names := toolDefNames(te.ToolDefs())
+	if !names["mcp_local_new_search"] {
+		t.Fatal("expected restarted discovery to update ToolDefs")
+	}
+	if names["mcp_local_old_search"] {
+		t.Fatal("expected old discovered tool to be replaced")
+	}
+}
+
+func TestExecuteMCPRestartStdioServerRejectsHTTPServer(t *testing.T) {
+	te := New(Deps{
+		Logger:    silentTestLogger(),
+		MCPCaller: &fakeRestartMCPCaller{},
+		MCPDiscovered: []mcp.DiscoveredServer{
+			{
+				Server: mcp.ServerConfig{
+					Name:      "remote",
+					Transport: "http",
+					URL:       "https://example.invalid/mcp",
+				},
+			},
+		},
+	})
+
+	got := te.Execute(context.Background(), llm.ToolCall{
+		Function: llm.FunctionCall{
+			Name:      "mcp_restart_stdio_server",
+			Arguments: `{"server_name":"remote"}`,
+		},
+	})
+
+	if !strings.Contains(got, "not a stdio server") {
+		t.Fatalf("expected http rejection, got %q", got)
+	}
+}
+
 func toolDefNames(defs []llm.Tool) map[string]bool {
 	names := make(map[string]bool, len(defs))
 	for _, def := range defs {
@@ -281,4 +358,18 @@ func (f *fakeMCPCaller) CallTool(_ context.Context, serverName, toolName string,
 	f.toolName = toolName
 	f.args = append(json.RawMessage(nil), args...)
 	return f.result, nil
+}
+
+type fakeRestartMCPCaller struct {
+	discovered mcp.DiscoveredServer
+	serverName string
+}
+
+func (f *fakeRestartMCPCaller) CallTool(context.Context, string, string, json.RawMessage) (string, error) {
+	return "", nil
+}
+
+func (f *fakeRestartMCPCaller) RestartStdioServer(_ context.Context, serverName string) (mcp.DiscoveredServer, error) {
+	f.serverName = serverName
+	return f.discovered, nil
 }

--- a/internal/tools/mcp_update_test.go
+++ b/internal/tools/mcp_update_test.go
@@ -28,7 +28,7 @@ func TestMCPConfigUpdateRequiresRawApproval(t *testing.T) {
 	proposal := te.Execute(context.Background(), llm.ToolCall{
 		Function: llm.FunctionCall{
 			Name:      "mcp_propose_config_update",
-			Arguments: `{"config":` + configJSON + `}`,
+			Arguments: proposalArgs(t, emptyMCPConfigHash(t), configJSON),
 		},
 	})
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
@@ -92,7 +92,7 @@ func TestMCPConfigUpdateReloadsLiveToolSurface(t *testing.T) {
 	proposal := te.Execute(context.Background(), llm.ToolCall{
 		Function: llm.FunctionCall{
 			Name:      "mcp_propose_config_update",
-			Arguments: `{"config":` + configJSON + `}`,
+			Arguments: proposalArgs(t, emptyMCPConfigHash(t), configJSON),
 		},
 	})
 	approvalLine := approvalLineFromProposal(t, proposal)
@@ -155,7 +155,7 @@ func TestMCPConfigUpdateDefersOldCallerCloseWhileSubagentActive(t *testing.T) {
 	proposal := te.Execute(context.Background(), llm.ToolCall{
 		Function: llm.FunctionCall{
 			Name:      "mcp_propose_config_update",
-			Arguments: `{"config":` + configJSON + `}`,
+			Arguments: proposalArgs(t, emptyMCPConfigHash(t), configJSON),
 		},
 	})
 	approvalLine := approvalLineFromProposal(t, proposal)
@@ -193,7 +193,7 @@ func TestMCPConfigUpdateRejectsHashMismatch(t *testing.T) {
 	proposal := te.Execute(context.Background(), llm.ToolCall{
 		Function: llm.FunctionCall{
 			Name:      "mcp_propose_config_update",
-			Arguments: `{"config":` + proposedConfig + `}`,
+			Arguments: proposalArgs(t, emptyMCPConfigHash(t), proposedConfig),
 		},
 	})
 	approvalLine := approvalLineFromProposal(t, proposal)
@@ -230,9 +230,98 @@ func TestMCPConfigProposalRequiresConfigUpdatesEnabled(t *testing.T) {
 	}
 }
 
+func TestMCPReadConfigReturnsCurrentRawConfigAndHash(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp.json")
+	cfg := mcp.Config{Servers: []mcp.ServerConfig{
+		{
+			Name:       "github",
+			Transport:  "stdio",
+			Command:    "github-mcp",
+			Env:        map[string]string{"GITHUB_TOKEN": "raw-secret"},
+			AllowTools: []string{"search_repositories"},
+		},
+	}}
+	if err := mcp.SaveConfig(path, cfg); err != nil {
+		t.Fatal(err)
+	}
+	te := New(Deps{
+		Logger:               silentTestLogger(),
+		MCPConfigFile:        path,
+		MCPConfigEditEnabled: true,
+		MCPApprovals:         mcp.NewApprovals(),
+	})
+
+	got := te.Execute(context.Background(), llm.ToolCall{
+		Function: llm.FunctionCall{Name: "mcp_read_config"},
+	})
+
+	var result struct {
+		Config     mcp.Config `json:"config"`
+		ConfigHash string     `json:"config_hash"`
+	}
+	if err := json.Unmarshal([]byte(got), &result); err != nil {
+		t.Fatalf("mcp_read_config returned invalid JSON: %v\n%s", err, got)
+	}
+	wantHash, err := mcp.ConfigHash(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ConfigHash != wantHash {
+		t.Fatalf("config_hash = %q, want %q", result.ConfigHash, wantHash)
+	}
+	if got := result.Config.Servers[0].Env["GITHUB_TOKEN"]; got != "raw-secret" {
+		t.Fatalf("env token = %q, want raw-secret", got)
+	}
+}
+
+func TestMCPConfigProposalRequiresBaseConfigHash(t *testing.T) {
+	te := New(Deps{
+		Logger:               silentTestLogger(),
+		MCPConfigFile:        filepath.Join(t.TempDir(), "mcp.json"),
+		MCPConfigEditEnabled: true,
+		MCPApprovals:         mcp.NewApprovals(),
+	})
+
+	got := te.Execute(context.Background(), llm.ToolCall{
+		Function: llm.FunctionCall{
+			Name:      "mcp_propose_config_update",
+			Arguments: `{"config":{"servers":[]}}`,
+		},
+	})
+	if !strings.Contains(got, "base_config_hash") {
+		t.Fatalf("expected base_config_hash rejection, got %q", got)
+	}
+}
+
+func TestMCPConfigProposalRejectsStaleBaseConfigHash(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp.json")
+	if err := mcp.SaveConfig(path, mcp.Config{Servers: []mcp.ServerConfig{
+		{Name: "existing", Transport: "http", URL: "https://example.invalid/mcp"},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	te := New(Deps{
+		Logger:               silentTestLogger(),
+		MCPConfigFile:        path,
+		MCPConfigEditEnabled: true,
+		MCPApprovals:         mcp.NewApprovals(),
+	})
+
+	got := te.Execute(context.Background(), llm.ToolCall{
+		Function: llm.FunctionCall{
+			Name:      "mcp_propose_config_update",
+			Arguments: proposalArgs(t, emptyMCPConfigHash(t), `{"servers":[]}`),
+		},
+	})
+	if !strings.Contains(got, "stale") {
+		t.Fatalf("expected stale base hash rejection, got %q", got)
+	}
+}
+
 func TestMCPConfigProposalIncludesExactDiff(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "mcp.json")
-	if err := mcp.SaveConfig(path, mcp.Config{Servers: []mcp.ServerConfig{}}); err != nil {
+	current := mcp.Config{Servers: []mcp.ServerConfig{}}
+	if err := mcp.SaveConfig(path, current); err != nil {
 		t.Fatal(err)
 	}
 	te := New(Deps{
@@ -246,7 +335,7 @@ func TestMCPConfigProposalIncludesExactDiff(t *testing.T) {
 	proposal := te.Execute(context.Background(), llm.ToolCall{
 		Function: llm.FunctionCall{
 			Name:      "mcp_propose_config_update",
-			Arguments: `{"config":` + configJSON + `}`,
+			Arguments: proposalArgs(t, configHash(t, current), configJSON),
 		},
 	})
 
@@ -288,7 +377,7 @@ func TestMCPConfigProposalRejectsNoopUpdate(t *testing.T) {
 	got := te.Execute(context.Background(), llm.ToolCall{
 		Function: llm.FunctionCall{
 			Name:      "mcp_propose_config_update",
-			Arguments: `{"config":{"servers":[{"name":"github","transport":"http","url":"https://example.invalid/mcp","allow_tools":["search_repositories"]}]}}`,
+			Arguments: proposalArgs(t, configHash(t, cfg), `{"servers":[{"name":"github","transport":"http","url":"https://example.invalid/mcp","allow_tools":["search_repositories"]}]}`),
 		},
 	})
 	if !strings.Contains(got, "No MCP config changes to propose.") {
@@ -331,6 +420,29 @@ func approvalIDFromLine(t *testing.T, line string) string {
 		t.Fatalf("approval line %q has %d fields, want 4", line, len(parts))
 	}
 	return parts[2]
+}
+
+func proposalArgs(t *testing.T, baseHash, configJSON string) string {
+	t.Helper()
+	baseHashJSON, err := json.Marshal(baseHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return `{"base_config_hash":` + string(baseHashJSON) + `,"config":` + configJSON + `}`
+}
+
+func emptyMCPConfigHash(t *testing.T) string {
+	t.Helper()
+	return configHash(t, mcp.Config{Servers: []mcp.ServerConfig{}})
+}
+
+func configHash(t *testing.T, cfg mcp.Config) string {
+	t.Helper()
+	hash, err := mcp.ConfigHash(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return hash
 }
 
 type closeTrackingMCPCaller struct {


### PR DESCRIPTION
## Summary
- Adds `mcp_read_config` so the agent reads the current `mcp.json` before proposing a full-file replacement.
- Requires `base_config_hash` on `mcp_propose_config_update` and rejects stale proposals when the config changed after the read.
- Adds `mcp_restart_stdio_server` to restart one long-lived stdio MCP session and refresh discovery for that server.
- Ensures stdio restart reloads only the requested server entry from current `mcp.json` before restarting, so allowlist/command changes do not use stale in-memory config.
- Updates the system prompt so the agent preserves existing MCP entries and uses the restart tool for stdio setup/session refreshes.

## Why
This prevents the agent from accidentally dropping or rewriting unrelated MCP server entries when proposing config changes. It also gives the agent a targeted way to make stdio MCP servers pick up local setup and allowlist changes without rebuilding all MCP clients or restarting unrelated sessions.

## Not included
- Secret redaction or placeholder rehydration for `mcp_read_config`; raw config is returned for now, with future secret management expected to keep secrets out of `mcp.json`.
- A broad reload-all MCP tool.

## Verification
- `go test ./internal/tools ./internal/adapters/mcp`
- `go test $(go list ./... | awk '!/\\/backup\\//')`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run ./cmd/... ./internal/...`
- `docker build -t faultline-sandbox-check -f docker/sandbox/Dockerfile docker/sandbox`