### PR TITLE
fix(llm): accept Venice's stricter assistant-message wire shape

### DIFF
--- a/internal/adapters/llm/openai/client.go
+++ b/internal/adapters/llm/openai/client.go
@@ -84,6 +84,51 @@ func (l *Client) SetChatLog(c *ChatLogger) {
 	l.chatLog = c
 }
 
+// emptyAssistantPlaceholder is the text we substitute into outgoing
+// assistant messages that would otherwise have neither content nor
+// tool_calls. The OpenAI chat-completions spec is silent on whether this
+// is legal; in practice servers diverge. KoboldCpp and OpenAI proper
+// accept the bare `{"role":"assistant"}` shape on replay. Venice (and
+// likely some others — vLLM with strict validation, etc.) rejects it
+// with a 400. Substituting a short non-empty string keeps message
+// indices stable (preserving tool_call_id chains) while satisfying
+// stricter validators. Reads correctly to a human reviewing the
+// transcript.
+const emptyAssistantPlaceholder = "(no response)"
+
+// sanitizeForWire returns a slice safe to POST to any OpenAI-compatible
+// backend. The only transformation today is filling in placeholder
+// content for assistant messages that have neither content nor
+// tool_calls. The input slice is not mutated; we allocate lazily and
+// only copy if a fix is actually needed.
+//
+// This belongs in the adapter rather than the agent loop because it's
+// strictly a wire-shape concern: the in-memory message log may
+// legitimately contain bare assistant turns (e.g. legacy state files
+// resumed from a prior run that used a more permissive backend). The
+// agent loop should also avoid producing them going forward — see
+// agent.coerceAssistantMessage — but this sanitizer is the
+// belt-and-braces defense at the boundary.
+func sanitizeForWire(msgs []llm.Message) []llm.Message {
+	out := msgs
+	copied := false
+	for i, m := range msgs {
+		if m.Role != llm.RoleAssistant {
+			continue
+		}
+		if m.Content != "" || len(m.ToolCalls) > 0 {
+			continue
+		}
+		if !copied {
+			out = make([]llm.Message, len(msgs))
+			copy(out, msgs)
+			copied = true
+		}
+		out[i].Content = emptyAssistantPlaceholder
+	}
+	return out
+}
+
 // chatRequestWire is the JSON shape we POST. Kept separate from llm.ChatRequest
 // so we control exactly which keys appear on the wire (and with what
 // `omitempty` behavior). Fields here are pointers/zero-omitted where
@@ -108,15 +153,43 @@ type chatRequestWire struct {
 	RepetitionPenalty float32 `json:"repetition_penalty,omitempty"`
 }
 
-// apiError is the OpenAI-style error envelope: {"error": {"message": ...,
-// "type": ..., "code": ...}}. We try to decode this for non-2xx responses
-// to surface a useful message, and fall back to the raw body otherwise.
+// apiError is a tolerant decoder for the assorted error-envelope shapes
+// emitted by "OpenAI-compatible" backends on non-2xx responses. Two
+// known forms in the wild:
+//
+//   - OpenAI / KoboldCpp / vLLM (the spec shape):
+//     {"error": {"message": "...", "type": "...", "code": "..."}}
+//   - Venice (and presumably others):
+//     {"error": "string message", "request_id": "..."}
+//
+// We capture `error` as a raw message and try the object form first, the
+// string form second. The Message() helper returns whichever decoded
+// successfully, or "" if neither did (caller falls back to raw body).
 type apiError struct {
-	Error struct {
+	Error     json.RawMessage `json:"error"`
+	RequestID string          `json:"request_id,omitempty"`
+}
+
+// Message extracts a human-readable error string from whichever envelope
+// the server returned. Empty return means the body did not match either
+// known shape and the caller should fall back to the raw body.
+func (e *apiError) Message() string {
+	if len(e.Error) == 0 {
+		return ""
+	}
+	var obj struct {
 		Message string `json:"message"`
 		Type    string `json:"type"`
 		Code    string `json:"code"`
-	} `json:"error"`
+	}
+	if json.Unmarshal(e.Error, &obj) == nil && obj.Message != "" {
+		return obj.Message
+	}
+	var s string
+	if json.Unmarshal(e.Error, &s) == nil && s != "" {
+		return s
+	}
+	return ""
 }
 
 // Chat sends a chat completion request and returns the parsed response.
@@ -126,7 +199,7 @@ type apiError struct {
 func (l *Client) Chat(ctx context.Context, req llm.ChatRequest) (*llm.ChatResponse, error) {
 	wire := chatRequestWire{
 		Model:             l.model,
-		Messages:          req.Messages,
+		Messages:          sanitizeForWire(req.Messages),
 		Tools:             req.Tools,
 		Temperature:       req.Temperature,
 		TopP:              req.TopP,
@@ -217,9 +290,15 @@ func (l *Client) Chat(ctx context.Context, req llm.ChatRequest) (*llm.ChatRespon
 		// error envelope.
 		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		var ae apiError
-		if json.Unmarshal(raw, &ae) == nil && ae.Error.Message != "" {
-			return nil, fmt.Errorf("chat completion: HTTP %d: %s",
-				resp.StatusCode, ae.Error.Message)
+		if json.Unmarshal(raw, &ae) == nil {
+			if msg := ae.Message(); msg != "" {
+				if ae.RequestID != "" {
+					return nil, fmt.Errorf("chat completion: HTTP %d: %s (request_id=%s)",
+						resp.StatusCode, msg, ae.RequestID)
+				}
+				return nil, fmt.Errorf("chat completion: HTTP %d: %s",
+					resp.StatusCode, msg)
+			}
 		}
 		return nil, fmt.Errorf("chat completion: HTTP %d: %s",
 			resp.StatusCode, strings.TrimSpace(string(raw)))

--- a/internal/adapters/llm/openai/client.go
+++ b/internal/adapters/llm/openai/client.go
@@ -84,47 +84,85 @@ func (l *Client) SetChatLog(c *ChatLogger) {
 	l.chatLog = c
 }
 
-// emptyAssistantPlaceholder is the text we substitute into outgoing
-// assistant messages that would otherwise have neither content nor
-// tool_calls. The OpenAI chat-completions spec is silent on whether this
-// is legal; in practice servers diverge. KoboldCpp and OpenAI proper
-// accept the bare `{"role":"assistant"}` shape on replay. Venice (and
-// likely some others — vLLM with strict validation, etc.) rejects it
-// with a 400. Substituting a short non-empty string keeps message
-// indices stable (preserving tool_call_id chains) while satisfying
-// stricter validators. Reads correctly to a human reviewing the
-// transcript.
-const emptyAssistantPlaceholder = "(no response)"
-
-// sanitizeForWire returns a slice safe to POST to any OpenAI-compatible
-// backend. The only transformation today is filling in placeholder
-// content for assistant messages that have neither content nor
-// tool_calls. The input slice is not mutated; we allocate lazily and
-// only copy if a fix is actually needed.
+// wireMessage mirrors llm.Message but uses a pointer for Content so the
+// marshaller can distinguish "field intentionally absent" from "field
+// explicitly empty string". This matters because backends disagree on
+// what an assistant message with tool_calls and no text must look like:
 //
-// This belongs in the adapter rather than the agent loop because it's
-// strictly a wire-shape concern: the in-memory message log may
-// legitimately contain bare assistant turns (e.g. legacy state files
-// resumed from a prior run that used a more permissive backend). The
-// agent loop should also avoid producing them going forward — see
-// agent.coerceAssistantMessage — but this sanitizer is the
-// belt-and-braces defense at the boundary.
-func sanitizeForWire(msgs []llm.Message) []llm.Message {
-	out := msgs
-	copied := false
+//   - OpenAI / KoboldCpp / vLLM: accept content omitted entirely.
+//   - Venice: rejects with HTTP 400 "list object has no element 0"
+//     unless content is present as an explicit empty string (or a
+//     non-empty string). `"content": null` also fails. Empirically
+//     confirmed against the live API, May 2026.
+//
+// Our shared llm.Message uses `Content string` + `omitempty`, so it
+// cannot express "present but empty". Rather than mutating the shared
+// type (which is also the on-disk state-file shape and the API the rest
+// of the codebase reasons about), the wire shape is private here and
+// the toWireMessages converter decides per-role whether to force the
+// field on.
+type wireMessage struct {
+	Role       string         `json:"role"`
+	Content    *string        `json:"content,omitempty"`
+	ToolCalls  []llm.ToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string         `json:"tool_call_id,omitempty"`
+}
+
+// emptyContent is the canonical "" pointer used when a message needs to
+// emit `"content": ""` on the wire. Sharing one pointer avoids 270+ tiny
+// allocations per request on a long resumed conversation.
+var emptyContent = func() *string { s := ""; return &s }()
+
+// toWireMessages converts the agent's message slice into the per-message
+// wire shape Venice (and presumably other strict OpenAI-compatible
+// backends) will accept. Rules:
+//
+//   - assistant: content is ALWAYS emitted. If the source message has
+//     non-empty content, that's what we send. If it has tool_calls but
+//     no content, we send "". If it has neither (legacy state files
+//     resumed from a prior run on a more permissive backend), we send
+//     "" — the on-disk shape is fixed at append time by
+//     agent.coerceAssistantMessage going forward, but the wire layer
+//     handles pre-existing entries too.
+//   - tool: content is ALWAYS emitted. Venice's schema marks it
+//     `required`. We have never produced an empty-content tool message
+//     in practice (the wrapper adds a timestamp prefix), but explicit
+//     emission costs nothing and removes one class of future surprise.
+//   - user / system: content emitted when non-empty. These roles
+//     legitimately may have empty content in odd edge cases (e.g. a
+//     blank shutdown prompt); the `omitempty` behavior is preserved.
+//
+// The input slice is never mutated.
+func toWireMessages(msgs []llm.Message) []wireMessage {
+	out := make([]wireMessage, len(msgs))
 	for i, m := range msgs {
-		if m.Role != llm.RoleAssistant {
-			continue
+		w := wireMessage{
+			Role:       m.Role,
+			ToolCalls:  m.ToolCalls,
+			ToolCallID: m.ToolCallID,
 		}
-		if m.Content != "" || len(m.ToolCalls) > 0 {
-			continue
+		switch m.Role {
+		case llm.RoleAssistant, llm.RoleTool:
+			// Always emit content for these roles. Backends that
+			// accept omitted content are equally happy with an
+			// explicit empty string; backends that reject omitted
+			// content need it. Force it on.
+			if m.Content == "" {
+				w.Content = emptyContent
+			} else {
+				c := m.Content
+				w.Content = &c
+			}
+		default:
+			// system / user / unknown: preserve omitempty semantics.
+			// Empty content here would be a caller bug; we don't
+			// want to mask it with an empty string on the wire.
+			if m.Content != "" {
+				c := m.Content
+				w.Content = &c
+			}
 		}
-		if !copied {
-			out = make([]llm.Message, len(msgs))
-			copy(out, msgs)
-			copied = true
-		}
-		out[i].Content = emptyAssistantPlaceholder
+		out[i] = w
 	}
 	return out
 }
@@ -135,7 +173,7 @@ func sanitizeForWire(msgs []llm.Message) []llm.Message {
 // needed to avoid sending defaults that override server-side configuration.
 type chatRequestWire struct {
 	Model    string        `json:"model"`
-	Messages []llm.Message `json:"messages"`
+	Messages []wireMessage `json:"messages"`
 	Tools    []llm.Tool    `json:"tools,omitempty"`
 
 	// Sampler params (OpenAI-spec). All `omitempty`: if the agent sets
@@ -199,7 +237,7 @@ func (e *apiError) Message() string {
 func (l *Client) Chat(ctx context.Context, req llm.ChatRequest) (*llm.ChatResponse, error) {
 	wire := chatRequestWire{
 		Model:             l.model,
-		Messages:          sanitizeForWire(req.Messages),
+		Messages:          toWireMessages(req.Messages),
 		Tools:             req.Tools,
 		Temperature:       req.Temperature,
 		TopP:              req.TopP,

--- a/internal/adapters/llm/openai/client_test.go
+++ b/internal/adapters/llm/openai/client_test.go
@@ -7,75 +7,116 @@ import (
 	"github.com/matjam/faultline/internal/llm"
 )
 
-// TestSanitizeForWire_LegacyBareAssistant covers the regression that
-// triggered this code: state files resumed from a previous run can
-// contain assistant messages with neither content nor tool_calls. With
-// `omitempty` on both struct fields they serialize over the wire as
-// literally `{"role":"assistant"}`, which Venice (and presumably other
-// strict OpenAI-compatible backends) rejects with HTTP 400 "list object
-// has no element 0". The sanitizer must inject placeholder content so
-// the wire shape satisfies the assistant content-or-tool_calls rule.
-func TestSanitizeForWire_LegacyBareAssistant(t *testing.T) {
-	in := []llm.Message{
-		{Role: llm.RoleSystem, Content: "system"},
-		{Role: llm.RoleUser, Content: "hello"},
-		{Role: llm.RoleAssistant}, // the offending shape
-		{Role: llm.RoleUser, Content: "?"},
-	}
-	out := sanitizeForWire(in)
-
-	// Input slice must not be mutated. Other adapters / loggers /
-	// inspectors share the same Messages slice through the agent loop;
-	// rewriting it under them would be a footgun.
-	if in[2].Content != "" {
-		t.Fatalf("sanitizeForWire mutated caller's slice: in[2].Content=%q", in[2].Content)
-	}
-	if out[2].Content != emptyAssistantPlaceholder {
-		t.Fatalf("expected placeholder %q, got %q", emptyAssistantPlaceholder, out[2].Content)
-	}
-
-	// Marshaling the sanitized message must produce a JSON object with
-	// a `content` field — the whole point of the fix.
-	raw, err := json.Marshal(out[2])
+// marshalOne is a tiny helper: convert one llm.Message through the wire
+// path and return the marshaled JSON for assertion. Keeps each test
+// focused on the per-role rule it cares about.
+func marshalOne(t *testing.T, m llm.Message) string {
+	t.Helper()
+	wire := toWireMessages([]llm.Message{m})
+	raw, err := json.Marshal(wire[0])
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	if got, want := string(raw), `{"role":"assistant","content":"(no response)"}`; got != want {
-		t.Fatalf("wire shape mismatch:\n  got:  %s\n  want: %s", got, want)
+	return string(raw)
+}
+
+// TestWire_AssistantWithToolCallsForcesEmptyContent is the core
+// regression. Venice rejects assistant messages with tool_calls when
+// `content` is either omitted or null; only an explicit empty string (or
+// non-empty string) is accepted. Confirmed empirically against
+// api.venice.ai with /v1/chat/completions returning HTTP 400 "list
+// object has no element 0" on the omitted-content payload.
+func TestWire_AssistantWithToolCallsForcesEmptyContent(t *testing.T) {
+	in := llm.Message{
+		Role: llm.RoleAssistant,
+		ToolCalls: []llm.ToolCall{
+			{ID: "call_1", Type: llm.ToolTypeFunction, Function: llm.FunctionCall{Name: "sleep", Arguments: `{"seconds":1}`}},
+		},
+	}
+	got := marshalOne(t, in)
+	want := `{"role":"assistant","content":"","tool_calls":[{"id":"call_1","type":"function","function":{"name":"sleep","arguments":"{\"seconds\":1}"}}]}`
+	if got != want {
+		t.Fatalf("assistant+tool_calls wire shape mismatch:\n  got:  %s\n  want: %s", got, want)
 	}
 }
 
-// TestSanitizeForWire_NoOp confirms that messages already satisfying the
-// content-or-tool_calls rule are returned untouched (and that the slice
-// is the exact same backing array — we promised no copy when no fix is
-// needed, which matters because the message log can be large).
-func TestSanitizeForWire_NoOp(t *testing.T) {
-	in := []llm.Message{
-		{Role: llm.RoleSystem, Content: "system"},
-		{Role: llm.RoleAssistant, Content: "i have content"},
-		{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{ID: "x", Type: llm.ToolTypeFunction}}},
-		{Role: llm.RoleTool, Content: "result", ToolCallID: "x"},
-	}
-	out := sanitizeForWire(in)
-	if &out[0] != &in[0] {
-		t.Fatal("sanitizeForWire allocated a copy when none was needed")
+// TestWire_AssistantBareForcesEmptyContent covers the legacy state-file
+// case: bare `{"role":"assistant"}` entries from sessions that pre-date
+// the agent-side coercer. The wire layer still must emit an explicit
+// empty string so Venice accepts the request. (Going forward,
+// agent.coerceAssistantMessage substitutes a placeholder at append
+// time, so newly-recorded bare entries become e.g. "(no response)" on
+// disk — but the wire layer is the last line of defense.)
+func TestWire_AssistantBareForcesEmptyContent(t *testing.T) {
+	in := llm.Message{Role: llm.RoleAssistant}
+	got := marshalOne(t, in)
+	want := `{"role":"assistant","content":""}`
+	if got != want {
+		t.Fatalf("bare assistant wire shape mismatch:\n  got:  %s\n  want: %s", got, want)
 	}
 }
 
-// TestSanitizeForWire_NonAssistantUntouched guards against the sanitizer
-// over-reaching. A user / tool / system message with no content is the
-// caller's problem (and rare); we only know what the assistant rule
-// requires.
-func TestSanitizeForWire_NonAssistantUntouched(t *testing.T) {
+// TestWire_AssistantWithContentPreserved verifies normal assistant
+// turns with real text content marshal unchanged.
+func TestWire_AssistantWithContentPreserved(t *testing.T) {
+	in := llm.Message{Role: llm.RoleAssistant, Content: "hello"}
+	got := marshalOne(t, in)
+	want := `{"role":"assistant","content":"hello"}`
+	if got != want {
+		t.Fatalf("assistant content wire shape mismatch:\n  got:  %s\n  want: %s", got, want)
+	}
+}
+
+// TestWire_ToolMessageContentAlwaysEmitted covers Venice's required-
+// content rule on tool messages. We have never produced an empty-content
+// tool message in practice (the wrapper prepends a timestamp), but the
+// wire layer enforces the rule defensively.
+func TestWire_ToolMessageContentAlwaysEmitted(t *testing.T) {
+	got := marshalOne(t, llm.Message{Role: llm.RoleTool, Content: "result", ToolCallID: "call_1"})
+	want := `{"role":"tool","content":"result","tool_call_id":"call_1"}`
+	if got != want {
+		t.Fatalf("tool message wire shape mismatch:\n  got:  %s\n  want: %s", got, want)
+	}
+
+	got = marshalOne(t, llm.Message{Role: llm.RoleTool, ToolCallID: "call_2"})
+	want = `{"role":"tool","content":"","tool_call_id":"call_2"}`
+	if got != want {
+		t.Fatalf("empty-content tool message wire shape mismatch:\n  got:  %s\n  want: %s", got, want)
+	}
+}
+
+// TestWire_UserSystemPreserveOmitempty makes sure the converter doesn't
+// over-reach: empty content on user/system messages is a caller bug we
+// don't want to silently paper over by emitting a meaningless empty
+// string. The omitempty behavior is preserved for these roles.
+func TestWire_UserSystemPreserveOmitempty(t *testing.T) {
+	got := marshalOne(t, llm.Message{Role: llm.RoleUser})
+	if got != `{"role":"user"}` {
+		t.Fatalf("empty user wire shape unexpected: %s", got)
+	}
+	got = marshalOne(t, llm.Message{Role: llm.RoleSystem})
+	if got != `{"role":"system"}` {
+		t.Fatalf("empty system wire shape unexpected: %s", got)
+	}
+	got = marshalOne(t, llm.Message{Role: llm.RoleUser, Content: "hi"})
+	if got != `{"role":"user","content":"hi"}` {
+		t.Fatalf("normal user wire shape unexpected: %s", got)
+	}
+}
+
+// TestWire_InputNotMutated guards the no-mutation contract — the
+// converter must not write through to the caller's llm.Message slice.
+func TestWire_InputNotMutated(t *testing.T) {
 	in := []llm.Message{
-		{Role: llm.RoleUser},
+		{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{ID: "x"}}},
 		{Role: llm.RoleTool, ToolCallID: "x"},
 	}
-	out := sanitizeForWire(in)
-	for i := range in {
-		if out[i].Content != "" {
-			t.Fatalf("sanitizer touched non-assistant message %d: %+v", i, out[i])
-		}
+	_ = toWireMessages(in)
+	if in[0].Content != "" {
+		t.Fatalf("toWireMessages mutated input[0].Content: %q", in[0].Content)
+	}
+	if in[1].Content != "" {
+		t.Fatalf("toWireMessages mutated input[1].Content: %q", in[1].Content)
 	}
 }
 

--- a/internal/adapters/llm/openai/client_test.go
+++ b/internal/adapters/llm/openai/client_test.go
@@ -1,0 +1,126 @@
+package openai
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/matjam/faultline/internal/llm"
+)
+
+// TestSanitizeForWire_LegacyBareAssistant covers the regression that
+// triggered this code: state files resumed from a previous run can
+// contain assistant messages with neither content nor tool_calls. With
+// `omitempty` on both struct fields they serialize over the wire as
+// literally `{"role":"assistant"}`, which Venice (and presumably other
+// strict OpenAI-compatible backends) rejects with HTTP 400 "list object
+// has no element 0". The sanitizer must inject placeholder content so
+// the wire shape satisfies the assistant content-or-tool_calls rule.
+func TestSanitizeForWire_LegacyBareAssistant(t *testing.T) {
+	in := []llm.Message{
+		{Role: llm.RoleSystem, Content: "system"},
+		{Role: llm.RoleUser, Content: "hello"},
+		{Role: llm.RoleAssistant}, // the offending shape
+		{Role: llm.RoleUser, Content: "?"},
+	}
+	out := sanitizeForWire(in)
+
+	// Input slice must not be mutated. Other adapters / loggers /
+	// inspectors share the same Messages slice through the agent loop;
+	// rewriting it under them would be a footgun.
+	if in[2].Content != "" {
+		t.Fatalf("sanitizeForWire mutated caller's slice: in[2].Content=%q", in[2].Content)
+	}
+	if out[2].Content != emptyAssistantPlaceholder {
+		t.Fatalf("expected placeholder %q, got %q", emptyAssistantPlaceholder, out[2].Content)
+	}
+
+	// Marshaling the sanitized message must produce a JSON object with
+	// a `content` field — the whole point of the fix.
+	raw, err := json.Marshal(out[2])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if got, want := string(raw), `{"role":"assistant","content":"(no response)"}`; got != want {
+		t.Fatalf("wire shape mismatch:\n  got:  %s\n  want: %s", got, want)
+	}
+}
+
+// TestSanitizeForWire_NoOp confirms that messages already satisfying the
+// content-or-tool_calls rule are returned untouched (and that the slice
+// is the exact same backing array — we promised no copy when no fix is
+// needed, which matters because the message log can be large).
+func TestSanitizeForWire_NoOp(t *testing.T) {
+	in := []llm.Message{
+		{Role: llm.RoleSystem, Content: "system"},
+		{Role: llm.RoleAssistant, Content: "i have content"},
+		{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{ID: "x", Type: llm.ToolTypeFunction}}},
+		{Role: llm.RoleTool, Content: "result", ToolCallID: "x"},
+	}
+	out := sanitizeForWire(in)
+	if &out[0] != &in[0] {
+		t.Fatal("sanitizeForWire allocated a copy when none was needed")
+	}
+}
+
+// TestSanitizeForWire_NonAssistantUntouched guards against the sanitizer
+// over-reaching. A user / tool / system message with no content is the
+// caller's problem (and rare); we only know what the assistant rule
+// requires.
+func TestSanitizeForWire_NonAssistantUntouched(t *testing.T) {
+	in := []llm.Message{
+		{Role: llm.RoleUser},
+		{Role: llm.RoleTool, ToolCallID: "x"},
+	}
+	out := sanitizeForWire(in)
+	for i := range in {
+		if out[i].Content != "" {
+			t.Fatalf("sanitizer touched non-assistant message %d: %+v", i, out[i])
+		}
+	}
+}
+
+// TestAPIError_OpenAINested is the original envelope shape from
+// OpenAI / KoboldCpp / vLLM. Must continue to decode.
+func TestAPIError_OpenAINested(t *testing.T) {
+	body := []byte(`{"error":{"message":"context length exceeded","type":"invalid_request","code":"context_length_exceeded"}}`)
+	var ae apiError
+	if err := json.Unmarshal(body, &ae); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got, want := ae.Message(), "context length exceeded"; got != want {
+		t.Fatalf("Message() = %q, want %q", got, want)
+	}
+	if ae.RequestID != "" {
+		t.Fatalf("RequestID should be empty, got %q", ae.RequestID)
+	}
+}
+
+// TestAPIError_VeniceFlat is the new shape we discovered when switching
+// to Venice. Top-level `error` is a string, with a sibling `request_id`.
+// Both must be extracted without confusing the OpenAI-shape decoder.
+func TestAPIError_VeniceFlat(t *testing.T) {
+	body := []byte(`{"error":"list object has no element 0","request_id":"bUdIJBuzMNo4MHfEyEr0R"}`)
+	var ae apiError
+	if err := json.Unmarshal(body, &ae); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got, want := ae.Message(), "list object has no element 0"; got != want {
+		t.Fatalf("Message() = %q, want %q", got, want)
+	}
+	if got, want := ae.RequestID, "bUdIJBuzMNo4MHfEyEr0R"; got != want {
+		t.Fatalf("RequestID = %q, want %q", got, want)
+	}
+}
+
+// TestAPIError_Unknown verifies that a body matching neither shape
+// returns "" from Message() so the caller falls back to raw body.
+func TestAPIError_Unknown(t *testing.T) {
+	body := []byte(`{"something":"else"}`)
+	var ae apiError
+	if err := json.Unmarshal(body, &ae); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if ae.Message() != "" {
+		t.Fatalf("expected empty Message() for unknown shape, got %q", ae.Message())
+	}
+}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -191,6 +191,28 @@ func toolMessage(toolCallID, body string) llm.Message {
 	}
 }
 
+// emptyAssistantPlaceholder mirrors the wire-side sanitizer in
+// internal/adapters/llm/openai. Kept in sync intentionally: substituting
+// here means the in-memory log and the persisted state file both record
+// a non-empty content string, so even backends that never see the wire
+// sanitizer (future adapters, replay tools) get a clean log. The string
+// reads correctly to a human reviewing a transcript.
+const emptyAssistantPlaceholder = "(no response)"
+
+// coerceAssistantMessage substitutes placeholder content into an
+// assistant message that has neither content nor tool_calls. Some
+// backends (Venice, strict vLLM configurations) return 400 on bare
+// `{"role":"assistant"}` payloads; recording the placeholder at append
+// time prevents the log from ever containing such an entry. The wire-
+// side sanitizer in the openai adapter handles legacy state files that
+// pre-date this fix.
+func coerceAssistantMessage(msg llm.Message) llm.Message {
+	if msg.Role == llm.RoleAssistant && msg.Content == "" && len(msg.ToolCalls) == 0 {
+		msg.Content = emptyAssistantPlaceholder
+	}
+	return msg
+}
+
 // countMessageTokens returns the token count for a message log, using the
 // real tokenizer when available and falling back to the heuristic
 // otherwise. The tokenizer path uses a short timeout so a slow/failing
@@ -514,7 +536,7 @@ func (a *Agent) Run(ctx context.Context, shutdownCh <-chan struct{}) error {
 		}
 		a.recordChat(chatLatency, resp.Usage.PromptTokens, resp.Usage.CompletionTokens, finishReason, nil)
 
-		msg := resp.Choices[0].Message
+		msg := coerceAssistantMessage(resp.Choices[0].Message)
 		messages = append(messages, msg)
 
 		if msg.Content != "" {
@@ -755,7 +777,7 @@ func (a *Agent) compactContext(ctx context.Context, toolCtx context.Context, mes
 			return nil, nil, fmt.Errorf("llm chat during compaction: %w", err)
 		}
 
-		msg := resp.Choices[0].Message
+		msg := coerceAssistantMessage(resp.Choices[0].Message)
 		messages = append(messages, msg)
 
 		if msg.Content != "" {
@@ -1009,7 +1031,7 @@ func (a *Agent) gracefulSave(ctx context.Context, messages []llm.Message, toolDe
 			return errShutdown
 		}
 
-		msg := resp.Choices[0].Message
+		msg := coerceAssistantMessage(resp.Choices[0].Message)
 		messages = append(messages, msg)
 
 		if msg.Content != "" {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1,0 +1,56 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/matjam/faultline/internal/llm"
+)
+
+// TestCoerceAssistantMessage_BareGetsPlaceholder is the agent-side half
+// of the Venice fix: when the model returns a stop with no content and
+// no tool calls, recording the literal `{"role":"assistant"}` in the
+// message log poisons every subsequent request to backends that
+// validate the assistant content-or-tool_calls rule. Coercing at append
+// time keeps the persisted state file clean too, so a future restart
+// against a strict backend doesn't re-hit the wire-side sanitizer for
+// turns that were produced under this fix.
+func TestCoerceAssistantMessage_BareGetsPlaceholder(t *testing.T) {
+	in := llm.Message{Role: llm.RoleAssistant}
+	out := coerceAssistantMessage(in)
+	if out.Content != emptyAssistantPlaceholder {
+		t.Fatalf("expected content=%q, got %q", emptyAssistantPlaceholder, out.Content)
+	}
+}
+
+// TestCoerceAssistantMessage_PreservesContent verifies the function is
+// a no-op when the message already carries content, tool calls, or
+// both — we do not want to overwrite a real response.
+func TestCoerceAssistantMessage_PreservesContent(t *testing.T) {
+	cases := []llm.Message{
+		{Role: llm.RoleAssistant, Content: "real reply"},
+		{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{ID: "x", Type: llm.ToolTypeFunction}}},
+		{Role: llm.RoleAssistant, Content: "both", ToolCalls: []llm.ToolCall{{ID: "x"}}},
+	}
+	for i, c := range cases {
+		got := coerceAssistantMessage(c)
+		if got.Content != c.Content {
+			t.Fatalf("case %d: content changed from %q to %q", i, c.Content, got.Content)
+		}
+		if len(got.ToolCalls) != len(c.ToolCalls) {
+			t.Fatalf("case %d: tool_calls changed", i)
+		}
+	}
+}
+
+// TestCoerceAssistantMessage_OtherRolesUntouched protects against the
+// coercer over-reaching into roles whose required-field semantics it
+// doesn't know.
+func TestCoerceAssistantMessage_OtherRolesUntouched(t *testing.T) {
+	for _, role := range []string{llm.RoleSystem, llm.RoleUser, llm.RoleTool} {
+		in := llm.Message{Role: role}
+		out := coerceAssistantMessage(in)
+		if out.Content != "" {
+			t.Fatalf("role %q: content set to %q", role, out.Content)
+		}
+	}
+}

--- a/internal/agent/migrations.go
+++ b/internal/agent/migrations.go
@@ -188,7 +188,7 @@ func (a *Agent) applyOneMigration(
 			return "error: empty-response"
 		}
 
-		choice := resp.Choices[0].Message
+		choice := coerceAssistantMessage(resp.Choices[0].Message)
 		msgs = append(msgs, choice)
 		if choice.Content != "" {
 			a.logThought(choice.Content)


### PR DESCRIPTION
## Summary

Switching faultline's backend to Venice surfaced two wire-shape
divergences from OpenAI / KoboldCpp / vLLM that immediately 400'd on
the first chat request against an existing 566-message state file.

1. **Assistant messages with `tool_calls` require explicit `"content"`**
   on the wire — Venice rejects both omitted and `null` content with
   `HTTP 400 "list object has no element 0"`. Their own OpenAPI spec
   marks content as nullable; the runtime disagrees. Empirically
   confirmed by a probe holding everything else constant:
   | content shape | result |
   |---|---|
   | omitted (`omitempty`) | 400 |
   | `null` | 400 |
   | `""` | 200 |
   | `"text"` | 200 |
2. **Bare assistant messages** (no content, no tool_calls — produced
   by LLM "empty turns" and persisted to state) get serialized as
   `{"role":"assistant"}` under `omitempty` and also fail.
3. **Error envelope is flat**: `{"error":"...","request_id":"..."}`
   rather than the OpenAI-spec nested `{"error":{"message":...}}`,
   causing our decoder to silently fall back to dumping raw JSON.

## Approach

- **Private `wireMessage` in the openai adapter** with `Content *string`,
  populated by a `toWireMessages` converter that decides per-role
  whether to force-emit content (assistant + tool always; user / system
  preserve `omitempty`). Shared `llm.Message` unchanged — state-file
  shape, other adapters, agent loop unaffected.
- **`coerceAssistantMessage` in the agent loop** substitutes
  `"(no response)"` into bare assistant messages at append time across
  all four LLM-response sites (main loop, compaction, save-on-shutdown,
  prompt migrations). Keeps the persisted log human-readable; the wire
  layer is belt-and-braces for legacy state files.
- **`apiError` decoder** rebuilt to accept either envelope shape and
  surface `request_id` in the formatted error string when present.

## Verification

- Built a probe (not committed) that runs the production
  `internal/adapters/llm/openai` client against live Venice with the
  full 566-message state.json. Pre-fix: HTTP 400. Post-fix: HTTP 200.
- Tests cover both envelope shapes, all per-role wire-content rules,
  and the no-mutation contract on the converter.
- `go test ./...` — 25/25 packages pass.
- `go vet ./...` clean.
- `golangci-lint run` 0 issues.

## Out of scope

The underlying question of why the model occasionally returns
assistant turns with no content and no tool_calls is not investigated
here. The agent-side coercion masks it; if it turns out to be a
backend bug worth fixing upstream, it's a separate issue.